### PR TITLE
refactor(wezterm): standardize terminal UX across macOS and WSL

### DIFF
--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -1,6 +1,5 @@
 # =============================================================================
 # [Architecture]: Declarative Package Schema (Zero-Toil Edition)
-# [Rationale]: 1Password is excluded as it is a Tier -2 requirement.
 # =============================================================================
 packages:
   headless:
@@ -46,6 +45,7 @@ packages:
       - notion
       - raycast
       - visual-studio-code
+      - 1password
     windows:
       - wez.wezterm.nightly
       - SlackTechnologies.Slack
@@ -54,14 +54,8 @@ packages:
       - Flow-Launcher.Flow-Launcher
       - Microsoft.PowerToys
       - Microsoft.VisualStudioCode
-
-  fonts:
-    darwin:
-      - font-jetbrains-mono-nerd-font
-      - font-biz-udgothic
-      - font-ibm-plex-sans-jp
-    windows:
-      - DEVCOM.JetBrainsMonoNerdFont
+      - AgileBits.1Password
+      - AgileBits.1Password.CLI
 
   media:
     darwin:

--- a/.chezmoiscripts/run_onchange_before_00-install-windows-deps.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_00-install-windows-deps.sh.tmpl
@@ -45,9 +45,6 @@ install_winget_app {{ . | quote }}
 install_winget_app {{ . | quote }}
 {{ end -}}
 
-{{ range .packages.fonts.windows -}}
-install_winget_app {{ . | quote }}
-{{ end -}}
 {{- end }}
 
 echo "✅ [Infrastructure] Windows dependency provisioning complete."

--- a/dot_config/homebrew/Brewfile.tmpl
+++ b/dot_config/homebrew/Brewfile.tmpl
@@ -19,11 +19,6 @@ cask {{ . | quote }}
 # Desktop & Media Provisioning (Bypassed in CI)
 # =============================================================================
 
-# --- Fonts ---
-{{ range .packages.fonts.darwin -}}
-cask {{ . | quote }}
-{{ end -}}
-
 # --- Media Processing ---
 {{ range .packages.media.darwin -}}
 brew {{ . | quote }}

--- a/dot_config/wezterm/wezterm.lua.tmpl
+++ b/dot_config/wezterm/wezterm.lua.tmpl
@@ -5,6 +5,18 @@
 
 local wezterm = require("wezterm")
 local act = wezterm.action
+local font_fallback = { "JetBrains Mono" }
+
+if wezterm.target_triple:find("darwin") then
+  table.insert(font_fallback, "Apple Color Emoji")
+  table.insert(font_fallback, { family = "BIZ UDGothic", weight = "Bold" })
+  table.insert(font_fallback, "Hiragino Sans")
+else
+  table.insert(font_fallback, "Segoe UI Emoji")
+  table.insert(font_fallback, "BIZ UDGothic")
+  table.insert(font_fallback, "Meiryo")
+end
+
 local config = wezterm.config_builder()
 
 -- [Architecture]: Infrastructure Sovereignty
@@ -21,22 +33,17 @@ config.hide_tab_bar_if_only_one_tab = true
 -- [Architecture]: Sovereign Typography & Rendering
 config.front_end = "WebGpu"
 config.colors = wezterm.get_builtin_color_schemes()["Dracula"]
-config.font = wezterm.font_with_fallback({
-  "JetBrainsMono Nerd Font",
-  "Apple Color Emoji",
-  "Segoe UI Emoji",
-  "BIZ UD Gothic",
-  "IBM Plex Sans JP",
-  "Hiragino Sans",
-  "Meiryo",
-})
+config.key_map_preference = "Physical"
+config.font = wezterm.font_with_fallback(font_fallback)
 config.font_size = 14.0
 config.line_height = 1.15
 config.bold_brightens_ansi_colors = true
 config.allow_square_glyphs_to_overflow_width = "Always"
+config.use_cap_height_to_scale_fallback_fonts = true
 
 -- [Architecture]: Linguistic Interop
 config.use_ime = true
+config.send_composed_key_when_left_alt_is_pressed = true
 
 -- [Architecture]: SRE Diagnostic Clarity
 config.underline_thickness = "2pt"
@@ -84,13 +91,18 @@ wezterm.on("user-var-changed", function(window, pane, name, value)
   end
 end)
 
+local macos_specific_keys = {}
+if wezterm.target_triple:find("darwin") then
+  table.insert(macos_specific_keys, { key = "phys:Backslash", mods = "NONE", action = act.SendString("\\") })
+end
+
 local function direction_keys(key, direction)
   return {
     key = key,
-    mods = "CTRL",
+    mods = "CTRL|SHIFT",
     action = wezterm.action_callback(function(window, pane)
       if is_nvim_pane(pane) then
-        window:perform_action(act.SendKey({ key = key, mods = "CTRL" }), pane)
+        window:perform_action(act.SendKey({ key = key, mods = "CTRL|SHIFT" }), pane)
       else
         window:perform_action(act.ActivatePaneDirection(direction), pane)
       end
@@ -118,5 +130,9 @@ config.keys = {
   { key = "n", mods = "LEADER", action = act.ActivateTabRelative(1) },
   { key = "p", mods = "LEADER", action = act.ActivateTabRelative(-1) },
 }
+
+for _, key in ipairs(macos_specific_keys) do
+  table.insert(config.keys, key)
+end
 
 return config


### PR DESCRIPTION
## 🎯 Summary / Rationale

Standardize WezTerm behavior across macOS and WSL while reducing configuration drift in the bootstrap layer.

This change removes WezTerm-specific external font provisioning, switches the terminal to a simpler bundled/native fallback strategy, and aligns key behavior for daily terminal use across both environments.

## 🛠 Key Changes

- **WezTerm**: Switched to bundled `JetBrains Mono` with OS-native emoji and Japanese fallback fonts
- **WezTerm**: Enabled `Physical` key mapping for more consistent cross-OS behavior
- **WezTerm**: Enabled composed left Alt/Option input on macOS for UK layout symbol entry
- **WezTerm**: Added macOS-specific JIS backslash normalization inside the terminal
- **WezTerm**: Moved pane navigation to `Ctrl+Shift+h/j/k/l` to avoid conflict with standard terminal clear behavior
- **Bootstrap**: Removed obsolete font provisioning paths now that WezTerm no longer depends on those external font packages
- **Packages**: Updated managed GUI package definitions to reflect current personal workstation usage

## 🧪 Verification Proof

```zsh
git diff --check
chezmoi execute-template < dot_config/wezterm/wezterm.lua.tmpl >/dev/null
wezterm-gui ls-fonts
wezterm-gui ls-fonts --text 'Hello 日本語 😀 \\ #'\n```\n\n## ⚠️ Side Effects / Risks\n\n- Existing muscle memory for pane navigation changes from `Ctrl+h/j/k/l` to `Ctrl+Shift+h/j/k/l`\n- Terminal typography now depends on OS-native fallback fonts for emoji and Japanese text\n- Personal workstation package scope now includes additional GUI tooling by design\n