### PR TITLE
fix(git): implement Null-GPG protocol to suppress verification noise on web merges

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -74,6 +74,9 @@
 {{   $ssh_auth_sock = (joinPath $home ".1password/agent.sock") }}
 {{ end }}
 
+{{/* Null-GPG Protocol Dependency */}}
+{{ $true_cmd := lookPath "true" | default "/usr/bin/true" }}
+
 [data]
     osid = {{ $osid | quote }}
     arch = {{ $arch | quote }}
@@ -97,6 +100,7 @@
         xdg_cache = {{ (joinPath $home ".cache") | quote }}
         mise = {{ (joinPath $home ".local/bin/mise") | quote }}
         jq = {{ (joinPath $home ".local/bin/jq") | quote }}
+        true_cmd = {{ $true_cmd | quote }}
 
 [edit]
     command = "nvim"

--- a/dot_config/git/config.tmpl
+++ b/dot_config/git/config.tmpl
@@ -10,6 +10,9 @@
 
 [gpg]
     format = ssh
+    # [Rationale]: Null-GPG Protocol. Silences execution errors for unmanageable PGP signatures (e.g., GitHub Web Merges)
+    # without breaking the hermetic environment (Zero GPG dependency).
+    program = {{ .paths.true_cmd | quote }}
 
 [gpg "ssh"]
     program = {{ .paths.op_sign | quote }}


### PR DESCRIPTION
- Redirect gpg.program to OS-native 'true' binary via chezmoi dynamic path resolution
- Preserve gpg.format=ssh to maintain 1Password identity isolation
- Eliminate 'cannot run gpg' crash when fetching GitHub-signed squash commits
