### PR TITLE
feat(nvim): enable project-aware eslint

### DIFF
--- a/dot_config/nvim/lua/config/lazy.lua
+++ b/dot_config/nvim/lua/config/lazy.lua
@@ -24,6 +24,11 @@ require("lazy").setup({
     -- from $PATH (provided via mise) for Markdown, JSON, and YAML.
     { import = "lazyvim.plugins.extras.formatting.prettier" },
 
+    -- [Rationale]: Use project-local ESLint for diagnostics and code actions
+    -- while preserving Prettier as the formatting owner.
+    -- [Reference]: https://www.lazyvim.org/extras/linting/eslint
+    { import = "lazyvim.plugins.extras.linting.eslint" },
+
     -- Language-specific extras for 2026 SOTA workflows.
     { import = "lazyvim.plugins.extras.lang.python" },
     { import = "lazyvim.plugins.extras.lang.typescript" },

--- a/dot_config/nvim/lua/config/options.lua.tmpl
+++ b/dot_config/nvim/lua/config/options.lua.tmpl
@@ -6,6 +6,11 @@ vim.g.maplocalleader = "\\"
 vim.g.lazyvim_python_lsp = "basedpyright"
 vim.g.lazyvim_python_ruff = "ruff"
 
+-- [LazyVim]: Keep ESLint diagnostics/code actions project-local while
+-- preserving Prettier as the formatting owner.
+-- [Reference]: https://www.lazyvim.org/extras/linting/eslint
+vim.g.lazyvim_eslint_auto_format = false
+
 local opt = vim.opt
 
 -- General Preferences


### PR DESCRIPTION
## Summary

Enable project-aware ESLint integration in Neovim while preserving Prettier as the formatter owner.

## Why

Milestone 4 confirmed that the desired model is not to add broad project-oriented language tooling globally, but to let Neovim respect project-local configuration when launched from a project directory.

ESLint is the only evaluated extra with sufficient evidence for a minimal editor integration: project-local ESLint is available through the project dependency graph, while no global ESLint binary is required.

## Changes

- Import `lazyvim.plugins.extras.linting.eslint`.
- Set `vim.g.lazyvim_eslint_auto_format = false`.
- Preserve Prettier as the formatting owner.
- Keep ESLint dependencies, plugins, and rules project-local.
- Leave Go, Terraform, SQL, Telescope, and nvim-cmp out of scope.

## Validation

- [x] `git diff --check`
- [x] `pre-commit run --all-files`
- [x] `mise run integrate:nvim`
- [x] `mise run doctor:nvim`
- [x] `chezmoi diff`
- [x] `chezmoi apply --dry-run`
- [x] `chezmoi apply -v`
- [x] `.tsx` validation confirmed `eslint`, `vtsls`, and `typos_lsp` attach.
- [x] ESLint validation confirmed `format=false`.
- [x] `.py` validation confirmed `basedpyright`, `ruff`, and `typos_lsp` still attach.
- [x] GitHub Actions CI passes

## Risk and rollback

**Risk:** ESLint LSP depends on Neovim/Mason availability and only becomes useful in projects that provide local ESLint configuration and dependencies.

**Rollback:** Remove the ESLint extra import from `dot_config/nvim/lua/config/lazy.lua` and remove `vim.g.lazyvim_eslint_auto_format = false` from `dot_config/nvim/lua/config/options.lua.tmpl`.

## Review notes

This PR intentionally does not install global `eslint` or framework-specific ESLint plugins. ESLint ownership remains project-local; dotfiles only provide the Neovim editor integration layer.

## Out of scope

- Global `eslint`
- Framework-specific ESLint plugins
- Go extra
- Terraform extra
- SQL extra
- Telescope
- nvim-cmp
- Changes to Snacks picker
- Changes to blink.cmp
- Changes to Python LSP configuration
- Changes to shell linting configuration

## Linked issue

Closes #120
