### PR TITLE
feat(mise): integrate web toolchain and harden CI idempotency proof

### DIFF
--- a/.chezmoiscripts/run_onchange_after_21-generate-completions.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_21-generate-completions.sh.tmpl
@@ -39,9 +39,16 @@ find "$CACHE_DIR" -name "*.zwc" -type f -delete 2>/dev/null || true
 "$MISE_BIN" exec fd -- fd --gen-completions zsh > "$COMP_DIR/_fd"
 "$MISE_BIN" exec uv -- uv generate-shell-completion zsh > "$COMP_DIR/_uv"
 
-# --- Phase 1.1: SRE Toolchain Completions (Physical Bit Verified) ---
-# [Rationale]: Only tools with verified static stdout support are included.
-# [Interop]: Use 'docker-cli' tool name to invoke the 'docker' binary provided by Aqua.
+# --- Phase 1.1: Web Development Ecosystem ---
+# [Rationale]: Statically generated completions for Node.js toolchains.
+"$MISE_BIN" exec pnpm -- pnpm completion zsh > "$COMP_DIR/_pnpm"
+
+# [Rationale]: Replace absolute/relative paths to the binary with a generic 'hs'
+# to ensure resolution via mise shims in the user's PATH.
+echo "#compdef hs" > "$COMP_DIR/_hs"
+"$MISE_BIN" exec "npm:@hubspot/cli" -- hs completion | sed "s|[^[:space:]]*/bin/hs|hs|g" >> "$COMP_DIR/_hs"
+
+# --- Phase 1.2: SRE Toolchain Completions (Physical Bit Verified) ---
 "$MISE_BIN" exec docker-cli -- docker completion zsh > "$COMP_DIR/_docker"
 "$MISE_BIN" exec kubectl -- kubectl completion zsh > "$COMP_DIR/_kubectl"
 "$MISE_BIN" exec helm -- helm completion zsh > "$COMP_DIR/_helm"
@@ -49,7 +56,6 @@ find "$CACHE_DIR" -name "*.zwc" -type f -delete 2>/dev/null || true
 
 # [Rationale]: Modern utilities with built-in generation verified via physical audit.
 "$MISE_BIN" exec xh -- xh --generate complete-zsh > "$COMP_DIR/_xh"
-# [Fix]: Use --gen-completion-out to ensure the script is written to stdout for redirection.
 "$MISE_BIN" exec cargo:procs -- procs --gen-completion-out zsh > "$COMP_DIR/_procs"
 "$MISE_BIN" exec doggo -- doggo completions zsh > "$COMP_DIR/_doggo"
 

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -137,14 +137,23 @@ jobs:
       - name: Idempotency Proof (Convergence Validation)
         # [Architecture]: Boundary Enforcer (Managed Config vs Volatile State)
         # [Rationale]: lazy-lock.json is subject to runtime mutation via plugin managers.
-        # Exclude it to prevent false-positive drift failures in CI.
-        # [Reference]: https://www.chezmoi.io/reference/commands/managed/
+        # Evaluates drift natively via 'chezmoi status' to bypass POSIX ARG_MAX limits
+        # and non-deterministic xargs path tokenization across BSD/GNU environments.
+        # [Reference]: https://www.chezmoi.io/reference/commands/status/
         run: |
-          if ! chezmoi managed | grep -v ".config/nvim/lazy-lock.json" | xargs chezmoi verify --source="$GITHUB_WORKSPACE"; then
+          DRIFT_STATUS=$(chezmoi status | grep -v "lazy-lock.json" || true)
+
+          if [ -n "$DRIFT_STATUS" ]; then
             echo "❌ [Idempotency Failure] Detected drift in managed files."
-            chezmoi managed | grep -v ".config/nvim/lazy-lock.json" | xargs chezmoi diff --source="$GITHUB_WORKSPACE"
+            echo "$DRIFT_STATUS"
+
+            # Extract raw paths using sed to drop the 3-character status prefix (e.g., ' M '),
+            # securely pipe null-terminated strings to xargs for OS-agnostic diff execution.
+            echo "$DRIFT_STATUS" | sed 's/^...//' | tr '\n' '\0' | xargs -0 chezmoi diff --source="$GITHUB_WORKSPACE"
             exit 1
           fi
