### PR TITLE
docs(llm): add workflow guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,6 +3,10 @@
 Use [AGENTS.md](../AGENTS.md) as the primary repository-wide guidance for this
 repository.
 
+Use [docs/llm/README.md](../docs/llm/README.md) and
+[docs/workflows/README.md](../docs/workflows/README.md) for detailed LLM
+collaboration and workflow guidance.
+
 This is a chezmoi-managed dotfiles source-state repository. Keep suggestions
 small, scoped, and behavior-preserving.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,11 @@ When sources conflict, prefer the most specific reliable source for the task:
 Do not override explicit issue constraints with general guidance unless current
 repository evidence shows a conflict. Report the conflict instead of guessing.
 
+For detailed LLM and workflow guidance, use
+[docs/llm/README.md](./docs/llm/README.md) and
+[docs/workflows/README.md](./docs/workflows/README.md). Keep this file as the
+repository-wide entry point rather than duplicating detailed process rules here.
+
 ## Behavior preservation
 
 Preserve existing behavior unless the assigned issue explicitly scopes a change.

--- a/docs/llm/README.md
+++ b/docs/llm/README.md
@@ -1,0 +1,51 @@
+# LLM collaboration guidance
+
+This directory indexes repository-specific guidance for LLM-assisted dotfiles
+maintenance.
+
+Use these docs to route work, inspect evidence, produce safe output, write commit
+messages, review changes, and handle chezmoi template risks without changing
+provisioning behavior.
+
+## Entry points
+
+- [Routing](./routing.md): source priority, repository entry points,
+  Commander / Worker boundaries, task-surface routing, and uncertainty handling.
+- [Local state inspection](./local-state-inspection.md): how to use local file
+  contents, command output, validation output, CI evidence, and Repomix snapshots.
+- [Diff output guardrails](./diff-output-guardrails.md): safe patch, heredoc,
+  guarded-script, and non-patch output formats.
+- [Commit message guidelines](./commit-message-guidelines.md): Conventional
+  Commit structure, issue reference rules, and validation claim discipline.
+- [Review protocol](./review-protocol.md): scope review, behavior preservation,
+  validation review, link review, and LLM failure modes.
+- [Chezmoi template guidelines](./chezmoi-template-guidelines.md):
+  source-state and rendered-target guidance for Go Template files.
+
+## Related workflow docs
+
+- [Workflow documentation](../workflows/README.md): issue, pull request,
+  validation, merge, and closure workflows.
+- [Repository agent guidance](../../AGENTS.md): repository-wide agent boundaries
+  and validation expectations.
+- [Repomix instruction router](../../repomix-instruction.md): Repomix snapshot
+  instruction entry point.
+
+## Repository posture
+
+This repository is a chezmoi-managed dotfiles source-state repository. It is not
+a normal application repository.
+
+Preserve existing behavior unless the assigned issue explicitly scopes a change,
+especially:
+
+- chezmoi provisioning behavior
+- 1Password identity routing
+- SSH signing and SSH agent bridging
+- generated identity files
+- Neovim, WezTerm, zsh, Git, mise, and Homebrew behavior
+- GitHub Actions `compliance.yml` semantics
+- runtime versions, tool versions, dependencies, and lockfiles
+
+Treat generated `repomix-*.xml` files as read-only evidence. Make changes to
+the original repository files.

--- a/docs/llm/chezmoi-template-guidelines.md
+++ b/docs/llm/chezmoi-template-guidelines.md
@@ -1,0 +1,203 @@
+# Chezmoi template guidelines
+
+## Purpose
+
+Use this guide when changing chezmoi source-state templates.
+
+Chezmoi template changes are rendered-output-sensitive. A small source-state edit
+can change target files, provisioning behavior, shell startup, identity routing,
+or workstation convergence.
+
+## Source-state and rendered-target model
+
+This repository stores chezmoi source state.
+
+Source-state files are edited in the repository. Rendered target files are what
+chezmoi applies to the user's home directory.
+
+Do not assume source syntax and rendered syntax are the same. A valid
+source-state template can render invalid shell, Lua, TOML, INI, JSON, or service
+configuration if template whitespace, loops, conditionals, or comments are wrong.
+
+## Comment routing
+
+Use the right comment type for the intended audience.
+
+### Go Template comments
+
+Use Go Template comments for source-state-only rationale that should not appear
+in the rendered target file:
+
+```gotemplate
+{{/* [Rationale]: Source-only explanation for maintainers. */}}
+```
+
+Use this for:
+
+- template control-flow rationale
+- data-shape assumptions
+- source-state safety notes
+- LLM guidance that would be noise in the rendered file
+
+### Target-language comments
+
+Use target-language comments when the rendered target file should carry the
+explanation.
+
+Examples:
+
+```sh
+# [Rationale]: Keep this visible in the rendered shell script.
+```
+
+```lua
+-- [Rationale]: Keep this visible in the rendered Lua file.
+```
+
+Use this for:
+
+- operational notes useful in the target file
+- generated configuration explanations
+- warnings future users should see after rendering
+
+## Block comments vs repeated line comments
+
+Use block Go Template comments when a source-only rationale spans multiple
+lines. This is clearer than repeating many single-line template comments.
+
+Prefer:
+
+```gotemplate
+{{/*
+[Rationale]: This branch is source-state-only documentation.
+It explains why the rendered output must not include these notes.
+*/}}
+```
+
+Avoid noisy repeated comments when one block comment would be clearer.
+
+## Double-extension routing
+
+Treat the final rendered language as the validation target.
+
+### `.sh.tmpl`
+
+Rendered target is POSIX shell or shell script content. Preserve shebang
+placement, shell syntax, quoting, and executable behavior.
+
+### `.zsh.tmpl`
+
+Rendered target is Zsh. Preserve startup ordering, completion behavior, array
+syntax, and Zsh-specific constructs.
+
+### `.lua.tmpl`
+
+Rendered target is Lua. Preserve Lua syntax after template expansion. Be careful
+with commas, string quoting, and conditional table entries.
+
+### `.toml.tmpl`
+
+Rendered target is TOML. Preserve table boundaries, string quoting, and array
+syntax.
+
+### `.ini.tmpl`
+
+Rendered target is INI-like configuration. Preserve section headers, key-value
+format, and comment syntax expected by the target tool.
+
+### `.json.tmpl`
+
+Rendered target is JSON. Avoid trailing commas and comments in rendered JSON
+unless the target format explicitly supports them.
+
+### Extensionless executable `.tmpl` files
+
+Rendered target may be executable shell content even without a `.sh` suffix.
+Inspect shebangs and target paths before choosing validation.
+
+### `.chezmoitemplates/*`
+
+These files are template fragments included by other templates. Review both the
+fragment and every known include site before changing output-sensitive content.
+
+### `.chezmoiscripts/*`
+
+These files are chezmoi scripts with execution timing encoded in the filename.
+Preserve run phase, idempotency, shell choice, and rendered script validity.
+
+## Whitespace trimming
+
+Go Template delimiters can trim whitespace:
+
+- `{{-` trims whitespace before the action.
+- `-}}` trims whitespace after the action.
+
+Use trimming deliberately. It can prevent unwanted blank lines, but it can also
+join lines accidentally.
+
+Before changing trimming, consider whether it can cause:
+
+- shebang concatenation
+- command concatenation
+- missing blank lines
+- merged comments and code
+- invalid target-language syntax
+
+## Rendered-output risks
+
+Common rendered-output failures include:
+
+- shebang no longer being the first line
+- accidental line joining
+- missing blank lines between generated blocks
+- loop-generated extra blank lines
+- invalid shell syntax
+- invalid Lua table syntax
+- invalid TOML, INI, or JSON syntax
+- comments rendering into target files when they should remain source-only
+- source-only rationale disappearing when maintainers need it
+
+Do not refactor template comments or whitespace trimming as incidental cleanup.
+
+## Validation guidance
+
+Choose validation based on the touched surface.
+
+### When `chezmoi diff` is enough
+
+Use `chezmoi diff` when a template change should be reviewed through rendered
+output and does not require applying changes to the target home directory.
+
+This is usually enough for:
+
+- `.chezmoiignore.tmpl` changes
+- rendered config inspection
+- documentation-supported template edits
+- checking whether expected target output changes appear
+
+### When `chezmoi verify` is relevant
+
+Use `chezmoi verify` when checking whether target files match source-state
+expectations.
+
+This is useful for drift checks, but it is not a substitute for reviewing a new
+rendered diff when template logic changes.
+
+### When CI-style `chezmoi init --source="$PWD" --apply` is excessive
+
+A full init/apply check is heavyweight and can mutate a target environment. Do
+not require it for documentation-only changes or small source-state docs.
+
+### When CI-style apply may be justified
+
+A CI-style apply path can be justified when a future issue explicitly changes
+provisioning, identity routing, shell startup, tool installation, or other
+workstation convergence behavior and a safe disposable environment is available.
+
+## Out-of-scope caution
+
+Do not rewrite existing template comments, whitespace trimming, or rendered
+formatting as incidental cleanup.
+
+If comment normalization is valuable, record it as follow-up work after this
+guidance exists and the Commander Thread scopes a dedicated change.

