### PR TITLE
chore(renovate): test reconfigure flow

### DIFF
--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -30,12 +30,23 @@ packages:
       brews:
         - openssl@3
         - colima
+        - just
+        - atuin
+        - duckdb
+        - deno
         - eza
         - xh
+        - awscli
+        - azure-cli
       casks: []
     windows:
+      - Atuinsh.Atuin
+      - DuckDB.cli
+      - DenoLand.Deno
       - eza-community.eza
       - ducaale.xh
+      - Amazon.AWSCLI
+      - Microsoft.AzureCLI
 
   gui:
     darwin:

--- a/.chezmoidata/tools.yaml
+++ b/.chezmoidata/tools.yaml
@@ -11,6 +11,7 @@ mise_tools:
   "node": "24.15.0" # renovate: datasource=node-version
   "python": "3.14.4" # renovate: datasource=python-version
   "pnpm": "10.33.1" # renovate: datasource=npm
+  "core:deno": "2.7.13" # renovate: datasource=github-releases packageName=denoland/deno
   "rust": "1.95.0" # renovate: datasource=github-releases packageName=rust-lang/rust
   "go": "1.26.2" # renovate: datasource=golang-version
   "aqua:astral-sh/uv": "0.11.7" # renovate: datasource=github-releases packageName=astral-sh/uv
@@ -26,12 +27,14 @@ mise_tools:
   "pipx:neovim/pynvim": "0.6.0" # renovate: datasource=github-releases packageName=neovim/pynvim
   "npm:neovim": "5.4.0" # renovate: datasource=npm packageName=neovim
 
-  # --- 4. SOTA Development & Context ---
+  # --- 4. SOTA Development ---
   "aqua:tree-sitter/tree-sitter": "0.26.8" # renovate: datasource=github-releases packageName=tree-sitter/tree-sitter
   "aqua:pre-commit/pre-commit": "4.6.0" # renovate: datasource=github-releases packageName=pre-commit/pre-commit
-  "npm:repomix": "1.13.1" # renovate: datasource=npm packageName=repomix
 
   # --- 5. Engineering Utilities ---
+  "aqua:casey/just": "1.50.0" # renovate: datasource=github-releases packageName=casey/just
+  "aqua:atuinsh/atuin": "18.15.2" # renovate: datasource=github-releases packageName=atuinsh/atuin
+  "aqua:duckdb/duckdb": "1.5.2" # renovate: datasource=github-releases packageName=duckdb/duckdb
   "aqua:ajeetdsouza/zoxide": "0.9.9" # renovate: datasource=github-releases packageName=ajeetdsouza/zoxide
   "aqua:sharkdp/bat": "0.26.1" # renovate: datasource=github-releases packageName=sharkdp/bat
   "aqua:BurntSushi/ripgrep": "15.1.0" # renovate: datasource=github-releases packageName=BurntSushi/ripgrep
@@ -43,7 +46,6 @@ mise_tools:
   # --- 6. Data & GTM Operations ---
   "aqua:noahgorstein/jqp": "0.8.0" # renovate: datasource=github-releases packageName=noahgorstein/jqp
   "go:github.com/mikefarah/yq/v4": "4.53.2" # renovate: datasource=github-releases packageName=mikefarah/yq
-  "go:github.com/rs/curlie": "1.8.2" # renovate: datasource=github-releases packageName=rs/curlie
   "npm:@hubspot/cli": "8.4.0" # renovate: datasource=npm packageName=@hubspot/cli
 
   # --- 7. Documentation & Prose ---
@@ -63,6 +65,7 @@ mise_tools:
   "tflint": "0.62.0" # renovate: datasource=github-releases packageName=terraform-linters/tflint
   "terragrunt": "1.0.2" # renovate: datasource=github-releases packageName=gruntwork-io/terragrunt
 
+  "aqua:aws/aws-cli": "2.34.34" # renovate: datasource=github-releases packageName=aws/aws-cli
   # [Rationale]: gcloud (Google Cloud SDK) follows a proprietary release channel.
   # Automated tracking via GitHub is not feasible; requires manual intervention.
   "gcloud": "565.0.0"
@@ -72,3 +75,9 @@ mise_tools:
   "cargo:du-dust": "1.0.0" # renovate: datasource=crate packageName=du-dust
   "aqua:mr-karan/doggo": "1.1.5" # renovate: datasource=github-releases packageName=mr-karan/doggo
   "aqua:sachaos/viddy": "1.3.0" # renovate: datasource=github-releases packageName=sachaos/viddy
+
+  # --- 10. AI Coding & Context Engineering ---
+  "npm:repomix": "1.13.1" # renovate: datasource=npm packageName=repomix
+  "npm:@openai/codex": "0.122.0" # renovate: datasource=npm packageName=@openai/codex
+  "npm:@anthropic-ai/claude-code": "2.1.117" # renovate: datasource=npm packageName=@anthropic-ai/claude-code
+  "npm:@google/gemini-cli": "0.38.2" # renovate: datasource=npm packageName=@google/gemini-cli


### PR DESCRIPTION
Unify the shared developer toolchain across macOS and WSL2 with a
more portable, vendor-aligned baseline. This removes avoidable tool
overlap, improves day-one readiness for new environments, and keeps
the global workstation standard aligned with supported installation
paths.

The main trade-off is that Azure CLI is no longer managed via the
Python tool backend in mise. In practice, the pipx/uv path proved
unsound because dependency resolution for azure-cli 2.85.0 was not
satisfiable, while the vendor-supported OS package route converged
cleanly. This change therefore favors operational reliability and
maintainability over backend uniformity.

Key Changes:
- Add common baseline tools for shell history, task running, local analytics, and AI coding workflows
- Add Deno as a first-class runtime in the shared toolchain
- Add AWS CLI to the managed toolchain and keep Azure CLI on OS-native package managers
- Add Azure CLI and other host-level packages to macOS Homebrew and Windows winget package sets
- Remove curlie to eliminate overlap with xh
- Reorganize tool sections to make AI coding and context tooling explicit

[Evidence/Ref]: mise install logs, brew info azure-cli, uv dependency resolution logs
