### PR TITLE
feat(infra): reactive protocol-driven Smart Splits integration

### DIFF
--- a/dot_config/nvim/init.lua.tmpl
+++ b/dot_config/nvim/init.lua.tmpl
@@ -1,8 +1,33 @@
 -- [Architecture]: I/O Minimalist Bootstrap & Caching
 -- [Rationale]: Enable native Lua loader immediately to bypass file stat operations.
+{{/* [Reference]: https://neovim.io/doc/user/lua.html#_lua-module-vim.loader */}}
 if vim.loader then
   vim.loader.enable()
 end
+
+-- [Architecture]: Terminal Identity Propagation (OSC 1337 / Physical Bypass)
+-- [Rationale]: Directly writes to /dev/tty to bypass Neovim's TUI buffer.
+-- This ensures the signal survives startup/exit and reaches the terminal server.
+{{/* [Reference]: https://wezfurlong.org/wezterm/config/lua/pane/get_user_vars.html */}}
+local function set_wezterm_var(name, value)
+  if vim.env.TERM_PROGRAM ~= "WezTerm" then return end
+  local str_value = value and "true" or "false"
+  local osc = string.format("\027]1337;SetUserVar=%s=%s\007", name, vim.base64.encode(str_value))
+
+  local f = io.open("/dev/tty", "wb")
+  if f then
+    f:write(osc)
+    f:flush()
+    f:close()
+  end
+end
+
+vim.api.nvim_create_autocmd({ "VimEnter", "VimLeave" }, {
+  group = vim.api.nvim_create_augroup("WeztermSmartSplits", { clear = true }),
+  callback = function(ev)
+    set_wezterm_var("IS_NVIM", ev.event ~= "VimLeave")
+  end,
+})
 
 -- [Architecture]: Infrastructure Layer / Environment Sanitization
 -- [Rationale]: Mitigate Upstream Binary Relocation Defects (v0.11.x - v0.12.x).
@@ -45,14 +70,11 @@ local function reconstruct_package_path()
 end
 
 -- [Optimization]: Lazy Execution
--- Reconstruct search space ONLY if operating in the CI environment where poisoning occurs.
--- Eliminates redundant filesystem traversal during standard interactive use.
 if vim.env.CI == "true" then
   reconstruct_package_path()
 end
 
 -- [Provider]: Force isolated Python provider to prevent venv collision.
--- Assigning the variable is inherently lazy and avoids any immediate lookup penalty.
 vim.g.python3_host_prog = "{{ .paths.xdg_data }}/nvim/venv/bin/python"
 
 -- Load LazyVim core.

--- a/dot_config/nvim/lua/config/options.lua.tmpl
+++ b/dot_config/nvim/lua/config/options.lua.tmpl
@@ -28,15 +28,11 @@ opt.ignorecase = true
 opt.smartcase = true
 
 -- [Strategy]: 2026 Sovereign Spell Enforcement
--- [Rationale]: Deprecate native 'spell' to eliminate UI noise (red underlines).
--- Shift to Contextual LSPs (Harper/Typos) for non-destructive grammar/typo audit.
 opt.spell = false
 opt.spelllang = { "en" }
 opt.spelloptions = "camel"
 
 -- [Architecture]: WSL2 Deterministic Clipboard Provider
--- [Rationale]: Explicitly bind to win32yank.exe to bypass dynamic resolution
--- and ensure reliable Win32 interoperability.
 -- [Reference]: :help provider-clipboard
 if vim.fn.has("wsl") == 1 then
   vim.g.clipboard = {
@@ -52,3 +48,30 @@ if vim.fn.has("wsl") == 1 then
     cache_enabled = 1,
   }
 end
+
+-- [Architecture]: Protocol-Driven Outbound Navigation (Smart Splits)
+-- [Rationale]: Emits an OSC 1337 signal when reaching the vim boundary,
+-- delegating the pane switch to WezTerm's event listener.
+local function signal_move_to_wezterm(direction)
+  if vim.env.TERM_PROGRAM ~= "WezTerm" then return end
+  local osc = string.format("\027]1337;SetUserVar=MOVE_SIGNAL=%s\007", vim.base64.encode(direction))
+  local f = io.open("/dev/tty", "wb")
+  if f then
+    f:write(osc)
+    f:flush()
+    f:close()
+  end
+end
+
+local function move_or_signal(key, direction)
+  local prev_win = vim.api.nvim_get_current_win()
+  vim.cmd("wincmd " .. key)
+  if prev_win == vim.api.nvim_get_current_win() then
+    signal_move_to_wezterm(direction)
+  end
+end
+
+vim.keymap.set("n", "<C-h>", function() move_or_signal("h", "Left") end)
+vim.keymap.set("n", "<C-j>", function() move_or_signal("j", "Down") end)
+vim.keymap.set("n", "<C-k>", function() move_or_signal("k", "Up") end)
+vim.keymap.set("n", "<C-l>", function() move_or_signal("l", "Right") end)

--- a/dot_config/wezterm/wezterm.lua.tmpl
+++ b/dot_config/wezterm/wezterm.lua.tmpl
@@ -1,6 +1,7 @@
 {{- /* [Reference]: https://wezfurlong.org/wezterm/config/lua/config/use_ime.html */ -}}
 {{- /* [Reference]: https://wezfurlong.org/wezterm/config/lua/wezterm/font_with_fallback.html */ -}}
 {{- /* [Reference]: https://wezfurlong.org/wezterm/config/lua/config/window_decorations.html */ -}}
+{{- /* [Reference]: https://wezfurlong.org/wezterm/config/lua/window-event/user-var-changed.html */ -}}
 
 local wezterm = require("wezterm")
 local act = wezterm.action
