### PR TITLE
feat: implement L0 tiering and binary hermeticity for 1Password CLI

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -1,6 +1,5 @@
-# [Rationale]: Identity Provisioning Logic (Phase 7).
-# To ensure 100% convergence in headless CI environments where /dev/tty is absent.
-# Local defaults are strictly generic to maintain OSS integrity.
+# [Rationale]: Identity Provisioning Logic (Phase 8).
+# Fully automated binary hermeticity for 1Password CLI with legacy schema support.
 
 {{ $osid := .chezmoi.os }}
 {{ $arch := .chezmoi.arch }}
@@ -12,20 +11,17 @@
 {{ $primary_id := "" }}
 
 {{ if env "CI" }}
-# [Rationale]: Headless CI Mode. Use deterministic mock values.
 {{   $gh_user = "dotfiles-ci-bot" }}
 {{   $name = "CI Compliance Bot" }}
 {{   $email = "bot@example.com" }}
 {{   $primary_id = "ci-test" }}
 {{ else }}
-# [Rationale]: Interactive Mode. Defaults are generic placeholders for OSS.
 {{   $gh_user = promptStringOnce . "gh_user" "GitHub Username" "your-github-username" }}
 {{   $name = promptStringOnce . "name" "Full Name for Git" "Jane Doe" }}
 {{   $email = promptStringOnce . "email" "Primary Email for Git" "jane.doe@example.com" }}
 {{   $primary_id = promptStringOnce . "primary_id" "Primary 1Password dotfiles-id" "personal" }}
 {{ end }}
 
-# [Rationale]: Platform & Path Resolution
 {{ $is_wsl := false }}
 {{ if eq $osid "linux" }}
 {{   if hasKey .chezmoi.kernel "osrelease" }}
@@ -44,20 +40,28 @@
 {{ end }}
 
 {{ $brew_prefix := "/usr/local" }}
-{{ $op_bin := "" }}
 {{ if eq $osid "darwin" }}
 {{   if eq $arch "arm64" }}
 {{     $brew_prefix = "/opt/homebrew" }}
-{{     $op_bin = "/opt/homebrew/bin/op" }}
-{{   else }}
-{{     $op_bin = "/usr/local/bin/op" }}
 {{   end }}
 {{ else if eq $osid "linux" }}
 {{   $brew_prefix = "/home/linuxbrew/.linuxbrew" }}
 {{ end }}
 
-{{ if $is_wsl }}
-{{   $op_bin = "op.exe" }}
+{{/* Binary Path Resolution (Hermetic First) */}}
+{{ $local_bin := joinPath $home ".local/bin" }}
+{{ $op_bin := joinPath $local_bin "op" }}
+
+{{/* Fallback logic for initial bootstrap */}}
+{{ if not (stat $op_bin) }}
+{{   if eq $osid "darwin" }}
+{{     $op_bin = joinPath $brew_prefix "bin/op" }}
+{{     if not (stat $op_bin) }}{{ $op_bin = "/usr/local/bin/op" }}{{ end }}
+{{   else if $is_wsl }}
+{{     $op_bin = "op.exe" }}
+{{   else }}
+{{     $op_bin = "op" }}
+{{   end }}
 {{ end }}
 
 {{ $op_sign := "" }}

--- a/.chezmoidata.yaml
+++ b/.chezmoidata.yaml
@@ -4,8 +4,14 @@ ssh_keys:
 versions:
   python: "3.13"
   node: "lts"
+  op: "2.33.1"
 
 tool_integrity:
+  op:
+    version: "2.33.1"
+    hashes:
+      darwin-arm64: "8106127624bf55f0bf5ae6f8e2c56398e01db75d64c3088eface33885c854351"
+      linux-amd64: "0fc50cb22d791b5ee5e1421d97e96595fd61ca56ae92271bd1b28bb884971726"
   mise:
     version: "2026.4.4"
     hashes:

--- a/.chezmoiexternal.toml.tmpl
+++ b/.chezmoiexternal.toml.tmpl
@@ -1,25 +1,38 @@
-{{- /* 1. Platform Normalization (Directly using built-in variables) */ -}}
+{{- /* 1. Platform Normalization */ -}}
 {{- $hash_key := printf "%s-%s" .chezmoi.os .chezmoi.arch -}}
 
-{{- $os := "linux" -}}
-{{- if eq .chezmoi.os "darwin" }}{{ $os = "macos" }}{{ end -}}
+{{- /* Tool-specific OS identifiers */ -}}
+{{- $os_std := "linux" -}}
+{{- if eq .chezmoi.os "darwin" }}{{ $os_std = "macos" }}{{ end -}}
+{{- $os_op := .chezmoi.os -}}
 
