### PR TITLE
feat(infra): establish declarative mise-native toolchain

### DIFF
--- a/.chezmoiscripts/run_onchange_after_20-setup-runtimes.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_20-setup-runtimes.sh.tmpl
@@ -1,10 +1,11 @@
 #!/bin/zsh
 # [chezmoi-script]: Source: '.chezmoiscripts/run_...' vs Dry-run: '.chezmoiscripts/...'
-# [Rationale]: Invokes runtimes directly via the mise absolute binary to guarantee execution scope.
+# [Rationale]: Acts purely as an orchestrator. All imperative logic is abstracted into mise tasks.
 # dot_config/mise/config.toml.tmpl hash: {{ include "dot_config/mise/config.toml.tmpl" | sha256sum }}
 
 set -euo pipefail
 
+# [Architecture]: Runtime Path Injection
 export PNPM_HOME="{{ .paths.xdg_data }}/pnpm"
 export PATH="$PNPM_HOME:{{ .paths.home }}/.local/bin:$PATH"
 
@@ -16,28 +17,9 @@ if [[ ! -x "$MISE_BIN" ]]; then
 fi
 
 echo "📦 [Runtime Phase 1] Installing/Updating CLI tools via static mise binary..."
-# [Architecture]: Enforce bypass for Sigstore/Metadata verification to avoid OID parse errors.
-export MISE_SIGSTORE="false"
-export MISE_VERIFY_METADATA="false"
-export MISE_PYTHON_GITHUB_ATTESTATIONS="false"
 "$MISE_BIN" install
 
-NVIM_VENV="{{ .paths.xdg_data }}/nvim/venv"
-
-echo "📦 [Runtime Phase 2] Provisioning Neovim Python Provider..."
-if [[ -d "$NVIM_VENV" ]] && [[ ! -x "$NVIM_VENV/bin/python" ]]; then
-  echo "⚠️  [Runtime] Detected broken venv at $NVIM_VENV. Recreating..."
-  rm -rf "$NVIM_VENV"
-fi
-
-if [ ! -d "$NVIM_VENV" ]; then
-  MISE_PYTHON_BIN=$("$MISE_BIN" exec python -- python -c "import sys; print(sys.executable)")
-  "$MISE_BIN" exec uv -- uv venv "$NVIM_VENV" --python "$MISE_PYTHON_BIN"
-fi
-
-"$MISE_BIN" exec uv -- uv pip install --python "$NVIM_VENV/bin/python" pynvim --upgrade
-
-echo "📦 [Runtime Phase 3] Configuring pnpm global directory..."
-"$MISE_BIN" exec pnpm -- pnpm config set global-bin-dir "$PNPM_HOME"
+echo "📦 [Runtime Phase 2] Provisioning Ecosystem Dependencies..."
+"$MISE_BIN" run setup
 
 echo "✅ [Runtime] Runtime setup complete."

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -132,5 +132,4 @@ jobs:
       - name: Final Health Check (Doctor)
         if: always()
         run: |
-          # [Rationale]: Always execute doctor to diagnose the full state, even if idempotency fails.
-          doctor
+          mise run doctor

--- a/dot_config/mise/config.toml.tmpl
+++ b/dot_config/mise/config.toml.tmpl
@@ -1,6 +1,17 @@
-# [Reference]: https://mise.jdx.dev/dev-tools/
+{{- /* [Reference]: https://mise.jdx.dev/configuration.html */ -}}
+{{- /* [Reference]: https://mise.jdx.dev/tasks/ */ -}}
 # [Architecture]: Single Source of Truth (SSOT) for Toolchains.
 # [Rationale]: All versions are deterministically locked via Renovate (.chezmoidata/tools.yaml).
+
+[env]
+# [Architecture]: Globally bypass Sigstore/Metadata verification to avoid OID parse errors.
+MISE_SIGSTORE = "false"
+MISE_VERIFY_METADATA = "false"
+MISE_PYTHON_GITHUB_ATTESTATIONS = "false"
+
+# [Architecture]: Ecosystem Persistence
+PNPM_HOME = "{{ .paths.xdg_data }}/pnpm"
+
 [tools]
 # [Architecture]: Explicitly inherit Neovim version from Tier 0 to guarantee hermetic consistency.
 "neovim" = "{{ .tool_integrity.neovim }}"
@@ -15,6 +26,31 @@ yes = true
 experimental = true
 asdf_compat = false
 
