### PR TITLE
docs(llm): add comment hygiene guidance

### DIFF
--- a/.chezmoiscripts/run_onchange_before_00-backup-legacy-dots.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_00-backup-legacy-dots.sh.tmpl
@@ -1,11 +1,12 @@
 #!/bin/sh
 # [chezmoi-script]: L0 (POSIX Shell) Tiering
 # [Rationale]: Guaranteed execution even without Zsh/Mise environment.
-# [Staff Engineer Note]: Refactored to eliminate Zsh-specific array/typeset syntax.
-# [LLM Context]: This script is already strictly idempotent through lazy evaluation.
-#                The BACKUP_ROOT is ONLY created if a target file physically exists.
-#                Do NOT propose refactoring to prevent empty directory creation.
-
+{{/*
+Source-only maintainer note:
+This script intentionally stays POSIX-compatible. BACKUP_ROOT is created lazily
+only after a legacy target is found, so do not refactor it into eager directory
+creation.
+*/}}
 set -eu
 
 BACKUP_ROOT="{{ .paths.xdg_state }}/chezmoi/backup/legacy_$(date +%Y%m%d_%H%M%S)"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,11 @@ repository evidence shows a conflict. Report the conflict instead of guessing.
 
 For detailed LLM and workflow guidance, use
 [docs/llm/README.md](./docs/llm/README.md) and
-[docs/workflows/README.md](./docs/workflows/README.md). Keep this file as the
-repository-wide entry point rather than duplicating detailed process rules here.
+[docs/workflows/README.md](./docs/workflows/README.md). For comment hygiene and
+comment routing, use
+[docs/llm/comment-guidelines.md](./docs/llm/comment-guidelines.md). Keep this
+file as the repository-wide entry point rather than duplicating detailed process
+rules here.
 
 ## Behavior preservation
 

--- a/docs/llm/README.md
+++ b/docs/llm/README.md
@@ -15,6 +15,8 @@ provisioning behavior.
   contents, command output, validation output, CI evidence, and Repomix snapshots.
 - [Diff output guardrails](./diff-output-guardrails.md): safe patch, heredoc,
   guarded-script, and non-patch output formats.
+- [Comment guidelines](./comment-guidelines.md): comment usefulness,
+  source-only versus target-visible routing, labels, and LLM maintenance notes.
 - [Commit message guidelines](./commit-message-guidelines.md): Conventional
   Commit structure, issue reference rules, and validation claim discipline.
 - [Review protocol](./review-protocol.md): scope review, behavior preservation,