-{{- /* mise architecture naming convention */ -}}
+{{- /* Architecture naming conventions */ -}}
+{{- $arch := "amd64" -}}
+{{- if eq .chezmoi.arch "arm64" }}{{ $arch = "arm64" }}{{ end -}}
+
+{{- /* mise-specific architecture naming */ -}}
 {{- $mise_arch := "x64" -}}
 {{- if eq .chezmoi.arch "arm64" }}{{ $mise_arch = "arm64" }}{{ end -}}
 
-{{- /* jq architecture naming convention */ -}}
-{{- $jq_arch := "amd64" -}}
-{{- if eq .chezmoi.arch "arm64" }}{{ $jq_arch = "arm64" }}{{ end -}}
-
 {{- /* 2. Resource Definitions */ -}}
+
+{{- /* 1Password CLI bootstrap (Hermetic) */ -}}
+{{- $op_hash := index .tool_integrity.op.hashes $hash_key -}}
+{{- if $op_hash }}
+[".local/bin/op"]
+    type = "archive-file"
+    url = {{ printf "https://cache.agilebits.com/dist/1P/op2/pkg/v%s/op_%s_%s_v%s.zip" .tool_integrity.op.version $os_op $arch .tool_integrity.op.version | quote }}
+    executable = true
+    path = "op"
+    sha256 = {{ $op_hash | quote }}
+{{- end }}
 
 {{- /* mise bootstrap binary */ -}}
 {{- $mise_hash := index .tool_integrity.mise.hashes $hash_key -}}
 {{- if $mise_hash }}
 [".local/bin/mise"]
     type = "file"
-    url = {{ printf "https://github.com/jdx/mise/releases/download/v%s/mise-v%s-%s-%s" .tool_integrity.mise.version .tool_integrity.mise.version $os $mise_arch | quote }}
+    url = {{ printf "https://github.com/jdx/mise/releases/download/v%s/mise-v%s-%s-%s" .tool_integrity.mise.version .tool_integrity.mise.version $os_std $mise_arch | quote }}
     executable = true
     sha256 = {{ $mise_hash | quote }}
 {{- end }}
@@ -29,7 +42,7 @@
 {{- if $jq_hash }}
 [".local/bin/jq"]
     type = "file"
-    url = {{ printf "https://github.com/jqlang/jq/releases/download/jq-%s/jq-%s-%s" .tool_integrity.jq.version $os $jq_arch | quote }}
+    url = {{ printf "https://github.com/jqlang/jq/releases/download/jq-%s/jq-%s-%s" .tool_integrity.jq.version $os_std $arch | quote }}
     executable = true
     sha256 = {{ $jq_hash | quote }}
 {{- end }}

--- a/.chezmoiscripts/run_onchange_before_00-backup-legacy-dots.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_00-backup-legacy-dots.sh.tmpl
@@ -1,41 +1,36 @@
-#!/bin/zsh
-# [chezmoi-script]: Source: '.chezmoiscripts/run_...' vs Dry-run: '.chezmoiscripts/...'
-# [Rationale]: https://www.chezmoi.io/reference/special-directories/chezmoiscripts/
-# [Rationale]: Defensive Migration to prevent silent data loss.
-# [Staff Engineer Note]: Prefix 'run_onchange_before_' ensures execution before .chezmoiremove.
+#!/bin/sh
+# [chezmoi-script]: L0 (POSIX Shell) Tiering
+# [Rationale]: Guaranteed execution even without Zsh/Mise environment.
+# [Staff Engineer Note]: Refactored to eliminate Zsh-specific array/typeset syntax.
 
-set -euo pipefail
+set -eu
 
-# [SSOT]: Use path variables defined in .chezmoi.toml.tmpl for hermeticity.
 BACKUP_ROOT="{{ .paths.xdg_state }}/chezmoi/backup/legacy_$(date +%Y%m%d_%H%M%S)"
+backup_executed=false
 
-# Define exact paths targeted for Purge (.chezmoiremove) or Symlink overwrite
-# [2026 Best Practice]: Explicitly type standard arrays at top-level using typeset -a
-typeset -a legacy_files=(
-  "{{ .paths.home }}/.zshrc"
-  "{{ .paths.home }}/.gitconfig"
-  "{{ .paths.home }}/.gitconfig_jitera"
-  "{{ .paths.home }}/.Brewfile"
-  "{{ .paths.home }}/mise.toml"
+# POSIX-compliant list of targets
+set -- \
+  "{{ .paths.home }}/.zshrc" \
+  "{{ .paths.home }}/.gitconfig" \
+  "{{ .paths.home }}/.gitconfig_jitera" \
+  "{{ .paths.home }}/.Brewfile" \
+  "{{ .paths.home }}/mise.toml" \
   "{{ .paths.home }}/.ssh/config"
-)
 
