### PR TITLE
chore(infra): align renovate configuration with v43 and node v22

### DIFF
--- a/.chezmoidata/tools.yaml
+++ b/.chezmoidata/tools.yaml
@@ -6,7 +6,7 @@
 # =============================================================================
 
 tool_integrity:
-  "op": "2.33.1" # renovate: datasource=github-releases packageName=1Password/connect
+  "op": "2.33.1" # [Architecture]: Untrackable via standard datasource (Binary distributed via AgileBits).
   op_hashes:
     darwin-arm64: "8106127624bf55f0bf5ae6f8e2c56398e01db75d64c3088eface33885c854351"
     linux-amd64: "0fc50cb22d791b5ee5e1421d97e96595fd61ca56ae92271bd1b28bb884971726"
@@ -27,7 +27,7 @@ tool_integrity:
     linux-x86_64: "ab757a1fd9ad307d53d2df4045698906a7ca3993d92260dd8fe49108712d57d0"
 
 mise_tools:
-  "node": "20.12.2" # renovate: datasource=node-version
+  "node": "22.14.0" # renovate: datasource=node-version
   "python": "3.13.0" # renovate: datasource=python-version
   "pnpm": "10.33.0" # renovate: datasource=npm
   "rust": "1.77.2" # renovate: datasource=github-releases packageName=rust-lang/rust

--- a/.chezmoiignore.tmpl
+++ b/.chezmoiignore.tmpl
@@ -28,7 +28,10 @@ Thumbs.db
 **/*_history
 **/.zcompdump*
 .cache/**
-# [Note]: We allow .local/state/ to be scanned, only blacklisting specific noisy apps if needed.
+
+# [Rationale]: Exclude ephemeral lockfiles from being managed or applied to $HOME.
+package-lock.json
+pnpm-lock.yaml
 
 # =============================================================================
 # 4. Repository Meta

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ __pycache__/
 *.pyc
 .venv/
 .python-version
+package-lock.json
+pnpm-lock.yaml
 
 # --- AI & Editor Contexts ---
 repomix-*.xml

--- a/renovate.json5
+++ b/renovate.json5
@@ -20,11 +20,9 @@
     {
       "customType": "regex",
       "description": "Parse .chezmoidata/tools.yaml for versions with renovate comments",
-      "fileMatch": ["^\\.chezmoidata/tools\\.yaml$"],
-      // [Rationale]: Matches keys and versions ONLY when followed by a renovate comment.
-      // This prevents the regex from accidentally capturing SHA256 hashes or other metadata.
+      "managerFilePatterns": ["/^\\.chezmoidata/tools\\.yaml$/"],
       "matchStrings": [
-        "\"?(?<depName>[a-zA-Z0-9\\-_:/@\\.]+)\"?:\\s*\"(?<currentValue>[a-zA-Z0-9\\-\\.]+)\"\\s*#\\s*renovate:\\s*datasource=(?<datasource>[a-zA-Z0-9-]+)(?:\\s+packageName=(?<packageName>[^\\s]+))?"
+        "^\\s*[\"']?(?<depName>[a-zA-Z0-9\\-_:/@\\.]+)[\"']?:\\s*[\"'](?<currentValue>[a-zA-Z0-9\\-\\.]+)[\"']\\s*#\\s*renovate:\\s*datasource=(?<datasource>[a-zA-Z0-9-]+)(?:\\s+packageName=(?<packageName>[^\\s#]+))?"
       ]
     }
   ]


### PR DESCRIPTION
## 🎯 Summary / Rationale

Renovate was non-functional due to a combination of missing execution rights (GitHub App) and technical debt in the configuration. This PR fixes the configuration to meet Renovate v43's strict engine requirements and improves the reliability of the regexManager.

## 🛠 Key Changes

- **Node.js**: Upgraded to v22.14.0 via `tools.yaml` to satisfy Renovate v43 constraints.
- **Renovate**: Migrated `fileMatch` to `managerFilePatterns` and implemented indentation-aware regex.
- **Infrastructure**: Updated `.gitignore` to prevent ephemeral lockfiles from polluting the repository.

## 🧪 Verification Proof

```zsh
λ node --version
v22.14.0

λ mise x npm:renovate -- renovate-config-validator
 INFO: Validating renovate.json5
 INFO: Config validated successfully
```

## ⚠️ Side Effects / Risks

None. This is a non-breaking change to the internal meta-configuration.