--- a/docs/llm/commit-message-guidelines.md
+++ b/docs/llm/commit-message-guidelines.md
@@ -1,0 +1,152 @@
+# Commit message guidelines
+
+## Purpose
+
+Use commit messages to explain one logical repository change.
+
+Commit messages should be concise, accurate, and reviewable. They should not
+claim validation passed unless evidence exists.
+
+## Format
+
+Use Conventional Commits:
+
+```text
+<type>(<scope>): <summary>
+
+<body>
+```
+
+Common types:
+
+- `docs`: documentation-only changes
+- `chore`: repository maintenance
+- `fix`: correction of incorrect behavior
+- `feat`: new user-facing or system behavior
+- `refactor`: internal change without behavior change
+- `ci`: GitHub Actions or CI configuration
+- `test`: test-only changes
+
+Use scopes that match the touched surface, such as:
+
+- `docs(llm)`
+- `docs(workflows)`
+- `chore(repomix)`
+- `ci(compliance)`
+- `fix(chezmoi)`
+
+Do not invent a scope that implies untouched behavior.
+
+## Summary line
+
+Use the imperative mood.
+
+Aim for about 50 characters when practical. Keep the summary specific.
+
+Good examples:
+
+```text
+docs(llm): add diff output guardrails
+docs(workflows): document PR linkage rules
+chore(repomix): normalize snapshot routing
+```
+
+Avoid vague summaries:
+
+```text
+docs: update files
+chore: improve stuff
+```
+
+## Body
+
+Use the body to explain why the change is needed and what trade-offs it makes.
+
+Wrap body lines at about 72 characters when practical. Do not restate every line
+of the diff.
+
+A useful body can include:
+
+```text
+Add repository-specific LLM guidance so future dotfiles changes can
+choose the correct evidence, output format, and validation path.
+
+This keeps detailed rules in docs while leaving router files thin.
+```
+
+## Key changes
+
+For larger commits, use a short `Key Changes` section:
+
+```text
+Key Changes:
+- Add LLM routing, local evidence, and review guidance.
+- Add workflow docs for issues, PRs, validation, and merge decisions.
+- Keep the change documentation-only and behavior-preserving.
+```
+
+Keep bullets factual and scoped to the commit.
+
+## Validation
+
+Only include validation that has evidence.
+
+Good examples:
+
+```text
+Validation:
+- `git diff --check`: no output
+- `pre-commit run --all-files`: passed
+- `repomix`: packed successfully
+```
+
+If validation was not run:
+
+```text
+Validation:
+- Not run; commit message only.
+```
+
+Do not write `passed` unless the user provided command output, CI results, or
+explicit confirmation.
+
+For detailed validation rules, see
+[Validation workflow](../workflows/validation-workflow.md).
+
+## Issue references
+
+Use issue references deliberately.
+
+Use `Refs: #<issue-number>` when the commit should reference an issue without
+closing it. Avoid closing keywords in commit messages unless the user explicitly
+asks for them.
+
+Closing keywords usually belong in the pull request body. For PR linkage rules,
+see [Pull request workflow](../workflows/pull-request-workflow.md).
+
+## Squash commit guidance
+
+When a PR is squash merged, the final squash commit should summarize the whole
+PR, not just the last local commit.
+
+Use the PR body and actual validation evidence. Do not include unsupported
+validation claims.
+
+## Example
+
+```text
+docs(llm): add workflow guidance
+
+Add detailed LLM and workflow documentation for repository maintenance.
+This keeps durable rules under docs while preserving thin router files.
+
+Key Changes:
+- Add LLM routing, local-state, diff, commit, review, and chezmoi guidance.
+- Add issue, PR, validation, merge, and closure workflow docs.
+- Link router files to the new documentation indexes.
+
+Validation:
+- Not run; awaiting local validation output.
+
+Refs: #132
+```