-typeset backup_executed=false
-
-for target in "${legacy_files[@]}"; do
+for target; do
   # Target exists AND is a regular file (not a symlink managed by chezmoi)
-  if [[ -f "$target" && ! -L "$target" ]]; then
-    if [[ "$backup_executed" == "false" ]]; then
+  if [ -f "$target" ] && [ ! -L "$target" ]; then
+    if [ "$backup_executed" = "false" ]; then
       mkdir -p "$BACKUP_ROOT"
       backup_executed=true
     fi
 
     echo "📦 [Defensive Migration] Archiving: $target"
 
-    typeset target_dir
     target_dir=$(dirname "$target")
-    if [[ "$target_dir" != "{{ .paths.home }}" ]]; then
-      typeset rel_dir="${target_dir#{{ .paths.home }}/}"
+    if [ "$target_dir" != "{{ .paths.home }}" ]; then
+      # POSIX prefix removal
+      rel_dir="${target_dir#{{ .paths.home }}/}"
       mkdir -p "$BACKUP_ROOT/$rel_dir"
       mv "$target" "$BACKUP_ROOT/$rel_dir/$(basename "$target")"
     else
@@ -44,17 +39,18 @@ for target in "${legacy_files[@]}"; do
   fi
 done
 
-# Backup legacy ssh conf.d directory if it exists and is not a symlink
-if [[ -d "{{ .paths.home }}/.ssh/conf.d" && ! -L "{{ .paths.home }}/.ssh/conf.d" ]]; then
-  if [[ "$backup_executed" == "false" ]]; then
+# Backup legacy ssh conf.d directory
+LEGACY_SSH_DIR="{{ .paths.home }}/.ssh/conf.d"
+if [ -d "$LEGACY_SSH_DIR" ] && [ ! -L "$LEGACY_SSH_DIR" ]; then
+  if [ "$backup_executed" = "false" ]; then
     mkdir -p "$BACKUP_ROOT"
     backup_executed=true
   fi
   mkdir -p "$BACKUP_ROOT/.ssh"
-  echo "📦 [Defensive Migration] Archiving legacy directory: {{ .paths.home }}/.ssh/conf.d"
-  mv "{{ .paths.home }}/.ssh/conf.d" "$BACKUP_ROOT/.ssh/conf.d"
+  echo "📦 [Defensive Migration] Archiving legacy directory: $LEGACY_SSH_DIR"
+  mv "$LEGACY_SSH_DIR" "$BACKUP_ROOT/.ssh/conf.d"
 fi
 
-if [[ "$backup_executed" == "true" ]]; then
+if [ "$backup_executed" = "true" ]; then
   echo "✅ Legacy configurations safely archived to: $BACKUP_ROOT"
 fi

--- a/.chezmoiscripts/run_onchange_before_00-validate-session.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_00-validate-session.sh.tmpl
@@ -1,82 +1,76 @@
-#!/bin/zsh
-# [chezmoi-script]: Source: '.chezmoiscripts/run_...' vs Dry-run: '.chezmoiscripts/...'
-# [Rationale]: Strictly enforces schema-driven absolute paths to avoid PATH resolution errors.
+#!/bin/sh
+# [chezmoi-script]: L0 (POSIX Shell) Tiering
+# [Rationale]: Refactored to eliminate Zsh expand flags and typeset keywords.
 
-set -euo pipefail
+set -eu
 
 OP_BIN="{{ .paths.op }}"
 JQ_BIN="{{ .paths.jq }}"
 
 echo "🔍 [Network] Pre-caching GitHub known_hosts (Phase 00 Trust Anchor)..."
-# [Rationale]: Construct the trust chain deterministically *before* any git fetch/clone operations occur.
-typeset ssh_state_dir="{{ .paths.xdg_state }}/ssh"
+ssh_state_dir="{{ .paths.xdg_state }}/ssh"
 mkdir -p "$ssh_state_dir"
 
-if ! ssh-keygen -F github.com -f "$ssh_state_dir/known_hosts" &> /dev/null; then
+if ! ssh-keygen -F github.com -f "$ssh_state_dir/known_hosts" > /dev/null 2>&1; then
   ssh-keyscan -H github.com >> "$ssh_state_dir/known_hosts" 2> /dev/null
   echo "✅ [Network] GitHub host key cached to XDG_STATE_HOME."
 else
   echo "✅ [Network] GitHub host key is already present."
 fi
 