--- a/docs/llm/comment-guidelines.md
+++ b/docs/llm/comment-guidelines.md
@@ -1,0 +1,194 @@
+# Comment guidelines
+
+## Purpose
+
+Use this guide when adding, changing, or reviewing comments in repository source
+state.
+
+Good comments explain durable maintenance context that is hard to recover from
+the code alone. They should help humans and LLM-assisted workflows preserve
+behavior, validate the right surface, and avoid stale assumptions.
+
+This guide is reusable across repositories. The examples use this dotfiles
+repository because it is a chezmoi-managed source-state repository.
+
+## What comments should explain
+
+Keep comments that explain:
+
+- non-obvious behavior, ordering, or compatibility constraints
+- safety boundaries, idempotency, or destructive-operation guards
+- source-state versus rendered-target differences
+- generated-file warnings and regeneration paths
+- trigger hashes, extraction patterns, or other tool metadata
+- external specifications or primary references
+- intentional use of deprecated, surprising, or target-specific APIs
+
+Avoid comments that only restate nearby code.
+
+```sh
+# Bad: restates the command.
+mkdir -p "$BACKUP_ROOT"
+
+# Better: explains the behavior boundary.
+# BACKUP_ROOT is created only after a legacy target is found.
+mkdir -p "$BACKUP_ROOT"
+```
+
+## Comments to remove or rewrite
+
+Remove or rewrite comments that:
+
+- describe old migrations without current maintenance value
+- claim authority without a concrete technical referent
+- use time-sensitive claims such as "modern", "current", or a year as proof
+- duplicate repository policy that belongs in durable documentation
+- provide LLM-only guidance in files rendered to users
+- obscure higher-signal comments with decorative labels
+
+Prefer concrete technical wording over status-signaling terms.
+
+Avoid terms such as `Sovereign`, `Zero-Trust`, `SOTA`, `Best Practice`,
+`Staff Engineer Note`, and year-based authority claims unless the comment names
+the precise boundary, standard, threat model, or source that makes the term true.
+
+## Source-only versus target-visible comments
+
+Choose the comment syntax for the audience.
+
+Use source-only comments when the note is for maintainers editing source state.
+Use target-language comments when the rendered file should carry the note.
+
+In any generated, templated, or rendered repository, ask two questions:
+
+1. Who needs this note?
+2. In which file will that person read it?
+
+If the answer is "a repository maintainer", keep the note in source state. If the
+answer is "a user inspecting the rendered file", render the note.
+
+## Chezmoi and Go Template routing
+
+For chezmoi templates, use Go Template comments for source-state-only notes:
+
+```gotemplate
+{{/*
+Source-only maintainer note:
+This branch exists to preserve rendered shell compatibility.
+*/}}
+```
+
+Use target-language comments only when the rendered target should include the
+explanation:
+
+```sh
+# This directory is created lazily to avoid empty backup directories.
+```
+
+Do not change Go Template whitespace trimming as incidental cleanup. Template
+comments and `{{-` / `-}}` trimming can affect rendered output by joining lines,
+moving shebangs, or changing blank lines.
+
+## LLM-assisted maintenance notes
+
+LLM-specific instructions should usually live in durable docs such as
+`docs/llm/`, not in rendered configuration files.
+
+Use source-only comments only when a local warning is needed at the exact edit
+site. Good examples include:
+
+- "Do not make this eager; laziness prevents empty backup directories."
+- "This branch is source-state-only and must not render into the target file."
+- "This target-language comment is intentionally rendered for user inspection."
+
+Do not put prompts, review checklists, historical debate, or model-specific
+instructions into rendered files.
+
+## Label guidance
+
+Labels are useful when they create a real maintenance distinction.
+
+Useful labels include:
+
+- `[Security]` for concrete security boundaries or required permissions
+- `[Reference]` for official documentation or primary source links
+- `[Trigger]` for hashes or inputs that intentionally retrigger convergence
+- `[Generated]` for files or blocks that must not be hand-edited
+- tool-owned metadata such as mise task comments and Renovate extraction comments
+
+Labels often add noise when they only decorate a normal rationale. In those
+cases, prefer a plain sentence.
+
+Avoid broad labels such as `[Architecture]` and `[Rationale]` when the label does
+not add information beyond the comment body.
+
+## Preserve functional tool comments
+
+Do not remove comments that tools parse or humans use as operational metadata.
+
+Examples include:
+
+- mise task metadata such as `# [MISE] description="..."`
+- Renovate extraction or dependency comments
+- generated-file headers
+- trigger hashes in chezmoi scripts
+- references that explain why an external specification is required
+
+When in doubt, inspect the tool documentation or search the repository for the
+comment pattern before changing it.
+
+## Examples from this repository
+
+### Source-only idempotency note in a chezmoi script
+
+A note about lazy backup directory creation is useful to maintainers, but it
+should not render into the target shell script:
+
+```gotemplate
+{{/*
+Source-only maintainer note:
+BACKUP_ROOT is created lazily only after a legacy target is found.
+*/}}
+```
+
+### Target-visible shell comment
+
+A POSIX compatibility note can remain visible when it helps someone reading the
+rendered shell script:
+
+```sh
+# POSIX-compliant list of targets
+set -- \
+  "$HOME/.zshrc" \
+  "$HOME/.gitconfig"
+```
+
+### Trigger comment
+
+A hash comment in a chezmoi script is useful because it explains why a script
+reruns when an included source file changes:
+
+```sh
+# [Trigger]: WezTerm Config Hash: {{ include "dot_config/wezterm/wezterm.lua.tmpl" | sha256sum }}
+```
+
+### Tool metadata comment
+
+A mise task description is functional metadata and must be preserved:
+
+```sh
+# [MISE] description="Verify identity routing and SSH agent health"
+```
+
+## Review checklist
+
+Before changing comments, verify:
+
+- the intended audience is clear
+- source-only notes do not render into target files
+- rendered comments help someone reading the target file
+- labels carry a real distinction
+- unsupported authority-signaling terms are removed or made precise
+- functional tool comments are preserved
+- references point to official documentation or primary sources when possible
+- behavior, generated output semantics, and validation scope are unchanged

