### PR TITLE
chore(deps): atomic neovim plugin convergence

### DIFF
--- a/dot_config/nvim/lazy-lock.json
+++ b/dot_config/nvim/lazy-lock.json
@@ -17,7 +17,7 @@
   "lualine.nvim": { "branch": "master", "commit": "a905eeebc4e63fdc48b5135d3bf8aea5618fb21c" },
   "markdown-preview.nvim": { "branch": "master", "commit": "a923f5fc5ba36a3b17e289dc35dc17f66d0548ee" },
   "mason-lspconfig.nvim": { "branch": "main", "commit": "0a3b42c3e503df87aef6d6513e13148381495c3a" },
-  "mason.nvim": { "branch": "main", "commit": "b03fb0f20bc1d43daf558cda981a2be22e73ac42" },
+  "mason.nvim": { "branch": "main", "commit": "12ddd182d9efbdc848b540f16484a583d52da0fb" },
   "mini.ai": { "branch": "main", "commit": "43eb2074843950a3a25aae56a5f41362ec043bfa" },
   "mini.icons": { "branch": "main", "commit": "bac6317300e205335df425296570d84322730067" },
   "mini.pairs": { "branch": "main", "commit": "42387c7fe68fc0b6e95eaf37f1bb76e7bffaa0d9" },


### PR DESCRIPTION
### 🎯 Rationale
Automated state promotion of `lazy-lock.json`.

### ⚠️ Action Required (SSH Signature Preservation)
To preserve the cryptographic integrity of the SSH signature (Fast-Forward only), **DO NOT merge via GitHub UI**.
Execute the following locally after the CI pipeline passes:

```zsh
git checkout main
git merge --ff-only chore/deps-nvim-202604220533
git push origin main
git branch -d chore/deps-nvim-202604220533
git push origin --delete chore/deps-nvim-202604220533
```