@@ -12,14 +13,12 @@ config.audible_bell = "Disabled"
 config.scrollback_lines = 100000
 
 -- [Architecture]: 2026 Modern UI Standards
--- [Rationale]: Remove non-functional title bars to maximize workspace density.
 config.window_decorations = "RESIZE"
 config.window_background_opacity = 1.0
 config.window_padding = { left = 12, right = 12, top = 10, bottom = 8 }
 config.hide_tab_bar_if_only_one_tab = true
 
 -- [Architecture]: Sovereign Typography & Rendering
--- [Rationale]: Enforce WebGpu for sub-millisecond frame times.
 config.front_end = "WebGpu"
 config.colors = wezterm.get_builtin_color_schemes()["Dracula"]
 config.font = wezterm.font_with_fallback({
@@ -36,12 +35,10 @@ config.line_height = 1.15
 config.bold_brightens_ansi_colors = true
 config.allow_square_glyphs_to_overflow_width = "Always"
 
--- [Architecture]: Linguistic Interop (2026 Standard)
--- [Rationale]: Critical for seamless Japanese input and Neovim parity.
+-- [Architecture]: Linguistic Interop
 config.use_ime = true
 
 -- [Architecture]: SRE Diagnostic Clarity
--- [Rationale]: Explicitly enable undercurl/underline support for LSP diagnostics.
 config.underline_thickness = "2pt"
 config.underline_position = "-2pt"
 
@@ -63,28 +60,54 @@ else
 end
 
 -- ============================================================================
+-- [Architecture]: Smart Splits (Zero-CLI Protocol Implementation)
+-- ============================================================================
+
+local function is_vim(pane)
+  if not pane then return false end
+  local vars = pane:get_user_vars()
+  if vars and vars.IS_NVIM == "true" then return true end
+
+  local success, process_name = pcall(function() return pane:get_foreground_process_name() end)
+  return success and process_name and process_name:find("n?vim") ~= nil
+end
+
+wezterm.on("user-var-changed", function(window, pane, name, value)
+  if name == "MOVE_SIGNAL" then
+    window:perform_action(act.ActivatePaneDirection(value), pane)
+  end
+end)
+
+local function direction_keys(key, direction)
+  return {
+    key = key,
+    mods = "CTRL",
+    action = wezterm.action_callback(function(window, pane)
+      if is_vim(pane) then
+        window:perform_action(act.SendKey({ key = key, mods = "CTRL" }), pane)
+      else
+        window:perform_action(act.ActivatePaneDirection(direction), pane)
+      end
+    end),
+  }
+end
+
+-- ============================================================================
 -- [Architecture]: Keyboard Driven Multiplexer & Command Palette
 -- ============================================================================
 config.leader = { key = "b", mods = "CTRL", timeout_milliseconds = 1000 }
 config.keys = {
-  -- [2026 Discovery]: Command Palette (Modern UX)
   { key = "P", mods = "CTRL|SHIFT", action = act.ActivateCommandPalette },
-
-  -- [Action]: Session Detach
   { key = "d", mods = "LEADER", action = act.DetachDomain("CurrentPaneDomain") },
-
-  -- [Action]: Pane Management
   { key = "s", mods = "LEADER", action = act.SplitVertical({ domain = "CurrentPaneDomain" }) },
   { key = "v", mods = "LEADER", action = act.SplitHorizontal({ domain = "CurrentPaneDomain" }) },
   { key = "x", mods = "LEADER", action = act.CloseCurrentPane({ confirm = true }) },
 
-  -- [Action]: Pane Navigation (Vim Standard)
-  { key = "h", mods = "LEADER", action = act.ActivatePaneDirection("Left") },
-  { key = "j", mods = "LEADER", action = act.ActivatePaneDirection("Down") },
-  { key = "k", mods = "LEADER", action = act.ActivatePaneDirection("Up") },
-  { key = "l", mods = "LEADER", action = act.ActivatePaneDirection("Right") },
+  direction_keys("h", "Left"),
+  direction_keys("j", "Down"),
+  direction_keys("k", "Up"),
+  direction_keys("l", "Right"),
 
-  -- [Action]: Tab Management
   { key = "c", mods = "LEADER", action = act.SpawnTab("CurrentPaneDomain") },
   { key = "n", mods = "LEADER", action = act.ActivateTabRelative(1) },
   { key = "p", mods = "LEADER", action = act.ActivateTabRelative(-1) },


### PR DESCRIPTION
## 🎯 Summary / Rationale

This PR finalizes the seamless integration between WezTerm panes and Neovim windows. Moving away from imperative CLI calls (`wezterm cli`), it adopts a reactive, protocol-driven model using OSC 1337 UserVars. This ensures zero-latency navigation and eliminates 'context loss' common in multiplexed or WSL2 environments.

## 🛠 Key Changes

- **Neovim (init/options)**: 
  - Broadcasts `IS_NVIM` state to WezTerm via `/dev/tty` to bypass TUI buffering.
  - Emits `MOVE_SIGNAL` when reaching window boundaries, delegating movement to the terminal.
- **WezTerm**:
  - Implements a `user-var-changed` event listener to handle inbound navigation signals.
  - Uses a defensive `is_vim` check (combining UserVars and process names) for robust key routing.

## 🧪 Verification Proof

Verified across macOS (Tahoe) and WSL2 (Ubuntu 24.04):
1. **Smart Splits**: Bi-directional 1-stroke (`CTRL+H/J/K/L`) navigation is fully restored.
2. **Persistence**: Native Swift `pbcopy` and PowerShell clipboard bridges are functional.
3. **Determinism**: Neovim `reconstruct_package_path` CI logic is preserved.

## ⚠️ Side Effects / Risks

- Requires Neovim 0.10+ for `vim.base64` support.