### PR TITLE
chore(github): add markdown collaboration templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/change-request.md
+++ b/.github/ISSUE_TEMPLATE/change-request.md
@@ -1,0 +1,88 @@
+## Goal
+
+Describe the desired end state in one or two sentences.
+Focus on the outcome, not the implementation.
+
+---
+
+## Background
+
+Explain why this change is needed.
+Provide context, constraints, and any relevant prior decisions.
+
+---
+
+## Scope
+
+### In Scope
+
+- Clearly list what will be done.
+
+### Out of Scope
+
+- Clearly list what will NOT be done.
+
+---
+
+## Acceptance Criteria
+
+Define objective, testable conditions.
+
+- [ ] Condition 1
+- [ ] Condition 2
+- [ ] Condition 3
+
+All criteria must be:
+
+- Observable
+- Verifiable
+- Independent
+
+---
+
+## Validation
+
+Specify how correctness will be verified.
+
+- [ ] `mise run doctor` passes
+- [ ] `pre-commit run --all-files` passes
+- [ ] `git diff --check` passes
+- [ ] CI pipeline passes
+
+Add or remove checks as needed, but keep them executable.
+
+---
+
+## Constraints
+
+List hard requirements and limitations.
+
+- Do not introduce new dependencies without justification
+- Do not break existing workflows
+- Preserve current architecture unless explicitly required
+
+---
+
+## Risks
+
+Identify known risks or uncertainties.
+
+- Risk 1
+- Risk 2
+
+---
+
+## References
+
+Link only authoritative sources.
+
+- Official documentation
+- Related issues
+- Prior decisions
+
+---
+
+## Notes (Optional)
+
+Add clarifications if needed.
+Avoid duplicating other sections.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,46 @@
+## Summary
+
+<!-- Describe the change in one or two sentences. -->
+
+## Why
+
+<!-- Explain the problem, goal, or decision that led to this change. -->
+
+## Changes
+
+<!-- List the concrete changes in this pull request. -->
+
+-
+
+## Validation
+
+<!-- Check every item that you completed. Add exact command output or CI links when useful. -->
+
+- [ ] `git diff --check`
+- [ ] `pre-commit run --all-files`
+- [ ] `mise run doctor`
+- [ ] GitHub Actions CI passes
+
+## Risk and rollback
+
+<!-- Describe the main risk and the safest rollback path. -->
+
+**Risk:**
+
+**Rollback:**
+
+## Review notes
+
+<!-- Call out files, design trade-offs, or areas that need careful review. -->
+
+## Out of scope
+
+<!-- List related work that this pull request intentionally does not include. -->
+
+-
+
+## Linked issue
+
+<!-- Use a closing keyword when this pull request should close an issue after merge. -->
+
+Closes #

--- a/repomix-instruction.md
+++ b/repomix-instruction.md
@@ -1,101 +1,433 @@
-# Role: Principal SRE & Infrastructure Architect
+# Repository Instructions
 
-You are a Principal SRE responsible for a Deterministic Infrastructure Engine (dotfiles). Your core mission is to maintain a zero-drift, highly available developer environment. Your guiding tenets are **Truth over Speed**, **Idempotency over Convenience**, and **Zero-Speculation**. You treat any unverified assumption or hallucination as a critical configuration drift.
+This repository is a personal dotfiles repository managed with chezmoi, mise,
+GitHub Actions, Neovim, shell scripts, and related developer tools.
 
-## 0. Language & Writing Policy
+Use this file as custom guidance for AI systems that read Repomix output.
 
-- **Internal Logic & Reasoning**: MUST be written in English for maximum instruction adherence.
-- **User Interaction**: All thoughts, reasoning, and conversational responses MUST be in **JAPANESE**.
-- **Technical Content**: Code, comments, and Git communication MUST be in **ENGLISH** following the **Google Style Guide**.
-- **GitHub CLI (`gh`)**: PR titles, bodies, and issue comments MUST follow **Google Style Guide (English)** and **Conventional Commits**.
+These instructions define how to analyze the repository, request missing
+context, and produce useful artifacts. They do not replace the repository's
+Issue or pull request templates.
 
-## 1. The "Zero-Speculation" Protocol (Strict Stop)
+## Core principles
 
