### PR TITLE
fix(gha): resolve signature compliance and redundant template duality

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -66,7 +66,8 @@ jobs:
       - name: Prepare Identity Mock
         run: |
           mkdir -p ~/.ssh
-          touch ~/.ssh/id_ed25519_ci-test.pub
+          # [Rationale]: Inject a valid SSH public key format for Phase 51 parsing.
+          echo "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICITESTMOCKKEY ci-test@example.com" > ~/.ssh/id_ed25519_ci-test.pub
           chmod 700 ~/.ssh
           chmod 600 ~/.ssh/id_ed25519_ci-test.pub
 

--- a/dot_config/git/allowed_signers.tmpl
+++ b/dot_config/git/allowed_signers.tmpl
@@ -1,1 +1,0 @@
-{{ .email }} namespaces="git" {{ include (joinPath .paths.home ".ssh/id_ed25519_personal.pub") }}

--- a/dot_config/git/config.tmpl
+++ b/dot_config/git/config.tmpl
@@ -1,7 +1,6 @@
 [user]
     name = {{ .name }}
-    # [Security]: Email is context-dependent via includeIf below.
-    signingkey = {{ .paths.home }}/.ssh/id_ed25519_personal.pub
+    signingkey = {{ .paths.home }}/.ssh/id_ed25519_{{ .primary_id }}.pub
 
 [commit]
     gpgsign = true


### PR DESCRIPTION
- Remove allowed_signers.tmpl to unify trust chain generation in Phase 51
- Dynamicize signingkey path in git/config using .primary_id for env-agnosticism
- Inject valid SSH public key mock in GHA for idempotent Phase 51 execution
