### PR TITLE
feat(nvim): enable LazyVim Docker extra

### DIFF
--- a/dot_config/nvim/lua/config/lazy.lua
+++ b/dot_config/nvim/lua/config/lazy.lua
@@ -31,6 +31,7 @@ require("lazy").setup({
     { import = "lazyvim.plugins.extras.lang.yaml" },
     { import = "lazyvim.plugins.extras.lang.rust" },
     { import = "lazyvim.plugins.extras.lang.markdown" },
+    { import = "lazyvim.plugins.extras.lang.docker" },
 
     -- [Architecture]: 2026 SOTA Engines
     -- [Rationale]: Replaces legacy mini-animate, fzf-lua, and nvim-cmp with


### PR DESCRIPTION
## Summary

Enable LazyVim's official Docker language extra for baseline Dockerfile and Docker Compose editing support.

## Why

Milestone 2 of issue #114 adds Docker support to the Neovim configuration while preserving the repository's deterministic, LazyVim-aligned architecture.

This keeps Docker support upstream-driven instead of introducing bespoke local configuration for Docker LSP, Treesitter, linting, or formatting.

## Changes

- Added `lazyvim.plugins.extras.lang.docker` to `dot_config/nvim/lua/config/lazy.lua`
- Placed the Docker extra with the existing language-specific LazyVim extras
- Left `lazy-lock.json` unchanged because local restore confirmed it is synchronized
- Did not modify keymaps, options, or custom plugin configuration

## Validation

- [x] `git diff --check`
- [x] `pre-commit run --all-files`
- [x] `mise run integrate:nvim`
- [x] `mise run doctor:nvim`
- [x] `mise run doctor`
- [x] `chezmoi apply -v --dry-run`
- [x] `chezmoi apply -v`

Additional Neovim checks:

- [x] Dockerfile buffer resolves to `filetype=dockerfile`
- [x] `vim.lsp` health shows `dockerls` attached to the Dockerfile buffer
- [x] `vim.lsp` health shows `docker_compose_language_service` configured
- [x] `lazy-lock.json` remains synchronized

## Risk and rollback

**Risk:** Low. This change only imports an official LazyVim extra and does not add custom Docker-specific plugin configuration.

**Rollback:** Remove the `lazyvim.plugins.extras.lang.docker` import from `dot_config/nvim/lua/config/lazy.lua`. No lockfile rollback is required because `lazy-lock.json` did not change.

## Review notes

This PR intentionally relies on LazyVim's official Docker extra rather than manually configuring `dockerls`, `docker_compose_language_service`, `hadolint`, Treesitter, `nvim-lint`, or `none-ls`.

## Out of scope

- Custom Docker LSP configuration
- Custom Docker formatter or linter configuration
- DAP workflow
- Python test workflow
- TOML extra
- Yanky extra
- SQL tooling
- Telescope
- nvim-cmp
- `vim.pack` migration

## Linked issue

Refs #114
