### PR TITLE
refactor(shell): rationalize zsh and git aliases for safer workflows

### DIFF
--- a/dot_config/git/config.tmpl
+++ b/dot_config/git/config.tmpl
@@ -241,26 +241,40 @@ Editing rules:
     st = status -sb
     sw = switch
     sc = switch -c
+    br = branch -vv
     root = rev-parse --show-toplevel
     optimize = maintenance run
 
+    # -- Stage / Commit --
+    aa = add --all
+    ap = add --patch
+    unstage = restore --staged --
+    ci = commit -v
+    cim = commit -m
+    amend = commit --amend --no-edit
+
     # -- Contextual Diff --
-    # [Intent]: reviewer/LLM friendly staged diff with:
+    # [Intent]: reviewer/LLM friendly diff with:
     # - -W: function context
     # - -U10: broader local context
     # - -M -C: rename/copy awareness on demand
     # - histogram + indent heuristic: readability bias
     ctx = diff --histogram -M -C -W -U10 --inter-hunk-context=3 --indent-heuristic
+    ctxs = diff --staged --histogram -M -C -W -U10 --inter-hunk-context=3 --indent-heuristic
+    ctxh = diff HEAD --histogram -M -C -W -U10 --inter-hunk-context=3 --indent-heuristic
+    ds = diff --staged
+    dh = diff HEAD
+    pr = !f() { base=${1:-origin/main}; git diff --histogram -M -C -W -U10 --inter-hunk-context=3 --indent-heuristic "$base...HEAD"; }; f
 
     # -- History & Inspection --
     last = log -1 HEAD --stat
     lg = log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit --date=relative
     adog = log --graph --all --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit --date=relative
-    review = diff --cached --stat --conflicted
+    review = diff --staged --histogram -M -C -W -U10 --inter-hunk-context=3 --indent-heuristic
 
     # -- Workflow --
     fix = !git-absorb
-    amend = commit --amend --no-edit
+    pf = push --force-with-lease
 
 # ================================================================
 # Context-Aware Identity Routing (Policy Layer)

--- a/dot_config/zsh/dot_zshrc.tmpl
+++ b/dot_config/zsh/dot_zshrc.tmpl
@@ -35,17 +35,22 @@ ZSH_INIT_DIR="$XDG_CACHE_HOME/zsh/init"
 [[ -f "$ZSH_INIT_DIR/starship.zsh" ]] && source "$ZSH_INIT_DIR/starship.zsh"
 
 # --- Modern Unix Command Aliases ---
-alias ls='eza --icons'
-alias l='eza -lh --icons --git'
-alias lt='eza --tree --icons'
-alias cat='bat -pp'
-alias preview='bat'
-alias cd='z'
+if command -v eza >/dev/null 2>&1; then
+  alias ls='eza --icons'
+  alias l='eza -lh --icons --git'
+  alias la='eza -a --icons'
+  alias ll='eza -lah --icons --git'
+  alias lt='eza --tree --icons'
+  alias tree='eza --tree'
+fi
+if command -v bat >/dev/null 2>&1; then
+  alias preview='bat'
+fi
 alias cdi='zi'
-alias find='fd'
-alias grep='rg'
-alias g='git'
 alias lg='lazygit'
+alias ..='cd ..'
+alias ...='cd ../..'
+alias mkdirp='mkdir -p'
 
 # =============================================================================
 # [Architecture]: Sovereign Clipboard Protocol


### PR DESCRIPTION
## 🎯 Summary / Rationale

Refactor shell and Git aliases to improve predictability, portability, and review ergonomics.

This PR removes shell aliases that changed the meaning of core commands and moves workflow-oriented shortcuts into Git's native alias layer. It also introduces explicit diff surfaces for human and LLM-assisted review so that unstaged, staged, HEAD-relative, and merge-base-based comparisons are easy to invoke without ambiguity.

## 🛠 Key Changes

- **dot_config/git/config.tmpl**: Added Git-native workflow aliases for staging, commit, push, and branch inspection
- **dot_config/git/config.tmpl**: Added `ctx`, `ctxs`, `ctxh`, `ds`, `dh`, and `pr` for explicit diff surfaces
- **dot_config/git/config.tmpl**: Updated `review` to output a full staged patch with richer context
- **dot_config/zsh/dot_zshrc.tmpl**: Removed shell aliases that overrode core command semantics
- **dot_config/zsh/dot_zshrc.tmpl**: Kept `preview` as a dedicated `bat`-based viewer
- **dot_config/zsh/dot_zshrc.tmpl**: Added guarded `eza` aliases and small QoL navigation helpers

## 🧪 Verification Proof

```zsh
git apply --check /tmp/patch.diff
# exit status: 0

git diff --check
# no output

# manual validation
# - patch applied successfully
# - requested alias policy reflected in rendered templates
# - cat override removed
# - preview retained
# - lt uses eza tree without fixed --level
````

## ⚠️ Side Effects / Risks

* Users accustomed to shell-level overrides such as `find`, `grep`, or `cd` aliases will need to call modern replacements explicitly
* `pr` defaults to `origin/main`, so repositories with a different default remote/base branch require passing an argument
* `eza` and `bat` aliases are now conditional on command availability, which is safer but may differ from prior assumptions
