### PR TITLE
refactor(nvim): align Python LSP selection with LazyVim

### DIFF
--- a/dot_config/nvim/lua/config/options.lua.tmpl
+++ b/dot_config/nvim/lua/config/options.lua.tmpl
@@ -2,6 +2,10 @@
 vim.g.mapleader = " "
 vim.g.maplocalleader = "\\"
 
+-- [LazyVim]: Official Python extra option model.
+vim.g.lazyvim_python_lsp = "basedpyright"
+vim.g.lazyvim_python_ruff = "ruff"
+
 local opt = vim.opt
 
 -- General Preferences

--- a/dot_config/nvim/lua/plugins/lsp.lua
+++ b/dot_config/nvim/lua/plugins/lsp.lua
@@ -34,11 +34,7 @@ return {
         },
       },
       servers = {
-        pyright = { enabled = false },
         basedpyright = {
-          enabled = true,
-          -- [Interop]: Mason-managed binary names.
-          cmd = { "basedpyright-langserver", "--stdio" },
           -- [Architecture]: Zero-Speculation Path Resolution
           -- [Rationale]: By omitting settings.python.pythonPath, BasedPyright
           -- defaults to the 'python' binary available in the current PATH,
@@ -52,7 +48,6 @@ return {
             },
           },
         },
-        ruff = {},
         typos_lsp = {
           init_options = {
             diagnosticSeverity = "Hint",


### PR DESCRIPTION
## Summary

Align Python LSP selection with LazyVim's official Python extra option model.

## Why

Milestone 2 of issue #120 aims to reduce redundant manual Python LSP configuration and delegate server selection to LazyVim's supported Python extra options.

This keeps the current useful behavior while making the source of truth clearer:
LazyVim selects `basedpyright` and `ruff`, while local configuration only preserves intentionally custom BasedPyright analysis settings and general LSP/prose behavior.

## Changes

- Added `vim.g.lazyvim_python_lsp = "basedpyright"` to `dot_config/nvim/lua/config/options.lua.tmpl`
- Added `vim.g.lazyvim_python_ruff = "ruff"` to `dot_config/nvim/lua/config/options.lua.tmpl`
- Removed redundant manual `pyright` disablement from `dot_config/nvim/lua/plugins/lsp.lua`
- Removed redundant manual `basedpyright.enabled` and `basedpyright.cmd` overrides
- Removed redundant empty `ruff` server override
- Preserved custom BasedPyright analysis settings:
  - `typeCheckingMode = "standard"`
  - `diagnosticMode = "workspace"`
- Preserved existing diagnostics preferences, `typos_lsp`, `harper_ls`, `lazydev.nvim`, and Mason ensure list

## Validation

- [x] `git diff --check`
- [x] `pre-commit run --all-files`
- [x] `mise run integrate:nvim`
- [x] `mise run doctor:nvim`
- [x] `chezmoi apply --dry-run`
- [x] `nvim --headless "+Lazy! restore" +qa`
- [x] `:checkhealth vim.lsp` confirms `basedpyright` is active
- [x] `:checkhealth vim.lsp` confirms `ruff` is active
- [x] `:checkhealth vim.lsp` confirms `pyright` is not active
- [x] `:checkhealth vim.lsp` confirms BasedPyright settings remain applied

## Risk and rollback

**Risk:** Python LSP selection could drift if LazyVim changes its Python extra option behavior in the future.

**Rollback:** Revert the additions in `dot_config/nvim/lua/config/options.lua.tmpl` and restore the removed manual server overrides in `dot_config/nvim/lua/plugins/lsp.lua`.

## Review notes

This PR intentionally does not change Mason's `debugpy` entry. In this repository it remains Mason-managed DAP/runtime support, not a workstation-global Python tool.

## Out of scope

- Global `debugpy`
- `.chezmoidata/tools.yaml`
- TypeScript, Rust, Markdown, Docker, TOML, Git, shell, Terraform, Go, SQL tooling
- Telescope
- nvim-cmp
- Snacks picker
- LazyVim Git/TOML extras
- `lazy-lock.json`

## Linked issue

Refs #120
