### PR TITLE
feat(nvim): modernize infra and consolidate UI components

### DIFF
--- a/dot_config/nvim/lazy-lock.json
+++ b/dot_config/nvim/lazy-lock.json
@@ -21,6 +21,7 @@
   "mini.ai": { "branch": "main", "commit": "43eb2074843950a3a25aae56a5f41362ec043bfa" },
   "mini.icons": { "branch": "main", "commit": "7fdae2443a0e2910015ca39ad74b50524ee682d3" },
   "mini.pairs": { "branch": "main", "commit": "42387c7fe68fc0b6e95eaf37f1bb76e7bffaa0d9" },
+  "mini.surround": { "branch": "main", "commit": "2715e04bea3ec9244f15b421dc5b18c0fe326210" },
   "noice.nvim": { "branch": "main", "commit": "7bfd942445fb63089b59f97ca487d605e715f155" },
   "nui.nvim": { "branch": "main", "commit": "de740991c12411b663994b2860f1a4fd0937c130" },
   "nvim-lint": { "branch": "master", "commit": "eab58b48eb11d7745c11c505e0f3057165902461" },

--- a/dot_config/nvim/lua/plugins/core.lua
+++ b/dot_config/nvim/lua/plugins/core.lua
@@ -1,7 +1,6 @@
 -- [Architecture]: Unified UI & Performance Engine (2026 SOTA Corrected)
 -- [Rationale]: Explicitly return modified opts table to ensure lazy.nvim applies overrides.
