### PR TITLE
fix(wezterm): remove process-name fallback from smart splits

### DIFF
--- a/dot_config/wezterm/wezterm.lua.tmpl
+++ b/dot_config/wezterm/wezterm.lua.tmpl
@@ -71,13 +71,11 @@ end
 -- [Architecture]: Smart Splits (Zero-CLI Protocol Implementation)
 -- ============================================================================
 
-local function is_vim(pane)
+local function is_nvim_pane(pane)
   if not pane then return false end
   local vars = pane:get_user_vars()
   if vars and vars.IS_NVIM == "true" then return true end
-
-  local success, process_name = pcall(function() return pane:get_foreground_process_name() end)
-  return success and process_name and process_name:find("n?vim") ~= nil
+  return false
 end
 
 wezterm.on("user-var-changed", function(window, pane, name, value)
@@ -91,7 +89,7 @@ local function direction_keys(key, direction)
     key = key,
     mods = "CTRL",
     action = wezterm.action_callback(function(window, pane)
-      if is_vim(pane) then
+      if is_nvim_pane(pane) then
         window:perform_action(act.SendKey({ key = key, mods = "CTRL" }), pane)
       else
         window:perform_action(act.ActivatePaneDirection(direction), pane)


### PR DESCRIPTION
## 🎯 Summary / Rationale

Use pane user vars as the sole source of truth for Neovim detection in
WezTerm Smart Splits.

This removes the `pane:get_foreground_process_name()` fallback from the
routing path and aligns pane detection with the existing `IS_NVIM` /
`MOVE_SIGNAL` design. The goal is not to change the intended UX, but to
eliminate process-name-based detection from the implementation.

## 🛠 Key Changes

- **WezTerm Smart Splits**: Renamed `is_vim` to `is_nvim_pane`
- **Neovim Pane Detection**: Removed `pane:get_foreground_process_name()` fallback
- **Routing Logic**: `pane:get_user_vars().IS_NVIM == "true"` is now the only detection path
- **Key Dispatch**: Updated `<C-h/j/k/l>` branching to call `is_nvim_pane(...)`

## 🧪 Verification Proof

```zsh
# paste logs here
````

## ⚠️ Side Effects / Risks

* Panes that do not set `IS_NVIM=true` will now be treated as non-Neovim panes
* This change assumes the existing Neovim-side `SetUserVar` flow remains intact