--- a/docs/llm/diff-output-guardrails.md
+++ b/docs/llm/diff-output-guardrails.md
@@ -1,0 +1,190 @@
+# Diff output guardrails
+
+## Purpose
+
+Use these guardrails when producing LLM-generated repository changes.
+
+The output format must match the task, available evidence, and application path.
+Prefer exact, reviewable, behavior-preserving output over clever or abbreviated
+changes.
+
+## Output format selection
+
+Use a strict unified diff when:
+
+- the user asks for a patch
+- the change modifies existing code or configuration
+- the change must be applied with `git apply`
+- multiple existing files must change atomically
+
+Use whole-file heredocs when:
+
+- creating new Markdown files
+- replacing a short file in full with current contents known
+- Markdown hunk context would be fragile or noisy
+- the user wants `cat > file <<'EOF'` style output
+
+Use guarded scripts when:
+
+- the edit is mechanical across known files
+- the script can fail if expected text is missing
+- a large handwritten patch would be harder to review safely
+
+Use non-patch output when the deliverable is not a repository change, such as:
+
+- issue body
+- pull request body
+- commit message
+- review summary
+- command bundle
+- validation bundle
+- inspection bundle
+- reusable prompt
+
+Label non-patch deliverables clearly. Do not present them as apply-ready patches.
+
+## Strict unified diff requirements
+
+For repository changes intended for `git apply`, use strict Git extended unified
+diff format.
+
+A normal modified file should use:
+
+```diff
+diff --git a/path/to/file b/path/to/file
+--- a/path/to/file
++++ b/path/to/file
+@@ -1,3 +1,4 @@
+```
+
+A new file should use:
+
+```diff
+diff --git a/path/to/file b/path/to/file
+new file mode 100644
+--- /dev/null
++++ b/path/to/file
+@@ -0,0 +1,3 @@
+```
+
+A deleted file should use:
+
+```diff
+diff --git a/path/to/file b/path/to/file
+deleted file mode 100644
+--- a/path/to/file
++++ /dev/null
+@@ -1,3 +0,0 @@
+```
+
+Do not include fake `index` lines, placeholder hashes, abbreviated pseudo-diffs,
+or prose inside patch blocks.
+
+Patch code fences must contain only patch content.
+
+## Current-file-context requirement
+
+Do not output a targeted patch against an existing file unless current contents
+are known well enough for hunk context to match.
+
+Acceptable evidence includes:
+
+- current file contents
+- current `git diff`
+- current `sed -n` output
+- a current Repomix snapshot that includes the file
+
+If evidence is missing, request file context instead of guessing.
+
+## Whole-file heredocs for new Markdown
+
+For new Markdown files, whole-file heredocs are often safer than large diffs:
+
+```sh
+mkdir -p docs/example
+cat > docs/example/file.md <<'EOF_DOC_EXAMPLE_FILE_MD'
+# Example
+
+Content.
+EOF_DOC_EXAMPLE_FILE_MD
+```
+
+Use single-quoted heredoc delimiters so shell interpolation does not alter the
+file body. Choose delimiters that are unique to the target file.
+
+## Guarded scripts
+
+A guarded script should fail when expected text is missing.
+
+Good guarded scripts:
+
+- name target files explicitly
+- check old text before replacing it
+- avoid broad repository-wide rewrites
+- avoid generated files unless explicitly scoped
+- ask the user to inspect `git diff` afterward
+
+Do not use scripts to hide unclear changes.
+
+## Non-patch deliverables
+
+Non-patch deliverables should be clearly labeled and kept outside patch blocks.
+
+Examples:
+
+- commit message
+- PR body
+- issue body
+- review comment
+- validation command bundle
+
+When generated Markdown includes nested triple-backtick fences, wrap the outer
+chat block with quadruple backticks.
+
+## Generated-file discipline
+
+Do not edit generated or packed files directly.
+
+Treat these as read-only evidence unless a future issue explicitly scopes them:
+
+- `repomix-*.xml`
+- generated rendered target files
+- temporary validation artifacts
+
+Make changes to original repository files, then regenerate artifacts when
+validation requires it.
+
+## Whitespace and final newline discipline
+
+Preserve whitespace precisely.
+
+- Avoid trailing whitespace.
+- Preserve intentional blank lines.
+- Keep indentation stable.
+- End text files with a final newline.
+- Do not rewrap unrelated lines.
+- Do not change whitespace in rendered-output-sensitive templates incidentally.
+
+For chezmoi templates, be especially careful with `{{-` and `-}}` because they
+can remove newlines and join rendered output.
+
+## Validation after applying output
+
+After applying generated output, inspect the resulting tree:
+
+```sh
+git status --short
+git diff --stat
+git diff --check
+```
+
+Then run validation that matches the touched surface. For details, see
+[Validation workflow](../workflows/validation-workflow.md).
+
+## Unsupported patch claims
+
+Do not claim that a patch is guaranteed to apply unless it was actually tested
+against the current repository state.
+
+If a patch is untested, say it is untested. If it depends on partial evidence,
+state the missing evidence instead of overstating confidence.

--- a/docs/llm/local-state-inspection.md
+++ b/docs/llm/local-state-inspection.md
@@ -1,0 +1,184 @@
+# Local state inspection
+
+## Purpose
+
+Use local state inspection to ground LLM-assisted work in the user's current
+repository state.
+
+The LLM does not know the user's working tree unless the user provides command
+output, file contents, diffs, screenshots, CI evidence, or generated snapshots.
+
+## Core rule
+
+Do not invent local repository state.
+
+If a file, branch, diff, command result, validation result, PR state, issue state,
+tool version, or CI result has not been provided or directly inspected, do not
+claim it as fact.
+
+## Read-only inspection commands
+
+Use read-only commands that match the task scope.
+
+Common commands:
+
+```sh
+git branch --show-current
+git status --short
+git diff --stat
+git diff --name-status
+git diff --check
+git diff main...HEAD --stat
+git diff main...HEAD --name-status
+git ls-files
+find .github -maxdepth 3 -type f | sort
+find docs -maxdepth 4 -type f | sort
+rg -n "pattern" path
+sed -n '1,220p' path/to/file
+```
+
+For full repository context, use:
+
+```sh
+repomix
+```
+
+If configuration discovery is unclear, use:
+
+```sh
+repomix --config repomix.config.json
+```
+
+## Inspection bundles
+
+When several facts are needed, ask for a compact inspection bundle instead of
+one command at a time.
+
+A useful pre-work bundle:
+
+```sh
+set +e
+
+run() {
+  printf '\n===== %s =====\n' "$*"
+  "$@"
+  status=$?
+  printf -- '----- exit code: %s -----\n' "$status"
+}
+
+run git branch --show-current
+run git status --short
+run git diff --stat
+run find docs -maxdepth 4 -type f
+run find .github -maxdepth 3 -type f
+```
+
+Keep inspection bundles diagnostic:
+
+- use read-only commands
+- avoid printing secrets or unredacted environment values
+- continue after failures so later state is still visible
+- keep validation pass claims separate from diagnostic output
+
+## Branch and working tree state
+
+Check the branch and working tree before proposing repository changes.
+
+Use `git status --short` to detect staged, unstaged, untracked, or generated
+files. Do not mix new work into an unrelated dirty tree without calling out the
+risk.
+
+Use `git diff --name-status` or `git diff --stat` to confirm the touched surface.
+
+## File content inspection before patches
+
+Do not generate targeted patches against existing files unless current file
+contents are known well enough to match hunk context.
+
+Acceptable evidence includes:
+
+- user-provided file contents
+- user-provided `git diff`
+- user-provided `sed -n` output
+- a current Repomix snapshot that includes the file
+- directly inspected local files
+
+If contents are incomplete or stale, request the smallest useful file inspection
+instead of guessing.
+
+## Command output interpretation
+
+Report exactly what command output supports.
+
+Do not convert silence into success unless the command is known to report success
+that way and the user provided the exit status or context. For example,
+`git diff --check` with no output is useful evidence when the user states that it
+exited successfully.
+
+Do not infer one check from another. Local `pre-commit run --all-files` does not
+prove GitHub Actions passed.
+
+## Validation evidence handling
+
+A validation claim requires evidence.
+
+Evidence can be:
+
+- command output
+- exit code
+- CI result
+- explicit user confirmation
+- directly inspected repository state
+
+If validation was not run, say it was not run. If it failed and then passed on
+retry, report both the failure and retry result.
+
+For validation rules by surface, see
+[Validation workflow](../workflows/validation-workflow.md).
+
+## CI and remote state
+
+Do not claim remote state unless the user provides it or it is directly
+available.
+
+Remote state includes:
+
+- PR number
+- PR URL
+- review status
+- GitHub Actions status
+- issue checkbox state
+- issue closure state
+- labels, milestones, assignees, and projects
+
+When a command depends on a new PR number, wait until the user provides that
+number or URL.
+
+## Generated and packed files
+
+Treat generated and packed files as evidence, not source.
+
+Examples:
+
+- `repomix-*.xml`
+- generated rendered target files
+- temporary validation artifacts
+
+Do not edit generated Repomix output. Make changes to original repository files
+and regenerate snapshots when validation requires it.
+
+## Sensitive local data
+
+Avoid requesting or printing secrets.
+
+Be careful with:
+
+- 1Password item IDs and account IDs
+- SSH private keys
+- access tokens
+- environment variables
+- unredacted home paths when not needed
+- generated identity files
+
+Prefer structural inspection over secret-bearing output. Ask the user to redact
+sensitive values before sharing evidence.

