### PR TITLE
chore(tools): add terraform for tofu checks

### DIFF
--- a/.chezmoidata/tools.yaml
+++ b/.chezmoidata/tools.yaml
@@ -64,6 +64,7 @@ mise_tools:
   "helm": "4.1.4" # renovate: datasource=github-releases packageName=helm/helm
   "aqua:derailed/k9s": "0.50.18" # renovate: datasource=github-releases packageName=derailed/k9s
   "opentofu": "1.11.6" # renovate: datasource=github-releases packageName=opentofu/opentofu
+  "terraform": "1.14.9" # renovate: datasource=github-releases packageName=hashicorp/terraform
   "tflint": "0.62.0" # renovate: datasource=github-releases packageName=terraform-linters/tflint
   "terragrunt": "1.0.2" # renovate: datasource=github-releases packageName=gruntwork-io/terragrunt
 


### PR DESCRIPTION
## Summary

Add Terraform as a temporary mise-managed compatibility tool for the
OpenTofu migration workflow.

## Why

The repository is moving from Terraform to OpenTofu. During the migration,
Terraform still needs to be available locally for side-by-side compatibility
checks, version verification, and migration confidence.

This change intentionally does not modify completion generation or doctor
tasks because Terraform is only needed for temporary migration validation.

## Changes

- Add Terraform 1.14.9 to `.chezmoidata/tools.yaml`
- Keep OpenTofu as the primary IaC tool
- Preserve existing TFLint and Terragrunt tooling
- Leave completion generation unchanged
- Leave doctor completion checks unchanged

## Validation

- [x] `git diff --check`
- [x] `pre-commit run --all-files`
- [x] `chezmoi apply --dry-run`
- [x] `chezmoi apply`
- [x] `terraform version`
- [x] `tofu version`
- [x] `mise run doctor`
- [x] GitHub Actions CI passes

## Risk and rollback

**Risk:** Low. This only adds Terraform as an additional mise-managed CLI
for migration compatibility checks.

**Rollback:** Remove the Terraform entry from `.chezmoidata/tools.yaml` after
OpenTofu migration validation is complete.

## Review notes

Terraform is intentionally not added to completion generation or doctor
completion checks. It is only needed as a temporary compatibility tool during
the migration window.

## Out of scope

- Migrating Terraform state
- Rewriting IaC configuration
- Changing completion generation
- Changing doctor tasks
- Removing Terraform after migration completion

## Linked issue

N/A
