### PR TITLE
refactor(wezterm): dynamic WSL domain resolution

### DIFF
--- a/dot_config/wezterm/wezterm.lua.tmpl
+++ b/dot_config/wezterm/wezterm.lua.tmpl
@@ -51,9 +51,17 @@ config.inactive_pane_hsb = {
   brightness = 0.5,
 }
 
+-- ============================================================================
 -- [Architecture]: Cross-OS Multiplexer Engine
+-- ============================================================================
+-- [Rationale]: WSL domain enumeration is delegated to WezTerm's native logic.
+-- If a preferred domain is provided via SSOT (chezmoi), it is injected here;
+-- otherwise, default_domain is left unset to preserve WezTerm's standard behavior.
+-- [Reference]: https://wezterm.org/config/lua/config/default_domain.html
 if wezterm.target_triple:find("windows") then
-  config.default_domain = "WSL:Ubuntu"
+{{- if hasKey . "default_wsl_domain" }}
+  config.default_domain = {{ .default_wsl_domain | quote }}
+{{- end }}
 else
   config.unix_domains = { { name = "unix" } }
   config.default_gui_startup_args = { "connect", "unix" }


### PR DESCRIPTION
## 🎯 Summary / Rationale
Eliminates environment-specific hardcoding for WSL domains. This transition allows the dotfiles to be truly portable across different Windows/WSL setups by leveraging WezTerm's native detection and chezmoi's data injection.

## 🛠 Key Changes

- **WezTerm Config**: 
    - Replaced `config.default_domain = "WSL:Ubuntu"` with a dynamic `chezmoi` template block.
    - Added `[Architecture]` and `[Rationale]` metadata for maintainability.
    - Updated references to official documentation.

## 🧪 Verification Proof

```zsh
chezmoi verify && echo 0
0
```

## ⚠️ Side Effects / Risks
None. Environments without the `default_wsl_domain` chezmoi variable will safely default to WezTerm's native shell/domain resolution.