--- a/docs/llm/review-protocol.md
+++ b/docs/llm/review-protocol.md
@@ -1,0 +1,209 @@
+# Review protocol
+
+## Purpose
+
+Use this protocol when reviewing LLM-assisted changes in this dotfiles
+repository.
+
+A review should determine whether the change matches scope, preserves behavior,
+has accurate validation evidence, and is ready for human review or merge.
+
+## Review priorities
+
+Review in this order:
+
+1. Scope alignment.
+2. Behavior preservation.
+3. Validation evidence.
+4. Link and reference correctness.
+5. Diff quality.
+6. Documentation clarity.
+7. Follow-up recommendations.
+
+Do not start with style preferences when scope, behavior, or validation may be
+wrong.
+
+## Scope alignment
+
+Compare the diff against the assigned issue, PR slice, Worker prompt, or
+Commander instruction.
+
+Check whether the change:
+
+- solves the stated goal
+- stays within in-scope items
+- avoids unrelated cleanup
+- avoids unsupported behavior changes
+- uses correct issue references and closing keywords
+
+For one-issue / multiple-PR work, intermediate PRs should use `Refs #<issue>`.
+Only the final planned PR should use a closing keyword after remaining acceptance
+criteria are complete.
+
+## Behavior preservation
+
+For documentation-only changes, confirm that only documentation and minimal
+router files changed.
+
+For dotfiles behavior changes, confirm that the issue explicitly scopes the
+change and validation matches the touched surface.
+
+Pay special attention to:
+
+- chezmoi provisioning behavior
+- 1Password identity routing
+- SSH signing and SSH agent bridging
+- generated identity files
+- Neovim behavior
+- WezTerm behavior
+- zsh and shell startup behavior
+- Git behavior
+- mise task and toolchain behavior
+- Homebrew package behavior
+- GitHub Actions `compliance.yml` semantics
+- runtime versions, tool versions, dependencies, and lockfiles
+
+Do not assume a behavior change is safe because it is small.
+
+## Validation evidence
+
+Review validation claims against evidence.
+
+A validation claim is supported only when the user provides command output, CI
+results, or explicit confirmation.
+
+Check that:
+
+- passed checks are backed by evidence
+- skipped checks are identified as not run
+- failed checks and retries are reported honestly
+- GitHub Actions CI is not marked complete before it passes
+- validation matches the touched surface
+
+For detailed rules, see
+[Validation workflow](../workflows/validation-workflow.md).
+
+## Link and reference review
+
+For Markdown changes, verify repository-relative links.
+
+Check links to current files, especially:
+
+- [AGENTS.md](../../AGENTS.md)
+- [GitHub Copilot instructions](../../.github/copilot-instructions.md)
+- [Pull request template](../../.github/pull_request_template.md)
+- [Change request issue template](../../.github/ISSUE_TEMPLATE/change-request.md)
+- [Repomix instruction router](../../repomix-instruction.md)
+- [Repomix config](../../repomix.config.json)
+- [Workflow docs](../workflows/README.md)
+- [LLM docs](./README.md)
+- [README.md](../../README.md)
+
+Do not link to files planned for a later PR unless they already exist.
+
+## Diff quality
+
+A reviewable diff should be small, coherent, and scoped.
+
+Check that the diff:
+
+- avoids unrelated reformatting
+- preserves existing style and terminology
+- keeps router files thin
+- avoids duplicate rules across guidance files
+- avoids generated files unless explicitly scoped
+- keeps Markdown wrapping stable
+- ends text files with a final newline
+
+For output rules, see
+[Diff output guardrails](./diff-output-guardrails.md).
+
+## Documentation clarity
+
+Documentation should help future contributors make decisions.
+
+Check that docs:
+
+- have a clear purpose
+- separate requirements from evidence
+- separate LLM guidance from workflow guidance
+- use dotfiles-specific terminology
+- avoid monorepo-specific assumptions
+- avoid unsupported claims about tool behavior
+- link to durable repository files when relevant
+
+## Common LLM failure modes
+
+Watch for:
+
+- invented repository state
+- invented validation results
+- scope expansion
+- stale links
+- broken relative links
+- copied monorepo assumptions
+- fake patch metadata
+- prose inside patch blocks
+- closing keywords on non-final PRs
+- incidental template comment rewrites
+- unsupported claims about rendered output
+
+Request targeted corrections rather than broad rewrites.
+
+## Actionable review comments
+
+A good review comment identifies:
+
+- the file or section
+- the issue
+- why it matters
+- the requested change
+
+Prefer:
+
+```text
+docs/workflows/pull-request-workflow.md links to a future issue-form file that
+does not exist in this PR. Please link to the current Markdown issue template
+until the issue-form PR creates the YAML file.
+```
+
+Avoid vague comments:
+
+```text
+This feels off.
+```
+
+## Approval recommendation
+
+Recommend approval only when:
+
+- the diff matches the assigned scope
+- behavior preservation is clear
+- required evidence exists or is clearly pending
+- links resolve
+- risks and rollback are documented
+- out-of-scope work is not mixed in
+
+If evidence is incomplete, state exactly what remains.
+
+## Follow-up recommendations
+
+Use follow-up recommendations for useful work outside the current PR.
+
+A useful follow-up should include:
+
+- the observed issue
+- why it is outside scope
+- suggested future owner or issue scope
+- evidence needed before implementation
+
+Do not block the current PR on unrelated improvements unless correctness,
+safety, or reviewability requires it.
+
+## Commander and Worker review boundaries
+
+Commander Threads review issue topology, PR sequencing, cross-PR synthesis, and
+closure decisions.
+
+Worker Threads review only the assigned issue, PR, or bounded task unless the
+Commander explicitly asks for broader synthesis.