+
+          echo "✅ [Convergence] Zero-drift confirmed across all managed files."
 
       - name: Final Health Check (Doctor)
         run: |

--- a/dot_config/mise/config.toml.tmpl
+++ b/dot_config/mise/config.toml.tmpl
@@ -4,6 +4,7 @@
 # non-deterministic API discovery and mitigate GitHub API Rate Limits (HTTP 403).
 [tools]
 node = "lts"
+pnpm = "latest"
 rust = "latest"
 neovim = "0.12.1"
 python = "3.13"
@@ -39,6 +40,9 @@ stylua = "latest"
 "npm:neovim" = "latest"
 "npm:@mermaid-js/mermaid-cli" = "latest"
 "npm:repomix" = "latest"
+
+# Web Development & Node.js Ecosystem
+"npm:@hubspot/cli" = "latest"
 
 # Data Processing
 "go:github.com/noahgorstein/jqp" = "latest"

--- a/dot_config/nvim/lazy-lock.json
+++ b/dot_config/nvim/lazy-lock.json
@@ -19,7 +19,7 @@
   "mason-lspconfig.nvim": { "branch": "main", "commit": "0a3b42c3e503df87aef6d6513e13148381495c3a" },
   "mason.nvim": { "branch": "main", "commit": "b03fb0f20bc1d43daf558cda981a2be22e73ac42" },
   "mini.ai": { "branch": "main", "commit": "43eb2074843950a3a25aae56a5f41362ec043bfa" },
-  "mini.icons": { "branch": "main", "commit": "7fdae2443a0e2910015ca39ad74b50524ee682d3" },
+  "mini.icons": { "branch": "main", "commit": "bac6317300e205335df425296570d84322730067" },
   "mini.pairs": { "branch": "main", "commit": "42387c7fe68fc0b6e95eaf37f1bb76e7bffaa0d9" },
   "mini.surround": { "branch": "main", "commit": "2715e04bea3ec9244f15b421dc5b18c0fe326210" },
   "noice.nvim": { "branch": "main", "commit": "7bfd942445fb63089b59f97ca487d605e715f155" },


### PR DESCRIPTION
## 🎯 Summary / Rationale
This PR integrates the Web/Node.js toolchain into the hermetic 'mise' infrastructure and hardens the CI idempotency verification logic.

**Toolchain Integration:**
Migrated 'pnpm' and 'HubSpot CLI' to mise management to ensure deterministic provisioning. Included a specialized sanitization layer for 'hs' completions to neutralize non-deterministic path hardcoding inherent in the Yargs framework, ensuring OS-agnostic resolution via shims.

**CI Infrastructure Hardening:**
Refactored the GHA idempotency proof. The previous pipeline using 'chezmoi managed | xargs verify' was prone to failure on Ubuntu runners due to ARG_MAX limits and non-deterministic path tokenization. The new implementation leverages 'chezmoi status' for native, high-performance drift detection, utilizing null-terminated strings for safe cross-platform path handling.

**State Synchronization:**
Updated 'lazy-lock.json' to align with the latest upstream commit for 'mini.icons', resolving the persistent drift detected in CI.

## 🛠 Key Changes
- **mise**: Added 'pnpm' and 'npm:@hubspot/cli' to config.toml.tmpl.
- **zsh**: Implemented path-sanitized, pre-compiled completions for the web toolchain in run_onchange_after_21-generate-completions.sh.tmpl.
- **GHA**: Replaced 'managed | verify' pipeline with a robust 'chezmoi status' based drift detection in compliance.yml to fix Ubuntu-specific idempotency failures.
- **neovim**: Synchronized lazy-lock.json to eliminate upstream-induced drift.

## 🧪 Verification Proof
- GHA Compliance Workflow: All Green (ubuntu-24.04, macos-14).
- Local 'doctor' scan: Passed.

## ⚠️ Side Effects / Risks
- Initial 'chezmoi apply' duration will increase slightly due to mise provisioning new Node.js packages.