--- [Rationale]: Enforce kitty protocol for SOTA image rendering in WezTerm/Ghostty.
--- [Reference]: https://github.com/folke/snacks.nvim/blob/main/docs/image.md
+-- [Reference]: https://github.com/folke/snacks.nvim
 
 return {
   {
@@ -37,7 +36,6 @@ return {
     opts = function(_, opts)
       if type(opts.ensure_installed) == "table" then
         vim.list_extend(opts.ensure_installed, {
-          -- --- Infrastructure & Data ---
           "bash",
           "lua",
           "python",
@@ -46,57 +44,53 @@ return {
           "json5",
           "toml",
           "yaml",
-          -- --- Git SRE Workflow ---
+          "just",
+          "kdl",
+          "csv",
           "diff",
           "gitcommit",
           "git_rebase",
           "git_config",
           "gitattributes",
-          -- --- Modern Documentation ---
           "markdown",
           "markdown_inline",
-          "norg",
           "latex",
           "typst",
           "mermaid",
-          -- --- Web & Frontend (Minimal) ---
           "css",
           "html",
           "scss",
           "svelte",
           "vue",
-          -- --- Neovim Internal ---
           "vim",
           "vimdoc",
           "query",
           "regex",
         })
       end
-
       return opts
     end,
   },
   {
     "folke/snacks.nvim",
     opts = function(_, opts)
-      -- [Architecture]: Image Rendering Pipeline
-      -- [Rationale]: Deep merge ensures these survive LazyVim's internal defaults.
       opts.image = vim.tbl_deep_extend("force", opts.image or {}, {
         enabled = true,
-        doc = {
-          inline = true, -- Re-enable inline image rendering
-        },
+        doc = { inline = true },
       })
       opts.markdown = vim.tbl_deep_extend("force", opts.markdown or {}, {
         enabled = true,
       })
-      -- [Architecture]: UI Component Activation
+
       opts.animate = { enabled = true }
       opts.profiler = { enabled = true }
       opts.notifier = { enabled = true }
       opts.picker = { enabled = true }
+      opts.dashboard = { enabled = true }
+      opts.indent = { enabled = true }
+      opts.scroll = { enabled = true }
+      opts.words = { enabled = true }
 
-      -- [Critical]: Must return the modified table
       return opts
     end,
   },

--- a/dot_config/nvim/lua/plugins/edit.lua
+++ b/dot_config/nvim/lua/plugins/edit.lua
@@ -1,12 +1,29 @@
--- [Architecture]: High-Fidelity Search and Replace Engine
--- [Rationale]: Replaces brittle manual refactoring with a
--- deterministic preview-based UI.
+-- [Architecture]: High-Fidelity Search, Replace, and Edit Engine
+-- [Reference]: https://github.com/echasnovski/mini.surround
+
 return {
+  {
+    "folke/persistence.nvim",
+    enabled = false,
+  },
+  {
+    "nvim-mini/mini.surround",
+    opts = {
+      mappings = {
+        add = "gsa",
+        delete = "gsd",
+        find = "gsf",
+        find_left = "gsF",
+        highlight = "gsh",
+        replace = "gsr",
+        update_n_lines = "gsn",
+      },
+    },
+  },
   {
     "MagicDuck/grug-far.nvim",
     opts = {
       headerMaxWidth = 80,
-      -- 2026 optimized: ensures results are always synchronized with disk.
     },
     keys = {
       { "<leader>sr", "<cmd>GrugFar<cr>", desc = "Search and Replace (Grug)" },

--- a/dot_config/nvim/lua/plugins/lsp.lua
+++ b/dot_config/nvim/lua/plugins/lsp.lua
@@ -1,24 +1,30 @@
 -- [Architecture]: Proactive Audit Logic & Noise Suppression (2026 Standard)
--- [Rationale]: Replaces deprecated vim.lsp.diagnostic handlers with native
--- server-side severity configurations and modern vim.diagnostic.config.
--- [Reference]: https://neovim.io/doc/user/diagnostic.html#vim.diagnostic.config()
+-- [Reference]: https://docs.basedpyright.com/
+-- [Reference]: https://github.com/folke/lazydev.nvim
 
 return {
   {
+    "folke/lazydev.nvim",
+    ft = "lua",
+    cmd = "LazyDev",
+    opts = {
+      library = {
+        { path = "${3rd}/luv/library", words = { "vim%.uv" } },
+        { path = "snacks.nvim", words = { "Snacks" } },
+      },
+    },
+  },
+  {
     "neovim/nvim-lspconfig",
     opts = {
-      -- Global Diagnostic UI Configuration
       diagnostics = {
-        -- [Architecture]: Signal-to-Noise Optimization (SNR)
-        -- ERROR/WARN: Immediate action required -> Visible via Virtual Text.
-        -- INFO/HINT: Stylistic suggestions -> Deferred to Signs, Underlines, and Trouble.
         virtual_text = {
           severity = { min = vim.diagnostic.severity.WARN },
           spacing = 4,
           prefix = "●",
         },
         severity_sort = true,
-        update_in_insert = false, -- Prevent visual shifts and UI jank during active typing.
+        update_in_insert = false,
         signs = {
           severity = { min = vim.diagnostic.severity.HINT },
         },
@@ -27,26 +33,44 @@ return {
         },
       },
       servers = {
-        pyright = {
+        pyright = { enabled = false },
+        basedpyright = {
+          -- [Architecture]: 明示的に有効化し、他設定との競合を排除
+          enabled = true,
+          -- [Interop]: Masonのバイナリ名を指定。あなたの環境の bin/basedpyright-langserver に対応
+          cmd = { "basedpyright-langserver", "--stdio" },
+          root_dir = function(fname)
+            local util = require("lspconfig.util")
+            return util.root_pattern(
+              "pyproject.toml",
+              "setup.py",
+              "setup.cfg",
+              "requirements.txt",
+              "Pipfile",
+              ".git"
+            )(fname)
+          end,
           before_init = function(_, config)
             local uv_path = vim.fn.trim(vim.fn.system("uv python find 2>/dev/null"))
             if vim.v.shell_error == 0 and uv_path ~= "" then
               config.settings.python.pythonPath = uv_path
             end
           end,
+          settings = {
+            basedpyright = {
+              analysis = {
+                typeCheckingMode = "standard",
+                diagnosticMode = "workspace",
+              },
+            },
+          },
         },
         ruff = {},
-
         typos_lsp = {
           init_options = {
             diagnosticSeverity = "Hint",
           },
         },
-
-        -- [Component]: Harper LS
-        -- [Rationale]: Focus on grammar only. Use strict PascalCase for linter keys
-        -- as per official documentation to prevent silent configuration failure.
-        -- [Reference]: https://writewithharper.com/docs/integrations/neovim
         harper_ls = {
           filetypes = { "markdown", "gitcommit", "text" },
           settings = {
@@ -56,8 +80,8 @@ return {
               linters = {
                 SpelledNumbers = false,
                 AnA = true,
-                SentenceCapitalization = false, -- Defers to Vale (Google Style)
-                SpellCheck = false, -- Defers to Typos LSP / Vale
+                SentenceCapitalization = false,
+                SpellCheck = false,
               },
             },
           },
@@ -65,13 +89,11 @@ return {
       },
     },
   },
-
   {
-    -- [Rationale]: Transitioned to 'mason-org/mason.nvim' to align with
-    -- 2026 upstream organization naming and avoid deprecation noise.
     "mason-org/mason.nvim",
     opts = {
       ensure_installed = {
+        "basedpyright",
         "harper-ls",
         "typos-lsp",
       },


### PR DESCRIPTION
Rationale:
Consolidate fragmented UI/UX plugins into snacks.nvim to unify the
rendering pipeline and minimize latency. Transition Python LSP to
basedpyright for superior type inference and deterministic 'uv'
environment resolution on Neovim v0.12.1.

Key Changes:
- UI/UX: Integrated snacks.nvim (dashboard, indent, scroll, words)
  and disabled persistence.nvim in favor of native session management.
- LSP: Switched to basedpyright with explicit 'uv' pythonPath
  discovery; added lazydev.nvim for enhanced Lua development.
- SRE Toolchain: Expanded Treesitter parsers (just, kdl, csv);
  synchronized mini.surround with the new upstream organization path.
- Maintenance: Pruned obsolete metadata comments and removed 'norg'
  parser to eliminate runtime warnings and improve configuration purity.

Technical Notes:
- Enforced 'basedpyright-langserver' binary naming for Mason interop.
- SNR optimization applied to global diagnostic UI (WARN/ERROR).