--- a/docs/llm/routing.md
+++ b/docs/llm/routing.md
@@ -1,0 +1,185 @@
+# LLM routing
+
+## Purpose
+
+Use this guide to choose the right repository guidance, evidence, and workflow
+before starting LLM-assisted dotfiles work.
+
+Routing should keep changes scoped, evidence-based, and behavior-preserving.
+
+## Source priority
+
+When sources conflict, prefer the most specific reliable source for the task:
+
+1. The user's current instructions.
+2. The assigned issue, pull request, review, or Worker prompt.
+3. Current local evidence such as file contents, diffs, command output, and CI.
+4. [Repository agent guidance](../../AGENTS.md).
+5. Repository docs such as [README.md](../../README.md) and
+   [ARCHITECTURE.md](../../ARCHITECTURE.md).
+6. Official tool documentation when needed.
+
+Do not override explicit issue constraints with general guidance. If current
+local evidence contradicts the issue or prompt, report the conflict and ask the
+Commander Thread for a scope decision.
+
+## Repository entry points
+
+Start with these repository-wide entry points:
+
+- [AGENTS.md](../../AGENTS.md): repository-wide boundaries and validation posture.
+- [LLM collaboration index](./README.md): LLM-specific guidance.
+- [Workflow documentation](../workflows/README.md): issue, PR, validation, merge,
+  and closure workflows.
+- [Repomix instruction router](../../repomix-instruction.md): instructions for
+  LLMs consuming Repomix snapshots.
+- [GitHub Copilot instructions](../../.github/copilot-instructions.md): thin
+  router for tools that consume GitHub Copilot repository instructions directly.
+
+Keep router files thin. Detailed durable rules belong in `docs/llm/` and
+`docs/workflows/`.
+
+## Commander and Worker separation
+
+Use Commander / Worker separation when work spans multiple PRs or issue slices.
+
+Commander Threads own:
+
+- issue topology
+- PR sequencing
+- cross-PR synthesis
+- final merge and closure recommendations
+- decisions about scope changes
+
+Worker Threads own:
+
+- one assigned issue, PR, or bounded task
+- local evidence review for that scope
+- patch, heredoc, command, PR body, or review output for that scope
+- validation interpretation after the user provides evidence
+
+A Worker Thread should not silently expand scope, close a tracking issue, or
+change PR sequencing.
+
+## Local evidence hierarchy
+
+Prefer current local evidence over older snapshots when they conflict.
+
+Useful evidence includes:
+
+- `git status --short`
+- `git diff`
+- `git diff --stat`
+- `git diff --name-status`
+- `git diff --check`
+- `git ls-files`
+- `find`
+- `rg`
+- `sed`
+- validation command output
+- GitHub Actions results
+- Repomix snapshots
+
+Do not invent local state. For details, see
+[Local state inspection](./local-state-inspection.md).
+
+## Repomix routing
+
+Use Repomix snapshots as read-only evidence.
+
+The canonical command for a full repository snapshot is:
+
+```sh
+repomix
+```
+
+If configuration discovery is unclear, use the explicit fallback:
+
+```sh
+repomix --config repomix.config.json
+```
+
+Do not edit generated `repomix-*.xml` files. Do not add alternate repository-owned
+Repomix configs, wrapper tasks, or skeleton snapshots unless a future issue
+explicitly scopes that work.
+
+## Workflow routing
+
+Use workflow docs for process decisions:
+
+- [Issue workflow](../workflows/issue-workflow.md): scope contracts,
+  acceptance criteria, PR slicing, and out-of-scope findings.
+- [Pull request workflow](../workflows/pull-request-workflow.md): PR body,
+  labels, linked issues, review readiness, risk, and rollback.
+- [Validation workflow](../workflows/validation-workflow.md): validation by
+  touched surface and evidence reporting.
+- [Merge and close workflow](../workflows/merge-and-close-workflow.md): merge
+  readiness, issue closure, checkbox updates, and rollback after merge.
+
+## Task-surface routing
+
+Route by touched surface before proposing changes.
+
+### Documentation-only changes
+
+Prefer `docs/llm/` or `docs/workflows/` for durable guidance. Validate with
+`git diff --check`, `pre-commit run --all-files`, Markdown link checks, and
+`repomix` when LLM routing or snapshot guidance changes.
+
+### Chezmoi template changes
+
+Inspect source-state and rendered-target impact. Be careful with Go Template
+comments, whitespace trimming, shebang placement, blank lines, and target-language
+syntax. See [Chezmoi template guidelines](./chezmoi-template-guidelines.md).
+
+### `.chezmoiignore.tmpl` and target ignore changes
+
+Treat these as rendered-output-sensitive. Require `chezmoi diff` unless the user
+or Commander explicitly scopes a different evidence path.
+
+### Identity and 1Password-sensitive changes
+
+Avoid incidental edits. Changes touching 1Password, SSH signing, SSH agent
+bridging, generated identity files, or scoped Git identity routing require
+explicit issue scope and strong validation evidence.
+
+### Neovim changes
+
+Preserve LazyVim behavior, plugin lockfile semantics, provider configuration, and
+existing keymap decisions unless explicitly scoped. Prefer Neovim-specific
+validation only when Neovim files or rendered Neovim behavior change.
+
+### WezTerm changes
+
+Preserve macOS and WSL routing behavior. Treat WSL sync and Windows-host bridge
+logic as behavior-sensitive.
+
+### zsh and shell changes
+
+Preserve shell startup ordering, POSIX vs Zsh boundaries, and template rendering.
+Use shell-specific validation only when shell files or rendered shell behavior
+change.
+
+### mise task and toolchain changes
+
+Preserve tool versions, task names, task semantics, and lockfile behavior unless
+explicitly scoped. Use `mise run doctor` only when the touched surface justifies
+it.
+
+### GitHub Actions changes
+
+Preserve `compliance.yml` semantics unless explicitly scoped. Do not infer CI
+success from local validation.
+
+### Repomix routing changes
+
+Keep `repomix.config.json` and `repomix-instruction.md` aligned. Validate with
+`repomix` and inspect whether generated snapshots include the intended guidance.
+
+## Uncertainty handling
+
+If evidence is missing, state what is missing and request the smallest useful
+inspection bundle. Do not produce fragile patches based on guessed file contents.
+
+If a useful improvement is outside scope, record it as an out-of-scope note for
+the Commander Thread instead of implementing it.

--- a/docs/workflows/README.md
+++ b/docs/workflows/README.md
@@ -1,0 +1,29 @@
+# Workflow documentation
+
+This directory indexes repository workflow documentation.
+
+Use these docs for GitHub issue, pull request, validation, merge, and closure
+decisions in this chezmoi-managed dotfiles repository.
+
+## Workflow docs
+
+- [Issue workflow](./issue-workflow.md): scope contracts, acceptance criteria,
+  validation requirements, PR slicing, and out-of-scope findings.
+- [Pull request workflow](./pull-request-workflow.md): PR body expectations,
+  labels, linked issue keywords, validation evidence, risk, rollback, and review
+  readiness.
+- [Validation workflow](./validation-workflow.md): validation by touched surface,
+  evidence requirements, skipped checks, and reporting.
+- [Merge and close workflow](./merge-and-close-workflow.md): merge readiness,
+  issue closure, checkbox updates, closure comments, and rollback after merge.
+
+## Related guidance
+
+- [LLM collaboration guidance](../llm/README.md): LLM-specific routing,
+  evidence, output, review, and chezmoi template guidance.
+- [Repository agent guidance](../../AGENTS.md): repository-wide behavior
+  boundaries and validation expectations.
+- [Pull request template](../../.github/pull_request_template.md): current PR
+  body structure.
+- [Change request issue template](../../.github/ISSUE_TEMPLATE/change-request.md):
+  current scoped issue template.

