### PR TITLE
feat(infra): adopt unified clipboard management via cb

### DIFF
--- a/dot_config/mise/config.toml.tmpl
+++ b/dot_config/mise/config.toml.tmpl
@@ -17,6 +17,7 @@ gh = "latest"
 "go:github.com/jesseduffield/lazydocker" = "latest"
 pre-commit = "latest"
 vale = "latest"
+"github:Slackadays/Clipboard" = "latest"
 
 # Modern CLI Utilities
 zoxide = "latest"

--- a/dot_config/zsh/dot_zshrc.tmpl
+++ b/dot_config/zsh/dot_zshrc.tmpl
@@ -82,14 +82,6 @@ _osc7_cwd() {
 add-zsh-hook precmd _enforce_sovereignty
 add-zsh-hook precmd _osc7_cwd
 
-{{ if .is_wsl -}}
-# [Architecture]: Cross-OS Clipboard Bridge (WSL2 to Windows)
-# [Rationale]: Achieve parity with macOS pbcopy/pbpaste using native Windows Interop.
-# Static injection via chezmoi templates to ensure zero-runtime overhead.
-alias pbcopy='clip.exe'
-alias pbpaste='powershell.exe -NoProfile -Command "Get-Clipboard" | tr -d "\r"'
-{{ end -}}
-
 # --- Performance-tuned Compinit ---
 ZSH_COMPDUMP_DIR="$XDG_CACHE_HOME/zsh"
 autoload -Uz compinit


### PR DESCRIPTION
## 🎯 Summary / Rationale
Eliminated legacy OS-specific clipboard bridges in favor of a unified, OSC 52-native workflow using `cb`. This aligns with the platform's goal of logical purity and zero-speculation infrastructure.

## 🛠 Key Changes
- **Mise**: Provisioned `Slackadays/Clipboard` as the primary clipboard engine.
- **Zsh**: Purged legacy `clip.exe` aliases (`pbcopy`/`pbpaste`) to enforce usage of a single, cross-platform interface.

## 🧪 Verification Proof
- Verified `cb copy` and `cb paste` function correctly across WSL2 and macOS via WezTerm.
- Confirmed that the removal of legacy aliases does not impact the shell's deterministic state.

## ⚠️ Side Effects / Risks
- Users must now use `cb copy` and `cb paste` (or its internal history) instead of legacy `pbcopy`.
- Multi-file copying is limited by the OSC 52 protocol's single-entry specification.