### PR TITLE
chore(deps): atomic neovim plugin convergence

### DIFF
--- a/dot_config/nvim/lazy-lock.json
+++ b/dot_config/nvim/lazy-lock.json
@@ -32,7 +32,7 @@
   "nvim-dap-ui": { "branch": "master", "commit": "1a66cabaa4a4da0be107d5eda6d57242f0fe7e49" },
   "nvim-dap-virtual-text": { "branch": "master", "commit": "fbdb48c2ed45f4a8293d0d483f7730d24467ccb6" },
   "nvim-lint": { "branch": "master", "commit": "eab58b48eb11d7745c11c505e0f3057165902461" },
-  "nvim-lspconfig": { "branch": "master", "commit": "8fde495949782bb61c2605174e231d145a048d8c" },
+  "nvim-lspconfig": { "branch": "master", "commit": "21db1fd40cbcbf1524ae154ab8f394fdf085749a" },
   "nvim-nio": { "branch": "master", "commit": "21f5324bfac14e22ba26553caf69ec76ae8a7662" },
   "nvim-treesitter": { "branch": "main", "commit": "4916d6592ede8c07973490d9322f187e07dfefac" },
   "nvim-treesitter-textobjects": { "branch": "main", "commit": "851e865342e5a4cb1ae23d31caf6e991e1c99f1e" },


### PR DESCRIPTION
### 🎯 Rationale
Automated state promotion of `lazy-lock.json`.

### ⚠️ Action Required (SSH Signature Preservation)
To preserve the cryptographic integrity of the SSH signature (Fast-Forward only), **DO NOT merge via GitHub UI**.
Execute the following locally after the CI pipeline passes:

```zsh
git checkout main
git merge --ff-only chore/deps-nvim-202604262310
git push origin main
git branch -d chore/deps-nvim-202604262310
git push origin --delete chore/deps-nvim-202604262310
```