--- a/docs/llm/routing.md
+++ b/docs/llm/routing.md
@@ -126,6 +126,13 @@ Prefer `docs/llm/` or `docs/workflows/` for durable guidance. Validate with
 `git diff --check`, `pre-commit run --all-files`, Markdown link checks, and
 `repomix` when LLM routing or snapshot guidance changes.
 
+### Comment and reference hygiene changes
+
+Use [Comment guidelines](./comment-guidelines.md) before changing comments,
+references, or labels. Preserve comments that carry operational, safety,
+generated-file, trigger, or tool-metadata meaning. Do not mix broad vocabulary
+cleanup into a Worker scope unless the assigned issue explicitly includes it.
+
 ### Chezmoi template changes
 
 Inspect source-state and rendered-target impact. Be careful with Go Template

--- a/repomix-instruction.md
+++ b/repomix-instruction.md
@@ -7,7 +7,9 @@ Use [AGENTS.md](./AGENTS.md) as the primary repository-wide guidance.
 
 Use [docs/llm/README.md](./docs/llm/README.md) and
 [docs/workflows/README.md](./docs/workflows/README.md) for detailed LLM
-collaboration and workflow guidance.
+collaboration and workflow guidance. Use
+[docs/llm/comment-guidelines.md](./docs/llm/comment-guidelines.md) when reviewing
+or changing comments and references.
 
 This repository is a chezmoi-managed dotfiles source-state repository. Preserve
 existing provisioning, identity, editor, shell, Git, mise, Homebrew, and GitHub


### PR DESCRIPTION
## Summary

Add reusable comment hygiene guidance for repository source-state comments and
fix the highest-risk rendered comment routing issue in the legacy dot backup
chezmoi script.

## Why

Issue #136 splits comment hygiene work across multiple PRs. This PR establishes
the durable guidance needed before broader vocabulary cleanup, while keeping the
change behavior-preserving and limited to PR 2 scope.

## Changes

- Add `docs/llm/comment-guidelines.md`.
- Link the new guide from thin LLM routing entry points:
  - `AGENTS.md`
  - `docs/llm/README.md`
  - `docs/llm/routing.md`
  - `repomix-instruction.md`
- Convert the backup script's maintainer-only idempotency note to a Go Template
  comment so it no longer renders into the target shell script.
- Leave `.github/copilot-instructions.md` unchanged because it already routes to
  `docs/llm/README.md`.

## Validation

- [x] `git diff --check`
- [x] `pre-commit run --all-files`
- [ ] Markdown relative links resolve, when Markdown links change
  - Not run separately; repository-relative links are limited to existing files
    added or already present in this PR.
- [x] `repomix`, when LLM guidance or snapshot routing changes
- [ ] `mise run doctor`, when setup, toolchain, rendered config, or task behavior changes
  - Not run; this PR does not change setup, toolchain, rendered config behavior,
    or mise task semantics.
- [ ] GitHub Actions CI passes
  - Pending after PR creation.
- [x] `chezmoi diff`
  - Reviewed rendered output for `.chezmoiscripts/00-backup-legacy-dots.sh`.
  - Confirmed `Staff Engineer Note` and `LLM Context` no longer render.
  - Confirmed executable shell behavior remains unchanged.

## Risk and rollback

**Risk:** The main risk is accidentally hiding useful maintainer context or
changing rendered shell output while moving comments.

**Rollback:** Revert this PR. That restores the previous guidance state and the
previous rendered comments in the backup script without requiring manual target
state cleanup.

## Review notes

- This PR intentionally keeps router files thin and moves detailed rules into
  `docs/llm/comment-guidelines.md`.
- The backup script change is comment-routing only. It does not change the
  shebang, shell options, target list, backup directory naming, lazy backup
  directory creation, file/directory detection conditions, move commands, or
  command output.
- `chezmoi diff` also showed an unrelated local rendered Neovim URL drift from
  earlier PR 1 work. That drift is not part of this PR's source diff.

## Out of scope

- Broad cleanup of `Sovereign`, `Zero-Trust`, `SOTA`, `Best Practice`,
  `[Architecture]`, or `[Rationale]`.
- Neovim comment vocabulary cleanup.
- WezTerm, SSH, zsh, mise, Homebrew, GitHub Actions, provisioning, identity, or
  toolchain behavior changes.
- Editing generated `repomix-*.xml` files.

## Linked issue

Refs #136