--- a/docs/workflows/issue-workflow.md
+++ b/docs/workflows/issue-workflow.md
@@ -1,0 +1,169 @@
+# Issue workflow
+
+## Purpose
+
+Use issues as scope contracts for repository changes.
+
+An issue should explain the desired end state, boundaries, acceptance criteria,
+validation requirements, constraints, risks, and references before implementation
+work starts.
+
+## When to use an issue
+
+Use an issue when work:
+
+- changes repository behavior
+- changes documentation that future work depends on
+- spans multiple files
+- needs validation evidence
+- may require multiple PRs
+- needs Commander / Worker coordination
+- has explicit out-of-scope boundaries
+
+Small typo fixes may not need a dedicated issue unless they are part of a larger
+tracked effort.
+
+## Issue content requirements
+
+A useful issue should include:
+
+- goal
+- background
+- in scope
+- out of scope
+- acceptance criteria
+- validation
+- constraints
+- risks
+- references
+
+Use the current [change request issue template](../../.github/ISSUE_TEMPLATE/change-request.md)
+unless a future PR replaces it with a structured issue form.
+
+## Scope boundaries
+
+Define what will and will not be done.
+
+For dotfiles work, out-of-scope boundaries often include:
+
+- provisioning behavior
+- identity routing
+- SSH signing and agent bridging
+- generated identity files
+- Neovim, WezTerm, zsh, Git, mise, and Homebrew behavior
+- GitHub Actions semantics
+- runtime versions, tool versions, dependencies, and lockfiles
+- generated Repomix snapshots
+
+If a Worker finds useful work outside scope, it should record the finding for
+the Commander Thread instead of implementing it.
+
+## Acceptance criteria
+
+Acceptance criteria should be objective, observable, and independent.
+
+Good criteria describe repository state or behavior that can be verified.
+
+Avoid criteria that depend on intention, preference, or unstated assumptions.
+
+## Validation requirements
+
+Validation requirements should match the touched surface.
+
+Separate required checks from completed checks. Do not mark validation complete
+until evidence exists.
+
+For detailed guidance, see
+[Validation workflow](./validation-workflow.md).
+
+## One issue / one PR
+
+Use one issue / one PR when the work is small and can be completed in one
+reviewable diff.
+
+The PR may use `Closes #<issue-number>` when it fully completes the issue and
+the issue should close on merge.
+
+## One issue / multiple PRs
+
+Use one issue / multiple PRs when the work has a single goal but needs smaller
+reviewable slices.
+
+For intermediate PRs:
+
+```text
+Refs #<issue-number>
+```
+
+For the final planned PR, use a closing keyword only when it completes the
+remaining acceptance criteria:
+
+```text
+Closes #<issue-number>
+```
+
+This model supports work such as issue #132, where entry points, detailed docs,
+and template normalization are intentionally split across separate PRs.
+
+## Parent issue / sub-issues
+
+Use parent issues and sub-issues for heavier programs of work that need separate
+ownership or independent closure.
+
+A PR may close a sub-issue and reference a parent issue:
+
+```text
+Closes #<sub-issue-number>
+Refs #<parent-issue-number>
+```
+
+Close the parent only after parent-level acceptance criteria and validation are
+complete.
+
+## Commander / Worker coordination
+
+Commander Threads own:
+
+- issue topology
+- PR slicing
+- sequencing
+- cross-PR synthesis
+- final issue closure decisions
+
+Worker Threads own:
+
+- one assigned issue, sub-issue, PR, or bounded task
+- evidence review for that scope
+- proposed changes
+- validation interpretation after evidence is provided
+
+Workers should not change issue topology or close tracking issues unless
+explicitly assigned that decision.
+
+## References and evidence
+
+Use references to preserve decision traceability.
+
+Useful references include:
+
+- official documentation
+- related issues
+- related PRs
+- prior Commander decisions
+- Repomix snapshots
+- validation output
+- CI results
+
+Do not cite generated snapshots as editable source.
+
+## Out-of-scope findings
+
+When a Worker finds out-of-scope work, record:
+
+- what was found
+- why it is outside scope
+- why it may matter
+- what evidence is needed later
+- whether it should become a follow-up issue
+
+Do not mix out-of-scope work into the current PR.

--- a/docs/workflows/merge-and-close-workflow.md
+++ b/docs/workflows/merge-and-close-workflow.md
@@ -1,0 +1,160 @@
+# Merge and close workflow
+
+## Purpose
+
+Use this workflow to finish repository changes without losing traceability.
+
+A PR should be merged only after scope, validation evidence, review status, and
+issue closure behavior are clear.
+
+## Before merging
+
+Before merging, confirm:
+
+- the PR scope matches the linked issue or PR slice
+- required review is complete
+- required local validation has evidence
+- required GitHub Actions checks have passed
+- linked issue keywords are correct
+- checkboxes are not marked complete without evidence
+- out-of-scope findings are captured separately
+
+Do not merge only because a patch applies cleanly.
+
+## Merge method guidance
+
+Use the merge method that matches repository policy and the PR shape.
+
+For small, reviewable PRs with a clean final message, squash merge is usually
+appropriate.
+
+Do not use a merge method that hides validation failures, bypasses required
+checks, or obscures issue relationships.
+
+## GitHub CLI merge command
+
+Prefer long options in reusable docs:
+
+```sh
+gh pr merge <pr-number> --squash --delete-branch
+```
+
+Short options may be acceptable locally, but long options are clearer in shared
+instructions.
+
+Do not merge from a Worker Thread when the Commander Thread owns PR sequencing,
+issue closure, or cross-PR synthesis.
+
+## Closing keywords
+
+Use closing keywords only when merge should close the issue.
+
+Use `Refs #<issue-number>` when a PR contributes to an issue but does not
+complete it.
+
+Use `Closes #<issue-number>` only when a PR completes the linked issue and should
+close it on merge.
+
+For a tracking issue split across multiple PRs, only the final planned PR should
+close the issue.
+
+PR2 for issue #132 should use:
+
+```text
+Refs #132
+```
+
+It should not use `Closes #132`.
+
+## Issue checkbox updates
+
+Update issue checkboxes only when evidence exists.
+
+Acceptable evidence includes:
+
+- merged PR files
+- command output
+- CI results
+- review confirmation
+- linked PR content
+
+Do not check an item because work is planned, likely correct, or suggested by an
+LLM.
+
+## After merging
+
+After a PR is merged:
+
+- confirm whether GitHub automatically closed the intended issue
+- confirm whether the parent or tracking issue still has open criteria
+- update comments or checkboxes when evidence exists
+- delete or move on from the local branch according to repository practice
+- return to the Commander Thread when the next PR or closure decision belongs
+  there
+
+For intermediate PRs, confirm that the issue remains open and the next planned
+step is clear.
+
+## Manual issue closure
+
+Manual issue closure is appropriate only when all completion evidence exists but
+the issue was not automatically closed.
+
+Before manual closure, verify:
+
+- all acceptance criteria are complete
+- required validation evidence exists
+- related PRs are merged or intentionally abandoned
+- out-of-scope follow-up work is captured separately
+- the closure comment explains what completed the issue
+
+Do not manually close a tracking issue from a Worker Thread unless the Commander
+Thread assigns that final closure decision.
+
+## Closure comments
+
+Use closure comments to preserve traceability.
+
+A useful closure comment includes:
+
+- PRs that completed the issue
+- validation evidence used for closure
+- intentional exclusions
+- follow-up issues or deferred work
+
+Keep closure comments factual.
+
+## Failed or partial closure
+
+If a PR merges but does not complete the issue, leave the issue open and document
+the remaining work.
+
+Examples:
+
+- documentation was added but template normalization remains
+- local validation passed but CI is pending
+- a final README pointer is deferred to a later PR
+- a review finding became follow-up work
+
+Use `Refs #<issue-number>` for partial progress.
+
+## Rollback after merge
+
+If a merged PR must be reverted, the revert PR should explain:
+
+- which PR is being reverted
+- what behavior or documentation is restored
+- whether the original issue is reopened or a new issue is created
+- what validation was run for the revert
+
+For documentation-only changes, rollback is usually a normal revert. For behavior
+changes, confirm whether target state or manual cleanup is involved.
+
+## LLM-assisted merge decisions
+
+LLMs may recommend merge readiness based on provided evidence, but they must not
+claim CI passed, an issue closed, or checkboxes should be marked complete unless
+the user provides evidence or the state is directly available.
+
+For multi-PR issues, final merge and closure decisions should remain with the
+Commander Thread unless explicitly delegated.

