### PR TITLE
feat(nvim): add shell lint baseline

### DIFF
--- a/.chezmoidata/tools.yaml
+++ b/.chezmoidata/tools.yaml
@@ -55,6 +55,7 @@ mise_tools:
   "npm:@mermaid-js/mermaid-cli": "11.12.0" # renovate: datasource=npm packageName=@mermaid-js/mermaid-cli
   "aqua:JohnnyMorganz/StyLua": "2.4.1" # renovate: datasource=github-releases packageName=JohnnyMorganz/StyLua
   "aqua:mvdan/sh": "3.13.1" # renovate: datasource=github-releases packageName=mvdan/sh
+  "aqua:koalaman/shellcheck": "0.11.0" # renovate: datasource=github-releases packageName=koalaman/shellcheck
 
   # --- 8. Cloud & Platform Orchestration ---
   "docker-cli": "26.0.0" # renovate: datasource=github-releases packageName=docker/cli

--- a/dot_config/nvim/lua/plugins/lint.lua
+++ b/dot_config/nvim/lua/plugins/lint.lua
@@ -9,8 +9,10 @@ return {
     -- [Note]: LazyVim handles the 'config' and triggers. We only provide the 'opts'.
     opts = {
       linters_by_ft = {
-        markdown = { "vale" },
+        bash = { "shellcheck" },
         gitcommit = { "vale" },
+        markdown = { "vale" },
+        sh = { "shellcheck" },
       },
       -- [Critical]: Define linter overrides in 'linters' table to allow
       -- LazyVim's internal setup function to merge them correctly.


### PR DESCRIPTION
## Summary

Add a safe ShellCheck baseline for dotfiles-managed workstations and
enable shell diagnostics in Neovim for pure sh and bash files.

## Why

Milestone 3 of issue #120 introduces shell linting without treating
chezmoi Go-template files as raw shell. This keeps workstation-level
lint tooling available while avoiding false positives from `.tmpl`
files that must be rendered before shell analysis.

## Changes

- Add `aqua:koalaman/shellcheck` to mise-managed tools.
- Enable `shellcheck` diagnostics for `sh` and `bash` through
  `nvim-lint`.
- Preserve the existing `vale` lint configuration for Markdown and
  git commit messages.
- Preserve the existing `shfmt` pre-commit behavior.
- Keep `.tmpl` files out of raw ShellCheck linting.
- Apply shfmt normalization to `.bootstrap-identity.sh`.

## Validation

- [x] `git diff --check`
- [x] `chezmoi apply -v`
- [x] `mise exec shellcheck -- shellcheck --version`
- [x] `pre-commit run --all-files`
- [x] `mise run doctor:nvim`
- [x] `mise run doctor`
- [x] Pure `.sh` ShellCheck diagnostics verified in Neovim
- [x] `.sh.tmpl` raw ShellCheck diagnostics not triggered

## Risk and rollback

**Risk:**

ShellCheck diagnostics could be noisy for shell buffers, but the
change is limited to editor diagnostics for `sh` and `bash`. No
pre-commit ShellCheck enforcement is introduced.

**Rollback:**

Remove `aqua:koalaman/shellcheck` from `.chezmoidata/tools.yaml`,
remove `sh` and `bash` ShellCheck entries from
`dot_config/nvim/lua/plugins/lint.lua`, and revert the shfmt-only
bootstrap formatting change if desired.

## Review notes

This PR intentionally does not add ShellCheck to pre-commit. That
should remain a separate decision after existing shell scripts are
audited for warning volume.

## Out of scope

- Raw ShellCheck linting for chezmoi `.tmpl` files
- Template rendering or extraction pipelines
- ShellCheck integration for zsh filetypes
- SQL, Terraform, Go, ESLint, Telescope, or nvim-cmp changes
- Python LSP configuration changes

## Linked issue

Refs #120
