### PR TITLE
chore(deps): atomic neovim plugin convergence

### DIFF
--- a/dot_config/nvim/lazy-lock.json
+++ b/dot_config/nvim/lazy-lock.json
@@ -34,7 +34,7 @@
   "persistence.nvim": { "branch": "main", "commit": "b20b2a7887bd39c1a356980b45e03250f3dce49c" },
   "plenary.nvim": { "branch": "master", "commit": "74b06c6c75e4eeb3108ec01852001636d85a932b" },
   "render-markdown.nvim": { "branch": "main", "commit": "0fd43fb4b1f073931c4b481f5f3b7cea3749e190" },
-  "rustaceanvim": { "branch": "main", "commit": "69c5a32d332d3b359c51a3a5eb5dc2d2b5a90e30" },
+  "rustaceanvim": { "branch": "main", "commit": "824491c58bdba1f6f5e35e64e0ab8b2e2425d6b2" },
   "snacks.nvim": { "branch": "main", "commit": "ad9ede6a9cddf16cedbd31b8932d6dcdee9b716e" },
   "todo-comments.nvim": { "branch": "main", "commit": "31e3c38ce9b29781e4422fc0322eb0a21f4e8668" },
   "tokyonight.nvim": { "branch": "main", "commit": "cdc07ac78467a233fd62c493de29a17e0cf2b2b6" },


### PR DESCRIPTION
### 🎯 Rationale
Automated state promotion of `lazy-lock.json`.

### ⚠️ Action Required (SSH Signature Preservation)
To preserve the cryptographic integrity of the SSH signature (Fast-Forward only), **DO NOT merge via GitHub UI**.
Execute the following locally after the CI pipeline passes:

```zsh
git checkout main
git merge --ff-only chore/deps-nvim-202604201324
git push origin main
git branch -d chore/deps-nvim-202604201324
git push origin --delete chore/deps-nvim-202604201324
```