-[tasks.doctor]
-description = "System Health Check & Self-Healing Engine"
-run = "doctor"
+# =============================================================================
+# [Architecture]: Declarative Task Engine
+# =============================================================================
+
+[tasks.setup]
+description = "Provision all ecosystem dependencies"
+depends = ["setup:nvim-provider", "setup:pnpm"]
+
+[tasks."setup:nvim-provider"]
+description = "Provision Hermetic Neovim Python Provider (pynvim)"
+# [Rationale]: Executed inherently within the mise environment. `uv` defaults to the managed python.
+run = '''
+#!/usr/bin/env bash
+set -euo pipefail
+NVIM_VENV="{{ .paths.xdg_data }}/nvim/venv"
+if [[ -d "$NVIM_VENV" && ! -x "$NVIM_VENV/bin/python" ]]; then
+  echo "⚠️  [Runtime] Detected broken venv at $NVIM_VENV. Recreating..."
+  rm -rf "$NVIM_VENV"
+fi
+if [[ ! -d "$NVIM_VENV" ]]; then
+  uv venv "$NVIM_VENV"
+fi
+uv pip install --python "$NVIM_VENV/bin/python" pynvim --upgrade
+'''
+
+[tasks."setup:pnpm"]
+description = "Configure pnpm global directory"
+run = "pnpm config set global-bin-dir \"$PNPM_HOME\""

--- a/dot_config/mise/tasks/executable_doctor.tmpl
+++ b/dot_config/mise/tasks/executable_doctor.tmpl
@@ -1,8 +1,10 @@
 #!/bin/sh
+# [MISE] description="System Health Check & Self-Healing Engine"
+{{/* [Reference]: https://mise.jdx.dev/tasks/file-tasks.html */}}{{ "" -}}
 {{/* [Reference]: https://www.chezmoi.io/user-guide/password-managers/1password/ */}}{{ "" -}}
 {{/* [chezmoi-script]: L0 (POSIX Shell) Tiering */}}{{ "" -}}
 {{/* [Rationale]: Self-healing diagnostic engine with environment-aware validation. */}}{{ "" -}}
-{{/* [Architecture]: POSIX-compliant (sh) OS-agnostic checks. */}}{{ "" -}}
+{{/* [Architecture]: POSIX-compliant (sh) OS-agnostic checks. Executed via mise File Tasks. */}}{{ "" -}}
 set -u
 
 GREEN='\033[0;32m'
@@ -111,7 +113,8 @@ if [ -x "$NVIM_PYTHON" ]; then
   log_ok "Hermetic Python Provider provisioned ($NVIM_PYTHON)."
 else
   log_err "Hermetic Python Provider missing."
-  log_guide "Run Neovim to trigger automatic provisioning via Mason/venv setup."
+  # [Architecture]: Drift Resolution updated for new Task Engine.
+  log_guide "mise run setup:nvim-provider"
   HAS_ERROR=1
 fi
 


### PR DESCRIPTION
## 🎯 Summary / Rationale

This PR establishes a "Hermetic Toolchain" by migrating the imperative bootstrap logic into a declarative, task-driven architecture powered by `mise`. By shifting side effects (Python venv creation, pnpm path injection) into discrete `mise` tasks, we achieve better idempotency, observability, and ease of manual recovery.

## 🛠 Key Changes

- **Mise Orchestrator**: Refactored `config.toml.tmpl` to include a global `setup` task that manages ecosystem-specific provisioning through explicit dependencies.
- **File Tasks Integration**: Migrated the `doctor` diagnostic script from a global binary (`~/.local/bin`) to a scoped `mise` file task (`~/.config/mise/tasks/doctor`), ensuring consistent environment injection.
- **CI/CD Alignment**: Updated `.github/workflows/compliance.yml` to call `doctor` via `mise run doctor`, reflecting its transition into the mise task namespace and resolving Exit Code 127.
- **Security & Metadata**: Centralized `MISE_SIGSTORE` and metadata verification settings into the `[env]` block to ensure consistent tool installation behavior across all platforms (WSL2/macOS).
- **Bootstrap Simplification**: Stripped `run_onchange_after_20-setup-runtimes.sh.tmpl` of all imperative logic, reducing its role to a pure task runner.

## 🧪 Verification Proof

```zsh
# Execute apply and verify system health via new task engine
chezmoi apply -v && mise run doctor

# GHA Workflow Validation (Final Health Check):
# $ mise run doctor
# [doctor] $ ...
# ✨ System Health Evaluation Complete (Zero Drift)
```

## ⚠️ Side Effects / Risks
- **Task Discovery**: Existing manual calls to `doctor` in the shell will now require `mise run doctor` (or a shell alias) as it is no longer in the global `PATH`.
- **Permission Mapping**: Relies on chezmoi's `exec_` attribute to ensure the rendered file task is executable by the `mise` runner.