-if [[ "${SKIP_OP_VALIDATION:-}" == "true" || "${CI:-}" == "true" ]]; then
+if [ "${SKIP_OP_VALIDATION:-}" = "true" ] || [ "${CI:-}" = "true" ]; then
   echo "⚠️  [Validation] Skipping 1Password session check (Bypass enabled)."
   exit 0
 fi
 
 echo "🔍 [Validation] Verifying 1Password CLI session..."
 
-if [[ ! -x "$OP_BIN" ]]; then
+# Check for executable bit rather than relying on PATH
+if [ ! -x "$OP_BIN" ]; then
   {{ if .is_wsl -}}
-  if ! command -v op.exe &> /dev/null; then
-    echo "❌ [Error] 1Password CLI ('op.exe') is not installed or available in PATH."
+  # WSL special case: check for op.exe in Windows PATH if not hermetic yet
+  if ! command -v op.exe > /dev/null 2>&1; then
+    echo "❌ [Error] 1Password CLI ('op.exe') is not installed."
     exit 1
   fi
   OP_BIN="op.exe"
   {{ else -}}
   echo "❌ [Error] 1Password CLI is not installed at $OP_BIN."
-  echo "👉 Action: Install it via Brew or Winget before proceeding."
   exit 1
   {{ end -}}
 fi
 
-if ! "$OP_BIN" account get &> /dev/null; then
+if ! "$OP_BIN" account get > /dev/null 2>&1; then
   echo "❌ [Error] 1Password session is locked or inactive."
   echo "👉 Action: Run 'op signin' or unlock the 1Password desktop app."
   exit 1
 fi
 
-typeset primary_id="{{ .primary_id }}"
-echo "🔍 [Validation] Verifying Identity Pointer '$primary_id' across all 1Password accounts..."
+primary_id="{{ .primary_id }}"
+echo "🔍 [Validation] Verifying Identity Pointer '$primary_id'..."
 
-typeset accounts
-if ! accounts=$("$OP_BIN" account list --format json | "$JQ_BIN" -r '.[].url'); then
-  echo "❌ [Error] Failed to fetch 1Password accounts."
-  exit 1
-fi
+id_found=false
+accounts=$("$OP_BIN" account list --format json | "$JQ_BIN" -r '.[].url')
 
-typeset id_found=false
-
-for url in ${(f)accounts}; do
-  typeset item_ids
+# POSIX-compliant loop for newline-separated strings
+for url in $accounts; do
   item_ids=$("$OP_BIN" item list --tags "{{ .ssh_keys.discovery_tag }}" --account "$url" --format json 2> /dev/null | "$JQ_BIN" -r '.[].id // empty')
 
-  for id in ${(f)item_ids}; do
-    if [[ -z "$id" ]]; then continue; fi
+  for id in $item_ids; do
+    if [ -z "$id" ]; then continue; fi
 
-    typeset dotfiles_id
     dotfiles_id=$("$OP_BIN" item get "$id" --account "$url" --format json 2> /dev/null | "$JQ_BIN" -r '.fields[]? | select(.label == "dotfiles-id") | .value // empty')
 
-    if [[ "$dotfiles_id" == "$primary_id" ]]; then
+    if [ "$dotfiles_id" = "$primary_id" ]; then
       id_found=true
       break 2
     fi
   done
 done
 
-if [[ "$id_found" != "true" ]]; then
-  echo "❌ [Error] Identity Pointer mismatch. '$primary_id' was not found in any 1Password account."
+if [ "$id_found" != "true" ]; then
+  echo "❌ [Error] Identity Pointer mismatch. '$primary_id' was not found."
   exit 1
 fi
 
-echo "✅ [Validation] 1Password session & Identity Pointer '$primary_id' verified. Proceeding."
+echo "✅ [Validation] 1Password session & Identity Pointer '$primary_id' verified."

--- a/dot_config/zsh/dot_zshrc.tmpl
+++ b/dot_config/zsh/dot_zshrc.tmpl
@@ -10,8 +10,8 @@ export XDG_CACHE_HOME="{{ .paths.xdg_cache }}"
 # --- Path Optimization ---
 typeset -U path PATH
 path=(
-  "{{ .brew_prefix }}/bin"
   "$HOME/.local/bin"
+  "{{ .brew_prefix }}/bin"
   "$XDG_DATA_HOME/mise/shims"
   "$XDG_DATA_HOME/pnpm"
   $path


### PR DESCRIPTION
- Downgrade phase-00 scripts to POSIX shell (L0) for Zsh-independent bootstrap
- Automate 1Password CLI provisioning via .chezmoiexternal with SHA-256 verification
- Implement fallback-to-hermetic path resolution logic in .chezmoi.toml
- Prioritize ~/.local/bin in Zsh PATH for environment consistency
- Restore missing brew_prefix and windows_user data schema entries
