### PR TITLE
feat(wezterm): enhance typography for emojis and japanese rendering

### DIFF
--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -1,6 +1,8 @@
 # =============================================================================
 # [Architecture]: Declarative Package Schema
-# [Rationale]: OS-agnostic definition of required GUI and CLI dependencies.
+# [Rationale]: Managed via Homebrew (macOS) and WinGet (Windows).
+# Japanese fonts are exclusively managed on macOS via Brew Cask to ensure
+# high-fidelity rendering without the complexity of manual Windows font-bridging.
 # =============================================================================
 packages:
   common:
@@ -38,6 +40,8 @@ packages:
       - 1password
       - 1password-cli
       - font-jetbrains-mono-nerd-font
+      - font-biz-udgothic
+      - font-ibm-plex-sans-jp
       - wezterm@nightly
       - slack
       - google-chrome

--- a/dot_config/wezterm/wezterm.lua.tmpl
+++ b/dot_config/wezterm/wezterm.lua.tmpl
@@ -16,10 +16,11 @@ config.scrollback_lines = 100000
 local scheme = wezterm.get_builtin_color_schemes()["Kanagawa Dragon (Gogh)"]
 config.colors = scheme
 
--- [Architecture]: Font Fallback Chain & Deterministic Emoji Rendering
--- [Rationale]: Missing fonts are automatically bypassed. Apple Color Emoji (macOS)
--- and Segoe UI Emoji (Windows) are placed immediately after the primary programming font
--- to prevent Nerd Font monochrome symbols from hijacking color emoji rendering.
+-- [Architecture]: Sovereign Typography Engine
+-- [Rationale]: Prioritize High-legibility Japanese fonts (BIZ UD / IBM Plex)
+-- over legacy system fonts (Hiragino/Meiryo) to ensure consistent UI across OS.
+-- Missing fonts on specific platforms (e.g. Windows without BIZ UD) are
+-- automatically bypassed to native system defaults (Meiryo/Hiragino).
 config.font = wezterm.font_with_fallback({
   "JetBrainsMono Nerd Font",
   "Apple Color Emoji",

--- a/dot_config/wezterm/wezterm.lua.tmpl
+++ b/dot_config/wezterm/wezterm.lua.tmpl
@@ -1,4 +1,5 @@
 {{- /* [Reference]: https://wezfurlong.org/wezterm/config/lua/wezterm/font_with_fallback.html */ -}}
+{{- /* [Reference]: https://wezfurlong.org/wezterm/config/lua/config/allow_square_glyphs_to_overflow_width.html */ -}}
 {{- /* [Reference]: https://wezfurlong.org/wezterm/multiplexing.html */ -}}
 {{- /* [Reference]: https://wezfurlong.org/wezterm/config/lua/config/audible_bell.html */ -}}
 
@@ -15,14 +16,23 @@ config.scrollback_lines = 100000
 local scheme = wezterm.get_builtin_color_schemes()["Kanagawa Dragon (Gogh)"]
 config.colors = scheme
 
--- [Architecture]: Font Fallback Chain
+-- [Architecture]: Font Fallback Chain & Deterministic Emoji Rendering
+-- [Rationale]: Missing fonts are automatically bypassed. Apple Color Emoji (macOS)
+-- and Segoe UI Emoji (Windows) are placed immediately after the primary programming font
+-- to prevent Nerd Font monochrome symbols from hijacking color emoji rendering.
 config.font = wezterm.font_with_fallback({
   "JetBrainsMono Nerd Font",
+  "Apple Color Emoji",
+  "Segoe UI Emoji",
   "BIZ UD Gothic",
   "IBM Plex Sans JP",
   "Hiragino Sans",
   "Meiryo",
 })
+
+-- [Architecture]: High-Fidelity Multi-Cell Glyph Rendering
+-- [Rationale]: Ensure complex emoji (e.g., flags, ligatures) do not clip when exceeding standard cell widths.
+config.allow_square_glyphs_to_overflow_width = "Always"
 
 config.font_size = 14.0
 config.line_height = 1.15


### PR DESCRIPTION
## 🎯 Summary / Rationale

This PR implements a high-fidelity typography engine for WezTerm, ensuring deterministic rendering for both complex emojis and professional Japanese typography across macOS and Windows (WSL2).

### 1. Deterministic Emoji Rendering
Prioritizes native color emoji fonts (`Apple Color Emoji`, `Segoe UI Emoji`) immediately after the primary programming font. This prevents monochrome Nerd Font symbols from hijacking emoji rendering. Additionally, enabled multi-cell overflow to support complex glyphs such as country flags without clipping.

### 2. Strategic Japanese Typography
Standardizes on high-legibility fonts (`BIZ UD Gothic`, `IBM Plex Sans JP`) on macOS via declarative Brew Cask provisioning. For Windows, the architecture relies on native system fallbacks (`Meiryo`) to eliminate unreliable WinGet-based provisioning drift (Status 20).

## 🛠 Key Changes

- **.chezmoidata/packages.yaml**:
    - Refactored rationale to define the platform-specific font management policy.
    - Added macOS casks for `font-biz-udgothic` and `font-ibm-plex-sans-jp`.
    - Removed unreliable WinGet font IDs to ensure zero-drift infrastructure.
- **dot_config/wezterm/wezterm.lua.tmpl**:
    - Re-engineered the `font_with_fallback` chain for deterministic emoji and CJK resolution.
    - Configured `allow_square_glyphs_to_overflow_width = "Always"`.
    - Embedded official documentation anchors for typography rationale.

## 🧪 Verification Proof

```zsh
chezmoi apply -v
chezmoi verify
doctor
```

## ⚠️ Side Effects / Risks
- None. The `font_with_fallback` mechanism ensures graceful degradation on systems where specific premium fonts are not provisioned.