-- **Referential Authority**: The ONLY source of truth is the [official chezmoi documentation](https://www.chezmoi.io/) and the [official 1Password CLI documentation](https://developer.1password.com/docs/cli/). You MUST NOT rely on blog posts, outdated tutorials, or your own "knowledge" if it conflicts with the latest official guide.
-- **The Stop Rule**: If there is < 100% certainty regarding file state, OS behavior, CLI flags (e.g., `op`), or template functions, **STOP IMMEDIATELY**. Request the official documentation URL or the output of the `--help` command from the user.
-- **Anti-Helpfulness Policy**: DO NOT attempt to "fill in the gaps" or be "helpful" by guessing a user's intent or a system's configuration. It is better to fail with a request for information than to succeed with a hallucination.
-- **Minimum 50-Cycle Self-Consistency Loop (SCL)**: Before any output, you must perform at least 50 internal cycles of self-review to verify logical consistency, cross-platform side effects, and adherence to this protocol. If any failure is detected in cycle 50, restart the audit until zero drift is achieved.
-- **Physical Bit Verification**: Disentangle the "Disk State", "Git Index", and "Remote Origin". Audit all three layers using physical commands (`ls -l`, `git status`, `git rev-parse`).
+Optimize for:
 
-## 2. Standardized Workflow (The 9-Phase Gate)
+- Correctness over speed
+- Minimal changes over broad rewrites
+- Verified facts over assumptions
+- Clear trade-offs over hidden reasoning
+- CLI-first workflows over GitHub UI dependency
+- Small reviewable units over large mixed changes
 
-You MUST NOT skip any phase. Each phase acts as a mandatory gate.
+Do not over-apply process. Use the lightest workflow that keeps the change
+safe and reviewable.
 
-1. **Context Audit & Isolation**: Analyze current state and ensure task isolation.
-   - Propose `git switch -c <branch-name>` using Conventional Commits.
-   - Explicitly distinguish between **Source Paths** (repository) and **Target Paths** (`$HOME`).
-2. **Referential Verification**: Verify CLI options via `--help` or official documentation. Do NOT hallucinate flags.
-3. **Side-Effect Audit**: Analyze cross-platform interactions (WSL2 vs macOS, network dependency).
-4. **Architectural Consensus**: Present the "Rationale" and "Target OS". Wait for the user's agreement before generating code.
-5. **Atomic Generation**:
-   - Provide the **ENTIRE file content**. Never provide snippets or partial updates.
-   - **Mandatory Anchoring**: You MUST include the relevant official reference URL in a comment within the file (using Go template comments `{{- /* ... */ -}}` for `.tmpl` files).
-6. **The Rally Protocol (Step-by-Step Verification)**:
-   - **Step 6a (Dry-Run)**: Output `chezmoi apply -v --dry-run` ONLY.
-   - **Step 6b (Wait)**: **STOP**. Wait for the user to report the physical output. Do NOT predict success.
-   - **Step 6c (Execution)**: After dry-run verification, propose `chezmoi apply -v`, `chezmoi verify`, and `doctor` sequentially.
-7. **Verification Ceremony**:
-   - If templates changed, `chezmoi init` is mandatory.
-   - `chezmoi verify` MUST result in zero-diff.
-8. **RCA Gate (Failure Only)**: Perform a Root Cause Analysis (Expected vs Actual) if any step fails.
-9. **Final Audit & Artifact Generation**: Generate the **Commit Message** and **Pull Request** according to Section 4.
+## Language policy
 
-## 3. Technical & Formatting Standards
+- Respond to the user in Japanese.
+- Write code, comments, commit messages, GitHub Issue bodies, and pull request
+  bodies in English.
+- Follow Google Style Guide principles for technical writing:
+  - Be clear.
+  - Be concise.
+  - Use active voice.
+  - Prefer concrete nouns and commands.
+  - Avoid ambiguous wording.
+- Do not expose private reasoning.
+- State uncertainty only when it affects the answer or the proposed change.
 
-- **Atomic File Block**: `1. /path/to/file` followed by a code block containing the full content.
-- **Semantic Meta-Tags**: Use `[Rationale]`, `[Architecture]`, `[Interop]`, and `[Security]`.
-- **Go Template Commenting**: Use `{{- /* [Reference]: URL */ -}}` for template-level notes.
-- **Path Convention**:
-  - **`.chezmoiignore` & `.chezmoiremove`**: MUST use **Target Paths** (relative to `$HOME`).
-  - **`includeTemplate`**: MUST use **Source Paths** (relative to sourceDir).
+## Evidence policy
 
-## 3.5. Go Template Integrity Protocol (GTIP)
+Use evidence in this order:
 
-- **Shebang Protection**: Never use `{{-` (Left Trim) immediately after a Shebang line. This physically merges the interpreter path with the next command.
-- **Mandatory Anchor**: Use `{{ "" -}}` (Empty string + Right Trim) to eliminate template-induced newlines while preserving the leading newline of the Shebang.
-- **Strict Comment Syntax**: Use only `{{/* ... */}}`. Do NOT include whitespace control markers (`-`) inside the comment delimiters (e.g., `{{/* ... -}}` is a Syntax Error).
-- **Execution Validation**: If a template contains Shebangs or complex Whitespace Control, you MUST run `chezmoi execute-template` in a mental or physical sandbox before outputting.
+1. Repository content included in the provided Repomix output
+2. Current file contents, diffs, logs, or command output provided by the user
+3. Official documentation for the relevant tool
+4. Clearly labeled inference based on the above
 
-## 4. Git & Peer Review Protocol (Google Style)
+Do not invent:
 
-### A. Commit Message Schema
+- File paths
+- Tool versions
+- CLI flags
+- Configuration values
+- Issue numbers
+- Pull request numbers
+- Validation results
+- CI results
+- User intent that was not stated
+
+If required information is missing, say what is missing and request the
+smallest useful context.
+
+## Repository workflow
+
+The preferred workflow is:
+
+1. Discuss and research the change.
+2. Create a GitHub Issue only when the change needs planning, records a
+   decision, or may split into multiple pull requests.
+3. Implement each concrete change in a small branch.
+4. Validate locally.
+5. Generate a Conventional Commit message.
+6. Generate a pull request body and `gh pr create` command.
+7. Let CI verify the final result.
+
+Do not require an Issue for every small change.
+
+Use Issues for:
+
+- Goal
+- Background
+- Scope
+- Acceptance criteria
+- Validation expectations
+- Constraints
+- Risks
+- References
+
+Use pull requests for:
+
+- Implemented changes
+- Validation evidence
+- Risk and rollback
+- Review notes
+- Linked Issues
+
+Do not use pull request bodies as the only source of requirements.
+
+## Source of truth for GitHub artifacts
+
+For GitHub Issues, use this repository file as the format source of truth:
 
 ```text
-<type>(<scope>): <short summary in imperative mood>
-
-<detailed rationale: Explain the "Why" and the technical trade-offs.
-Focus on the problem solved, not just the code changed.
-Adhere to Google Engineering Practices.>
-
-Key Changes:
-- <bulleted list of logic changes>
-
-[Evidence/Ref]: <benchmarks, doctor logs, or relevant URLs>
+.github/ISSUE_TEMPLATE/change-request.md
 ```
 
-### B. Pull Request Schema
+For pull requests, use this repository file as the format source of truth:
 
-````markdown
-## 🎯 Summary / Rationale
+```text
+.github/pull_request_template.md
+```
 
-## 🛠 Key Changes
+Do not duplicate or redefine those templates in this instruction file.
 
-- **<Component>**: <Brief description of logic change>
+When generating a GitHub Issue, include:
 
-## 🧪 Verification Proof
+- Issue title
+- Recommended label, if one clearly fits
+- Recommended branch command
+- Issue body based on `.github/ISSUE_TEMPLATE/change-request.md`
+- Optional `mktemp` + `gh issue create --body-file` command
+
+When generating a pull request, include:
+
+- PR title
+- PR body based on `.github/pull_request_template.md`
+- Optional `mktemp` + `gh pr create --body-file` command
+- A closing keyword only when the PR should close an Issue
+
+Do not invent Issue numbers. Use `Closes #<number>` only when the user
+provided the Issue number.
+
+## GitHub CLI policy
+
+When generating `gh issue create` or `gh pr create` commands:
+
+- Prefer `mktemp` plus `--body-file` for multiline Markdown bodies.
+- Use `--assignee "@me"` when assigning the user to their own Issue or PR is
+  appropriate.
+- Use `--label` only when a label clearly fits.
+- Do not invent repository labels.
+- Do not assume GitHub Projects, milestones, reviewers, or base branches unless
+  provided.
+
+For Issues, prefer this shape:
 
 ```zsh
-<paste logs here>
+ISSUE_BODY="$(mktemp "${TMPDIR:-/tmp}/issue-<short-topic>.XXXXXX.md")"
+
+cat > "$ISSUE_BODY" <<'EOF'
+<issue body>
+EOF
+
+gh issue create \
+  --title "<issue title>" \
+  --body-file "$ISSUE_BODY" \
+  --assignee "@me"
 ```
 
-## ⚠️ Side Effects / Risks
-````
+For pull requests, prefer this shape:
 
-## 5. Source of Truth (Reference Map)
+```zsh
+PR_BODY="$(mktemp "${TMPDIR:-/tmp}/pr-<short-topic>.XXXXXX.md")"
 
-- **Official Guides (Priority 1)**:
-  - [Command Overview](https://www.chezmoi.io/user-guide/command-overview/)
-  - [Setup Guide](https://www.chezmoi.io/user-guide/setup/)
-  - [Daily Operations](https://www.chezmoi.io/user-guide/daily-operations/)
-  - [Templating](https://www.chezmoi.io/user-guide/templating/)
-  - [Password Managers (1Password)](https://www.chezmoi.io/user-guide/password-managers/1password/)
+cat > "$PR_BODY" <<'EOF'
+<pull request body>
+EOF
+
+gh pr create \
+  --title "<pr title>" \
+  --body-file "$PR_BODY" \
+  --assignee "@me"
+```
+
+## Task routing
+
+Choose the output mode that matches the user's request.
+
+### Planning mode
+
+Use for architecture, workflow, roadmap, research, or design discussion.
+
+Include:
+
+- Recommendation
+- Trade-offs
+- Risks
+- Validation strategy
+- Next concrete step
+
+Do not output implementation unless the user asks for it.
+
+### Issue mode
+
+Use when the user asks to create or refine a GitHub Issue.
+
+Use `.github/ISSUE_TEMPLATE/change-request.md` as the format.
+
+Include a recommended branch command:
+
+```zsh
+git switch -c <recommended-branch-name>
+```
+
+Do not include implementation details unless they are hard constraints.
+
+### Patch mode
+
+Use when the user asks for code or file changes.
+
+Decide whether a strict unified diff or full file output is safer.
+
+Use a strict unified diff when:
+
+- The change is small
+- The current file content is fully available
+- The target context is unambiguous
+- The patch is likely to apply cleanly with `git apply`
+
+Use full file output when:
+
+- The file is new
+- The file is short
+- The change is a large rewrite
+- The hunk context would be fragile
+- The user explicitly asks for full content
+
+Do not generate a strict patch if the current file content is insufficient.
+
+### Commit mode
+
+Use when the user asks for a commit message.
+
+Follow Conventional Commits.
+
+Use this structure:
+
+```text
+<type>(<scope>): <summary>
+
+<why this change is needed and what trade-offs it makes>
+
+Key Changes:
+- <change 1>
+- <change 2>
+
+Validation:
+- <command or evidence>
+```
+
+Rules:
+
+- Write in clear English.
+- Use Google Style Guide principles.
+- Use the imperative mood for the summary.
+- Aim to keep the summary within 50 characters.
+- Wrap body lines at 72 characters when practical.
+- Do not include personal or sensitive information.
+- Do not claim validation passed unless the user provided evidence.
+- Do not require an Issue number for commit messages.
+- Use Issue numbers in pull request bodies by default.
+- If the user provides an Issue number and asks to reference it in the commit,
+  use `Refs: #<number>`.
+- Do not use closing keywords in commit messages unless the user explicitly
+  requests it.
+
+### Pull request mode
+
+Use when the user asks for a pull request body or `gh pr create` command.
+
+Use `.github/pull_request_template.md` as the format.
+
+Focus on:
+
+- Summary
+- Why
+- Changes
+- Validation
+- Risk and rollback
+- Review notes
+- Out of scope
+- Linked Issue
+
+### Review mode
+
+Use when the user asks to review a plan, file, diff, pull request, or
+implementation.
+
+Separate:
+
+- Blocking issues
+- Non-blocking suggestions
+- Risks
+- Recommended next action
+
+Clearly distinguish verified findings from inferred concerns.
+
+## Patch input policy
+
+Assume patch requests start from a clean working tree unless the user says
+otherwise.
+
+Before generating a strict patch, ask the user to provide:
+
+```zsh
+git status --short
+git branch --show-current
+
+repomix \
+  --include-full-directory-structure \
+  --include "<comma-separated-target-paths>" \
+  -o /tmp/repomix-<short-topic>.xml
+```
+
+`git status --short` must be empty.
+
+Do not ask for `git diff` or `git diff --cached` by default.
+
+Ask for existing diffs only if the user explicitly says there are local
+changes.
+
+If the focused Repomix snapshot does not include enough related files, do not
+guess. Ask for a new focused Repomix snapshot with the missing paths.
+
+## Patch output policy
+
+When outputting a strict patch, make it compatible with `git apply`.
+
+Follow Git's patch format expectations:
+
+- Use `diff --git a/<path> b/<path>`
+- Use `--- a/<path>` and `+++ b/<path>`
+- Use accurate `@@ ... @@` hunk headers
+- Include enough context lines
+- Do not use zero-context patches
+- Do not include fake `index` lines
+- Do not include placeholder hashes
+- Do not include explanations inside the patch block
+- Do not include code fence attributes
+- End the patch code block with one blank line
+- Preserve whitespace, indentation, and final newlines
+- Keep the diff minimal and conservative
+
+If a patch is requested, also provide one recommended branch command outside the
+patch block:
+
+```zsh
+git switch -c <recommended-branch-name>
+```
+
+Reference the official Git documentation when patch format details matter:
+
+- https://git-scm.com/docs/diff-format
+- https://git-scm.com/docs/git-apply
+
+## Validation policy
+
+Prefer these checks when relevant:
+
+```zsh
+git diff --check
+pre-commit run --all-files
+mise run doctor
+```
+
+For changes that affect chezmoi-rendered targets, also consider:
+
+```zsh
+chezmoi init --source="$PWD" --apply
+chezmoi verify
+```
+
+For Neovim integration changes, also consider:
+
+```zsh
+mise run integrate:nvim
+```
+
+Do not claim that any command passed unless the user provided the result.
+
+When preparing a PR body, list validation as pending unless the user provided
+successful output.
+
+## Chezmoi and template safety
+
+When editing chezmoi templates:
+
+- Distinguish repository source paths from target paths.
+- Use source paths for files inside the repository.
+- Use target paths for `.chezmoiignore` and `.chezmoiremove`.
+- Preserve Go template syntax exactly.
+- Avoid whitespace-control changes unless necessary.
+- Do not place left-trim markers immediately after a shebang.
+- Prefer existing repository patterns over new conventions.
+- Add official reference comments only when the reference directly supports the
+  changed behavior.
+
+Do not add decorative references.
+
+## Output discipline
+
+Be concise by default.
+
+Prefer this order:
+
+1. Direct answer
+2. Evidence or rationale
+3. Concrete next step
+4. Artifact, if requested
+
+Avoid:
+
+- Large rewrites when a small change is enough
+- Multiple alternatives unless the user asks
+- Speculative best practices without labeling them as inference
+- Repeating decisions the user already accepted
+- Duplicating repository templates inside this instruction file
+
+## Stop conditions
+
+Stop and ask for missing information only when:
+
+- A strict patch is requested but current file contents are insufficient.
+- A command, flag, path, or version is essential and cannot be verified.
+- The user requests a destructive operation.
+- The request could expose secrets or credentials.
+- The task requires files that were not provided.
+- The requested output would require inventing Issue numbers, PR numbers,
+  validation results, or CI results.
+
+Otherwise, proceed with clearly labeled assumptions and the safest useful
+recommendation.


### PR DESCRIPTION
## Summary

Add Markdown templates for CLI-first, LLM-assisted GitHub collaboration.

## Why

This repository needs a stable structure for planning changes with Issues and
reviewing implementation details in pull requests.

## Changes

- Add `.github/ISSUE_TEMPLATE/change-request.md`
- Add `.github/pull_request_template.md`

## Validation

- [ ] `git diff --check`
- [ ] `pre-commit run --all-files`
- [ ] `mise run doctor`
- [ ] GitHub Actions CI passes

## Risk and rollback

**Risk:** Low. These files only affect future Issue and pull request authoring.

**Rollback:** Remove the two added Markdown template files.

## Review notes

Review whether the templates are concise enough for CLI-first use and clear
enough for LLM-assisted planning and review.

## Out of scope

- YAML Issue Forms
- GitHub Actions changes
- gh aliases or mise tasks
- Repository label changes

## Linked issue

Closes #112
