### PR TITLE
refactor(nvim): split keymaps from options

### DIFF
--- a/dot_config/nvim/lua/config/keymaps.lua.tmpl
+++ b/dot_config/nvim/lua/config/keymaps.lua.tmpl
@@ -1,0 +1,26 @@
+-- [Architecture]: Protocol-Driven Outbound Navigation (Smart Splits)
+-- [Rationale]: Emits an OSC 1337 signal when reaching the vim boundary,
+-- delegating the pane switch to WezTerm's event listener.
+local function signal_move_to_wezterm(direction)
+  if vim.env.TERM_PROGRAM ~= "WezTerm" then return end
+  local osc = string.format("\027]1337;SetUserVar=MOVE_SIGNAL=%s\007", vim.base64.encode(direction))
+  local f = io.open("/dev/tty", "wb")
+  if f then
+    f:write(osc)
+    f:flush()
+    f:close()
+  end
+end
+
+local function move_or_signal(key, direction)
+  local prev_win = vim.api.nvim_get_current_win()
+  vim.cmd("wincmd " .. key)
+  if prev_win == vim.api.nvim_get_current_win() then
+    signal_move_to_wezterm(direction)
+  end
+end
+
+vim.keymap.set("n", "<C-h>", function() move_or_signal("h", "Left") end)
+vim.keymap.set("n", "<C-j>", function() move_or_signal("j", "Down") end)
+vim.keymap.set("n", "<C-k>", function() move_or_signal("k", "Up") end)
+vim.keymap.set("n", "<C-l>", function() move_or_signal("l", "Right") end)

--- a/dot_config/nvim/lua/config/options.lua.tmpl
+++ b/dot_config/nvim/lua/config/options.lua.tmpl
@@ -48,30 +48,3 @@ if vim.fn.has("wsl") == 1 then
     cache_enabled = 1,
   }
 end
-
--- [Architecture]: Protocol-Driven Outbound Navigation (Smart Splits)
--- [Rationale]: Emits an OSC 1337 signal when reaching the vim boundary,
--- delegating the pane switch to WezTerm's event listener.
-local function signal_move_to_wezterm(direction)
-  if vim.env.TERM_PROGRAM ~= "WezTerm" then return end
-  local osc = string.format("\027]1337;SetUserVar=MOVE_SIGNAL=%s\007", vim.base64.encode(direction))
-  local f = io.open("/dev/tty", "wb")
-  if f then
-    f:write(osc)
-    f:flush()
-    f:close()
-  end
-end
-
-local function move_or_signal(key, direction)
-  local prev_win = vim.api.nvim_get_current_win()
-  vim.cmd("wincmd " .. key)
-  if prev_win == vim.api.nvim_get_current_win() then
-    signal_move_to_wezterm(direction)
-  end
-end
-
-vim.keymap.set("n", "<C-h>", function() move_or_signal("h", "Left") end)
-vim.keymap.set("n", "<C-j>", function() move_or_signal("j", "Down") end)
-vim.keymap.set("n", "<C-k>", function() move_or_signal("k", "Up") end)
-vim.keymap.set("n", "<C-l>", function() move_or_signal("l", "Right") end)


### PR DESCRIPTION
## Summary

Split Neovim keymap configuration from editor options by moving the WezTerm-aware `<C-h/j/k/l>` navigation mappings into `lua/config/keymaps.lua.tmpl`.

## Why

LazyVim provides separate config loading boundaries for `lua/config/options.lua` and `lua/config/keymaps.lua`.

This change aligns the repository with that model while preserving the existing WezTerm smart-split navigation behavior.

## Changes

- Added `dot_config/nvim/lua/config/keymaps.lua.tmpl`
- Moved WezTerm-aware navigation helper functions from `options.lua.tmpl`
- Moved `<C-h>`, `<C-j>`, `<C-k>`, and `<C-l>` normal-mode keymaps from `options.lua.tmpl`
- Kept leader settings, editor options, and WSL clipboard provider logic in `options.lua.tmpl`
- Left `lazy.lua`, `lazy-lock.json`, plugins, and LazyVim extras unchanged

## Validation

- [x] `git diff --check`
- [x] `pre-commit run --all-files`
- [x] `mise run integrate:nvim`
- [x] `mise run doctor:nvim`
- [x] `mise run doctor`
- [x] `chezmoi diff`
- [x] `chezmoi apply --dry-run`
- [x] GitHub Actions CI passes

## Risk and rollback

**Risk:** Low. The change only moves existing Lua helper functions and keymaps into LazyVim's dedicated keymaps config file without changing behavior.

**Rollback:** Delete `dot_config/nvim/lua/config/keymaps.lua.tmpl` and restore the moved WezTerm navigation block to `dot_config/nvim/lua/config/options.lua.tmpl`.

## Review notes

Please verify that the diff is limited to the new `keymaps.lua.tmpl` file and the removal of the moved block from `options.lua.tmpl`.

This PR intentionally does not modify plugin specs, LazyVim extras, `lazy.lua`, or `lazy-lock.json`.

## Out of scope

- LazyVim extras changes
- Plugin additions or removals
- DAP workflow
- Test workflow
- Docker support
- SQL tooling
- Telescope
- nvim-cmp
- Yanky
- TOML configuration
- `vim.pack` migration
- WezTerm protocol redesign

## Linked issue

Refs #114

This PR implements Milestone 1 only. It does not close the roadmap tracking issue.