--- a/docs/workflows/pull-request-workflow.md
+++ b/docs/workflows/pull-request-workflow.md
@@ -1,0 +1,140 @@
+# Pull request workflow
+
+## Purpose
+
+Use pull requests as reviewable units of change.
+
+A PR should show what changed, why it changed, how it was validated, what risks
+remain, how rollback works, and which issue it advances.
+
+## Before opening a PR
+
+Before opening a PR, confirm:
+
+- the branch has a clear scope
+- the diff matches the assigned issue or PR slice
+- unrelated cleanup is absent
+- generated files are not edited unless explicitly scoped
+- links in Markdown changes resolve
+- validation has been run or clearly deferred
+- the linked issue behavior is correct
+
+Use [Issue workflow](./issue-workflow.md) for PR slicing decisions.
+
+## PR body expectations
+
+Use [`.github/pull_request_template.md`](../../.github/pull_request_template.md)
+as the current PR body structure.
+
+Fill every section:
+
+- Summary
+- Why
+- Changes
+- Validation
+- Risk and rollback
+- Review notes
+- Out of scope
+- Linked issue
+
+Do not leave template comments in the final PR body.
+
+## Linked issue wording
+
+Use issue keywords deliberately.
+
+Use `Refs #<issue-number>` when the PR contributes to an issue but does not
+complete it.
+
+Use `Closes #<issue-number>` only when merging the PR should close the issue.
+
+For one issue split across multiple PRs, intermediate PRs should use:
+
+```text
+Refs #<issue-number>
+```
+
+The final planned PR may use:
+
+```text
+Closes #<issue-number>
+```
+
+Only use the closing keyword after remaining acceptance criteria are complete.
+
+The current PR template may still contain default closing-keyword wording until a
+later PR updates it. Do not modify the template unless the assigned issue or PR
+slice explicitly authorizes it.
+
+## Labels
+
+Choose labels that match repository conventions and the PR type.
+
+For GitHub default labels:
+
+- use `documentation` for documentation-only changes
+- use `enhancement` for planned workflow or tooling improvements
+- use `bug` for incorrect behavior fixes
+
+Do not add labels that imply urgency, ownership, or scope not supported by the
+issue.
+
+## Validation evidence
+
+The Validation section must report evidence, not expectations.
+
+Only check a validation item when there is command output, CI evidence, or
+explicit confirmation.
+
+Do not infer GitHub Actions success from local checks. Do not mark CI complete
+until CI actually passes.
+
+For detailed rules, see
+[Validation workflow](./validation-workflow.md).
+
+## Review readiness
+
+A PR is ready for review when:
+
+- the diff is scoped
+- the PR body explains intent and trade-offs
+- validation evidence is present or clearly pending
+- risk and rollback are documented
+- out-of-scope work is not mixed in
+- review notes call out important assumptions
+
+Draft PRs are appropriate when the scope or validation is intentionally
+incomplete.
+
+## Risk and rollback
+
+Every PR should include a rollback path.
+
+For documentation-only changes, rollback is usually reverting the PR.
+
+For behavior changes, describe what reverting restores and whether any target
+state, generated artifact, or manual cleanup is involved.
+
+Do not claim rollback is risk-free unless evidence supports it.
+
+## Out-of-scope notes
+
+Use out-of-scope notes to preserve review focus.
+
+Mention related work that was intentionally deferred, such as:
+
+- template comment normalization
+- README pointer updates assigned to a later PR
+- issue template conversion assigned to a later PR
+- broader validation automation
+- behavior-changing follow-up work
+
+Out-of-scope notes should not become hidden requirements for the current PR.
+
+## LLM-assisted PR discipline
+
+For LLM-assisted PRs, the Worker Thread may draft PR body text and recommend
+validation reporting, but it must not claim validation passed without evidence.
+
+When the PR is one slice of a larger issue, avoid closing the tracking issue
+unless explicitly assigned the final PR or closure review.

