### PR TITLE
fix(wezterm): restore explicit WSL default domain on Windows

### DIFF
--- a/dot_config/wezterm/wezterm.lua.tmpl
+++ b/dot_config/wezterm/wezterm.lua.tmpl
@@ -62,12 +62,14 @@ config.inactive_pane_hsb = {
 -- [Architecture]: Cross-OS Multiplexer Engine
 -- ============================================================================
 -- [Rationale]: WSL domain enumeration is delegated to WezTerm's native logic.
--- If a preferred domain is provided via SSOT (chezmoi), it is injected here;
--- otherwise, default_domain is left unset to preserve WezTerm's standard behavior.
+-- On Windows, the rendered config must explicitly target the active WSL domain
+-- to avoid WezTerm falling back to the built-in "local" domain.
 -- [Reference]: https://wezterm.org/config/lua/config/default_domain.html
 if wezterm.target_triple:find("windows") then
-{{- if hasKey . "default_wsl_domain" }}
-  config.default_domain = {{ .default_wsl_domain | quote }}
+{{ if .is_wsl -}}
+{{- $wsl_distro_name := env "WSL_DISTRO_NAME" | trim -}}
+{{- if eq $wsl_distro_name "" }}{{ fail "[FATAL] WSL_DISTRO_NAME is empty; cannot render WezTerm default_domain for Windows." }}{{ end -}}
+  config.default_domain = {{ printf "WSL:%s" $wsl_distro_name | quote }}
 {{- end }}
 else
   config.unix_domains = { { name = "unix" } }


### PR DESCRIPTION
## 🎯 Summary / Rationale

Fix a Windows WezTerm startup regression where the GUI launched the local
Windows shell instead of the intended WSL Ubuntu zsh environment.

The root cause was that the rendered Windows `.wezterm.lua` no longer emitted
`config.default_domain`, because the template depended on a non-existent
`default_wsl_domain` variable. As a result, WezTerm fell back to its standard
GUI startup behavior and opened the built-in `local` domain.

This PR derives the Windows WezTerm default domain directly from
`WSL_DISTRO_NAME` at chezmoi render time, which is the narrowest and most
deterministic fix for the only current consumer of that value.

## 🛠 Key Changes

- **WezTerm template**: Removed the fictional `default_wsl_domain` dependency
- **WezTerm template**: Render `config.default_domain = "WSL:<distro>"` from `WSL_DISTRO_NAME`
- **WezTerm template**: Fail fast if `WSL_DISTRO_NAME` is empty instead of silently falling back
- **Sync flow**: Kept the existing WSL-to-Windows WezTerm sync path unchanged

## 🧪 Verification Proof

```zsh
# Windows-side rendered config existed
Test-Path $HOME\.wezterm.lua
True

# WSL distro name confirmed
wsl -l -v
  NAME      STATE           VERSION
* Ubuntu    Running         2

# Before fix: no rendered default_domain assignment
Select-String -Path $HOME\.wezterm.lua -Pattern 'default_domain'

.wezterm.lua:61:-- otherwise, default_domain is left unset to preserve WezTerm's standard behavior.
.wezterm.lua:62:-- [Reference]: https://wezterm.org/config/lua/config/default_domain.html

# Before fix: no default_prog override
Select-String -Path $HOME\.wezterm.lua -Pattern 'default_prog'
# no outputs
````

## ⚠️ Side Effects / Risks

* This logic assumes chezmoi renders the Windows-bound WezTerm config from
  inside WSL, where `WSL_DISTRO_NAME` is available
* If `WSL_DISTRO_NAME` is unexpectedly empty, chezmoi will now fail fast
  instead of rendering a config that silently falls back to the local domain
* The fix is intentionally scoped to the WezTerm template and does not promote
  this value into shared chezmoi data, because there is currently no second
  consumer
