### PR TITLE
fix(nvim): resolve node provider via mise

### DIFF
--- a/dot_config/mise/tasks/doctor/executable_nvim.tmpl
+++ b/dot_config/mise/tasks/doctor/executable_nvim.tmpl
@@ -2,6 +2,7 @@
 # [MISE] description="Verify Neovim lockfile and provider health"
 {{/* [Reference]: https://mise.jdx.dev/tasks/file-tasks.html */}}{{ "" -}}
 {{/* [Reference]: https://neovim.io/doc/user/provider.html#provider-python */}}{{ "" -}}
+{{/* [Reference]: https://neovim.io/doc/user/provider.html#provider-nodejs */}}{{ "" -}}
 
 set -euo pipefail
 
@@ -18,6 +19,7 @@ log_guide() { printf "  ${BLUE}👉 %s${NC}\n" "$1"; }
 
 IS_CI="${CI:-false}"
 LOCK_FILE="{{ .paths.xdg_config }}/nvim/lazy-lock.json"
+MISE_BIN="{{ .paths.mise }}"
 HAS_ERROR=0
 
 echo "--- 4. Neovim Deterministic State ---"
@@ -35,11 +37,29 @@ else
 fi
 
 if command -v nvim >/dev/null 2>&1; then
-  if nvim --headless +"lua if vim.fn.has('python3') == 1 then print('PROVIDER_OK') end" +qa 2>&1 | grep -q "PROVIDER_OK"; then
+  if nvim --headless +"lua if vim.fn.has('python3') == 1 then print('PYTHON_PROVIDER_OK') end" +qa 2>&1 | grep -q "PYTHON_PROVIDER_OK"; then
     log_ok "Python Provider is natively recognized and functional in Neovim."
   else
     log_err "Python Provider is dysfunctional or not recognized by Neovim."
     log_guide "Ensure 'pipx:neovim/pynvim' is in tools.yaml and run 'mise install'."
+    HAS_ERROR=1
+  fi
+
+  NODE_HOST="$("$MISE_BIN" which neovim-node-host 2>/dev/null || true)"
+
+  if [[ -n "$NODE_HOST" && -x "$NODE_HOST" ]]; then
+    log_ok "Node.js Provider host executable resolved via mise ($NODE_HOST)."
+  else
+    log_err "Node.js Provider host executable could not be resolved via mise."
+    log_guide "Ensure 'npm:neovim' is in tools.yaml and run 'mise install'."
+    HAS_ERROR=1
+  fi
+
+  if [[ -n "$NODE_HOST" ]] && "$NODE_HOST" --version >/dev/null 2>&1; then
+    log_ok "Node.js Provider host executable runs successfully."
+  else
+    log_err "Node.js Provider host executable failed to run."
+    log_guide "Run '\"$NODE_HOST\" --version' and inspect the error."
     HAS_ERROR=1
   fi
 else

--- a/dot_config/nvim/init.lua.tmpl
+++ b/dot_config/nvim/init.lua.tmpl
@@ -29,5 +29,15 @@ vim.api.nvim_create_autocmd({ "VimEnter", "VimLeave" }, {
   end,
 })
 
+-- [Provider]: Resolve Node.js host from the active executable path.
+-- [Rationale]: Keeps mise as the source of truth while avoiding hardcoded
+-- install paths. The resolved executable may be an npm wrapper; Neovim handles
+-- the provider check through its own provider implementation.
+-- [Reference]: https://neovim.io/doc/user/provider.html#provider-nodejs
+local node_host = vim.fn.exepath("neovim-node-host")
+if node_host ~= "" then
+  vim.g.node_host_prog = node_host
+end
+
 -- Load LazyVim core.
 require("config.lazy")


### PR DESCRIPTION
## 🎯 Summary / Rationale

Align Neovim's Node.js provider setup with the mise-managed `npm:neovim`
toolchain.

The Node provider host is installed by mise, so Neovim should resolve
`neovim-node-host` from the active executable path instead of hardcoding a
versioned install path. The doctor task now validates the same source of truth:
it resolves the host through mise and executes the host directly.

This avoids an invalid assumption that `neovim-node-host` is always a JavaScript
file. In npm-managed installs, the host may be a shell wrapper, so `node <host>`
is not a reliable validation method.

## 🛠 Key Changes

- **Neovim provider config**: Set `vim.g.node_host_prog` from
  `vim.fn.exepath("neovim-node-host")`.
- **Neovim doctor task**: Resolve `neovim-node-host` through mise.
- **Provider validation**: Verify the host with direct executable invocation
  via `"$NODE_HOST" --version`.
- **CI compatibility**: Avoid `node "$NODE_HOST"` checks because npm may expose
  `neovim-node-host` as a shell wrapper.
- **Documentation**: Add the official Neovim Node.js provider reference.

## 🧪 Verification Proof

```zsh
chezmoi apply # no errors

mise run doctor:nvim
[doctor:nvim] $ ~/.config/mise/tasks/doctor/nvim
--- 4. Neovim Deterministic State ---
  ✅ Neovim lockfile (lazy-lock.json) is synchronized.
  ✅ Python Provider is natively recognized and functional in Neovim.
  ✅ Node.js Provider host executable resolved via mise (/Users/.../.local/share/mise/installs/npm-neovim/5.4.0/bin/neovim-node-host).
  ✅ Node.js Provider host executable runs successfully.

nvim --headless +'lua print(vim.g.node_host_prog or "")' +'checkhealth vim.provider' +qa 2>&1
/Users/.../.local/share/mise/installs/npm-neovim/5.4.0/bin/neovim-node-host
checkhealth: 100% checking vim.providercheckhealth: checks done
````

CI also passed on both ubuntu-24.04 and macos-14.

## ⚠️ Side Effects / Risks

* This change prepares the Node.js provider foundation but does not add or enable
  any Node remote plugins.
* Perl and Ruby provider warnings remain unrelated and intentionally unchanged.
* The doctor task validates provider host availability, not Node remote plugin
  usage.