--- a/docs/workflows/validation-workflow.md
+++ b/docs/workflows/validation-workflow.md
@@ -1,0 +1,230 @@
+# Validation workflow
+
+## Purpose
+
+Use validation to prove that a change is correct for its touched surface.
+
+Validation requirements are what should be checked. Validation evidence is what
+was actually observed.
+
+Do not claim validation passed unless command output, CI evidence, or explicit
+confirmation exists.
+
+## Requirements vs evidence
+
+Keep these separate:
+
+- Required validation: checks that should be run before completion.
+- Completed validation: checks that have evidence.
+- Skipped validation: checks not run, with the reason.
+- Failed validation: checks that failed, including retry evidence if retried.
+
+Do not mark a checkbox complete because a check is expected to pass.
+
+## Baseline checks
+
+Common checks:
+
+```sh
+git diff --check
+pre-commit run --all-files
+repomix
+```
+
+Use the explicit Repomix fallback only when needed:
+
+```sh
+repomix --config repomix.config.json
+```
+
+## Documentation-only validation
+
+For documentation-only changes, usually run:
+
+```sh
+git diff --check
+pre-commit run --all-files
+```
+
+If the change adds or moves many Markdown links, also run the Markdown relative
+link helper below.
+
+If the change affects LLM routing or Repomix guidance, also run:
+
+```sh
+repomix
+```
+
+## PR2 recommended validation
+
+For the documentation PR that adds `docs/llm/` and `docs/workflows/`, use:
+
+```sh
+git diff --check
+pre-commit run --all-files
+repomix
+```
+
+Also run the Markdown relative link helper because this PR creates many new docs.
+
+Do not require `chezmoi diff` for this PR unless `.chezmoiignore.tmpl` or other
+rendered-output-sensitive template files change.
+
+## Markdown relative link validation
+
+Use this helper when documentation changes introduce repository-relative links:
+
+```sh
+python - <<'PY'
+from pathlib import Path
+import re
+
+root = Path(".").resolve()
+files = list(Path("docs").rglob("*.md")) + [
+    Path("AGENTS.md"),
+    Path("repomix-instruction.md"),
+    Path(".github/copilot-instructions.md"),
+    Path(".github/pull_request_template.md"),
+]
+
+link_re = re.compile(r"(?<!!)\[[^\]]+\]\(([^)]+)\)")
+errors = []
+
+for file in files:
+    if not file.exists():
+        continue
+    text = file.read_text()
+    for match in link_re.finditer(text):
+        target = match.group(1)
+        if (
+            target.startswith(("http://", "https://", "mailto:"))
+            or target.startswith("#")
+        ):
+            continue
+        path = target.split("#", 1)[0]
+        if not path:
+            continue
+        resolved = (file.parent / path).resolve()
+        try:
+            resolved.relative_to(root)
+        except ValueError:
+            errors.append((file, target, "outside repository"))
+            continue
+        if not resolved.exists():
+            errors.append((file, target, "missing"))
+
+if errors:
+    for file, target, reason in errors:
+        print(f"{file}: {target} -> {reason}")
+    raise SystemExit(1)
+
+print("All checked Markdown links resolve.")
+PY
+```
+
+## Repomix routing validation
+
+Run `repomix` when changes affect:
+
+- `repomix.config.json`
+- `repomix-instruction.md`
+- LLM routing docs
+- snapshot guidance
+- repository context generation
+
+Check that the command completes and that generated snapshots include the
+expected guidance without including generated `repomix-*.xml` artifacts as
+source.
+
+## Chezmoi template and rendered-output validation
+
+Use `chezmoi diff` when changes touch:
+
+- `.chezmoiignore.tmpl`
+- `.chezmoi.toml.tmpl`
+- `.chezmoiscripts/*`
+- `.chezmoitemplates/*`
+- rendered configuration templates
+- source files where whitespace trimming affects rendered output
+
+Use `chezmoi verify` when checking target drift against source-state
+expectations.
+
+Do not require full `chezmoi init --source="$PWD" --apply` unless the issue
+explicitly justifies heavyweight apply validation in a safe environment.
+
+## Identity-sensitive validation
+
+For changes touching identity, 1Password, SSH signing, SSH agent bridging, or
+generated identity files, validation must be explicitly scoped.
+
+Potential checks may include:
+
+- `chezmoi diff`
+- `mise run doctor:identity`
+- targeted file inspection
+- CI evidence when applicable
+
+Do not request secret values or unredacted private key material.
+
+## Neovim validation
+
+For Neovim behavior changes, choose checks that match the change.
+
+Potential checks include:
+
+- `mise run integrate:nvim`
+- `mise run doctor:nvim`
+- targeted `nvim --headless` commands
+- inspection of `dot_config/nvim/lazy-lock.json` when plugin state changes
+
+Do not run Neovim checks for unrelated documentation-only changes.
+
+## WezTerm validation
+
+For WezTerm template or WSL sync changes, use rendered-output inspection and
+targeted commands appropriate to the environment.
+
+Do not assume macOS and WSL behavior are equivalent.
+
+## zsh and shell validation
+
+For shell changes, consider:
+
+- `pre-commit run --all-files`
+- `shfmt` through pre-commit for pure shell files
+- rendered shell inspection for `.tmpl` files
+- targeted shell syntax checks when appropriate
+
+Templates may not be valid shell before rendering, so avoid applying pure shell
+linters to template source without understanding the surface.
+
+## mise and toolchain validation
+
+Use `mise run doctor` when changes touch setup instructions, toolchain behavior,
+mise tasks, rendered configuration behavior, or validation entry points.
+
+Do not require `mise run doctor` for documentation-only changes that do not
+alter setup, toolchain, rendered configuration, or task behavior.
+
+## GitHub Actions validation
+
+For GitHub Actions changes, local validation is not enough.
+
+Use:
+
+- YAML syntax checks through pre-commit when available
+- PR GitHub Actions results
+- focused review of changed workflow semantics
+
+Do not claim CI passed until the user provides CI evidence.
+
+## Avoid heavyweight checks by default
+
+Avoid heavyweight checks when lighter evidence is sufficient.
+
+Examples:
+
+- Do not require `chezmoi diff` for pure `docs/` changes.
+- Do not require `mise run doctor` for docs that do not change setup behavior.
+- Do not require full apply flows for documentation or router-only edits.

--- a/repomix-instruction.md
+++ b/repomix-instruction.md
@@ -5,6 +5,10 @@ this repository.
 
 Use [AGENTS.md](./AGENTS.md) as the primary repository-wide guidance.
 
+Use [docs/llm/README.md](./docs/llm/README.md) and
+[docs/workflows/README.md](./docs/workflows/README.md) for detailed LLM
+collaboration and workflow guidance.
+
 This repository is a chezmoi-managed dotfiles source-state repository. Preserve
 existing provisioning, identity, editor, shell, Git, mise, Homebrew, and GitHub
 Actions behavior unless the assigned issue explicitly scopes a change.


### PR DESCRIPTION
## Summary

Add detailed LLM collaboration and workflow documentation for this
chezmoi-managed dotfiles repository.

## Why

Issue #132 is split across multiple pull requests. PR 1 established the thin
repository entry points and canonical Repomix routing. This PR adds the detailed
LLM and workflow guidance that those entry points route to, while preserving
existing provisioning behavior.

## Changes

- Add `docs/llm/` guidance for:
  - LLM routing
  - local-state inspection
  - diff output guardrails
  - commit message guidelines
  - review protocol
  - chezmoi template guidelines
- Add `docs/workflows/` guidance for:
  - issue workflow
  - pull request workflow
  - validation workflow
  - merge and close workflow
- Add minimal links from:
  - `AGENTS.md`
  - `.github/copilot-instructions.md`
  - `repomix-instruction.md`

## Validation

- [x] Markdown relative link check
  - `All checked Markdown links resolve.`
- [x] `git diff --check`
  - No output.
- [x] `pre-commit run --all-files`
  - Passed:
    - `trim trailing whitespace`
    - `fix end of files`
    - `check yaml`
    - `check for added large files`
    - `shfmt`
    - `stylua`
- [x] `repomix`
  - Packed successfully to `repomix-dotfiles.xml`.
  - Security check reported no suspicious files.
- [x] GitHub Actions CI passes

## Risk and rollback

**Risk:** The new documentation could introduce incorrect routing guidance or
broken repository-relative links.

**Rollback:** Revert this pull request to remove the new documentation set and
restore the thin router files to their PR 1 state.

## Review notes

- This PR is documentation-only and behavior-preserving.
- Router file changes are intentionally minimal.
- This PR does not modify `.github/pull_request_template.md`,
  `.github/ISSUE_TEMPLATE/change-request.md`, `README.md`,
  `.chezmoiignore.tmpl`, `repomix.config.json`, or any rendered-output-sensitive
  chezmoi templates.
- `chezmoi diff` and `mise run doctor` were not run because this PR does not
  change rendered target behavior, setup behavior, toolchain behavior, or
  dotfiles runtime behavior.

## Out of scope

- Do not convert `.github/ISSUE_TEMPLATE/change-request.md` to YAML.
- Do not update `.github/pull_request_template.md`.
- Do not update `README.md`.
- Do not restructure or merge `ARCHITECTURE.md`.
- Do not refactor existing template comments.
- Do not change provisioning, identity, shell, editor, Git, mise, Homebrew,
  runtime, toolchain, dependencies, lockfiles, or GitHub Actions behavior.
- Do not close issue #132 from this intermediate PR.

## Linked issue

Refs #132
