### PR TITLE
Normalize comment vocabulary

### DIFF
--- a/.bootstrap-identity.sh
+++ b/.bootstrap-identity.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
-# [Architecture]: Tier -1 & 0 Bootstrapping (Sovereign Provisioning)
-# [Rationale]: Pure POSIX script to ensure 'mise' exists and is correctly resolved.
+# Tier -1 and Tier 0 bootstrap ensure mise exists before chezmoi hooks run.
+# POSIX shell keeps this path available before the managed shell environment exists.
 # [Reference]: https://mise.jdx.dev/getting-started.html
 # [Reference]: https://mise.jdx.dev/configuration.html#mise-trusted-config-paths
 
@@ -15,10 +15,10 @@ LOCAL_BIN="$HOME/.local/bin"
 MISE_SHIMS="$HOME/.local/share/mise/shims"
 mkdir -p "$LOCAL_BIN"
 
-# [Architecture]: Inject shims and local bin into PATH for hook execution.
+# Add mise shims and the local bin directory for hook execution.
 export PATH="$MISE_SHIMS:$LOCAL_BIN:$PATH"
 
-# [Architecture]: Deterministic Binary Discovery
+# Resolve the mise binary before installing it as a fallback.
 if command -v mise > /dev/null 2>&1; then
   MISE_BIN=$(command -v mise)
 else
@@ -35,21 +35,21 @@ else
 fi
 
 # --- Phase: Tier 0 (Environment Convergence) ---
-# [Rationale]: Suppress interactive prompts and enable deterministic bootstrapping.
+# Suppress interactive prompts during bootstrap.
 export MISE_YES=1
 export MISE_QUIET=1
 
-# [Architecture]: Pre-emptive Trust Assertion
-# [Rationale]: Whitelist the source directory to prevent interactive "Trust this file?" prompts.
+# Trust the source directory before running install.
+# This prevents interactive "Trust this file?" prompts.
 export MISE_TRUSTED_CONFIG_PATHS="$HOME/.local/share/chezmoi"
 
-# [Architecture]: Strict Dependency Isolation (Sandboxing)
+# Use a temporary mise config so bootstrap dependencies stay isolated.
 _MISE_SANDBOX=$(mktemp -d)
 trap 'rm -rf "$_MISE_SANDBOX"' EXIT
 export MISE_GLOBAL_CONFIG_FILE="$_MISE_SANDBOX/config.toml"
 
-# [Architecture]: Assert Trust on the repository state
+# Trust the repository source state before installing tools.
 "$MISE_BIN" trust "$HOME/.local/share/chezmoi"
 
-# [Rationale]: Silence on success. No echo is emitted unless an error occurs.
+# Stay silent on success; only errors should produce output.
 env XDG_CONFIG_HOME="$_MISE_SANDBOX" "$MISE_BIN" install

--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -29,14 +29,14 @@ sourceDir = {{ .chezmoi.sourceDir | quote }}
 {{-   $brew_prefix = "/home/linuxbrew/.linuxbrew" -}}
 {{- end -}}
 
-{{- /* --- 2. Sovereign Identity Verification (Tier -2 Assertion) --- */}}
+{{- /* --- 2. Identity prerequisite checks (Tier -2 assertion) --- */}}
 {{- $local_bin := joinPath $home ".local/bin" -}}
 {{- $mise_bin := joinPath $local_bin "mise" -}}
 {{- if not (stat $mise_bin) -}}
 {{-   $mise_bin = lookPath "mise" | default $mise_bin -}}
 {{- end -}}
 
-{{- /* [Architecture]: Resolve op binary path without speculation */}}
+{{- /* Resolve op binary path from the current platform without guessing. */}}
 {{- $op_bin := "" -}}
 {{- if $is_wsl -}}
 {{-   $win_op := output "powershell.exe" "-NoProfile" "-NonInteractive" "-Command" "(Get-Command op.exe -ErrorAction SilentlyContinue).Source | Write-Host -NoNewline" -}}
@@ -113,7 +113,7 @@ sourceDir = {{ .chezmoi.sourceDir | quote }}
 {{-   $ssh_auth_sock = joinPath $home ".1password/agent.sock" -}}
 {{- end -}}
 
-{{- /* [Architecture]: Deterministic Signature Helper Resolution (Cross-Platform) */ -}}
+{{- /* Resolve the SSH signing helper for the current platform. */ -}}
 {{- $op_sign := "" -}}
 {{- if eq $osid "darwin" -}}
 {{-   $op_sign = "/Applications/1Password.app/Contents/MacOS/op-ssh-sign" -}}

--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -1,5 +1,5 @@
 # =============================================================================
-# [Architecture]: Declarative Package Schema (Zero-Toil Edition)
+# Declarative package schema for workstation provisioning.
 # =============================================================================
 packages:
   headless:

--- a/.chezmoidata/tools.yaml
+++ b/.chezmoidata/tools.yaml
@@ -1,6 +1,6 @@
 # =============================================================================
-# [Architecture]: Hermetic Toolchain Integrity (Sovereign Tier 1+)
-# [Rationale]: Managed via mise global config. Versions locked via Renovate.
+# Toolchain versions are managed through mise global configuration.
+# Renovate tracks versions through inline metadata comments below.
 # [Reference]: https://mise.jdx.dev/dev-tools/backends/
 # =============================================================================
 
@@ -16,7 +16,7 @@ mise_tools:
   "go": "1.26.2" # renovate: datasource=golang-version
   "aqua:astral-sh/uv": "0.11.8" # renovate: datasource=github-releases packageName=astral-sh/uv
 
-  # --- 2. Sovereign Identity & VCS ---
+  # --- 2. Identity and VCS ---
   "aqua:cli/cli": "2.92.0" # renovate: datasource=github-releases packageName=cli/cli
   "aqua:jesseduffield/lazygit": "0.61.1" # renovate: datasource=github-releases packageName=jesseduffield/lazygit
   "cargo:git-absorb": "0.9.0" # renovate: datasource=crate packageName=git-absorb
@@ -27,7 +27,7 @@ mise_tools:
   "pipx:neovim/pynvim": "0.6.0" # renovate: datasource=github-releases packageName=neovim/pynvim
   "npm:neovim": "5.4.0" # renovate: datasource=npm packageName=neovim
 
-  # --- 4. SOTA Development ---
+  # --- 4. Development Tooling ---
   "aqua:tree-sitter/tree-sitter": "0.26.8" # renovate: datasource=github-releases packageName=tree-sitter/tree-sitter
   "aqua:pre-commit/pre-commit": "4.6.0" # renovate: datasource=github-releases packageName=pre-commit/pre-commit
   "pipx:pytest": "9.0.3" # renovate: datasource=pypi packageName=pytest
@@ -69,7 +69,7 @@ mise_tools:
   "terragrunt": "1.0.3" # renovate: datasource=github-releases packageName=gruntwork-io/terragrunt
 
   "aqua:aws/aws-cli": "2.34.34" # renovate: datasource=github-releases packageName=aws/aws-cli
-  # [Rationale]: gcloud (Google Cloud SDK) follows a proprietary release channel.
+  # gcloud (Google Cloud SDK) follows a proprietary release channel.
   # Automated tracking via GitHub is not feasible; requires manual intervention.
   "gcloud": "565.0.0"
 

--- a/.chezmoiexternal.toml.tmpl
+++ b/.chezmoiexternal.toml.tmpl
@@ -1,8 +1,8 @@
 {{- /* [Reference]: https://www.chezmoi.io/reference/special-files/chezmoiexternal-format/ */ -}}
-# =============================================================================
-# [Architecture]: Legacy Purge | Phase 18 Deterministic Edition
-# [Rationale]: Elimination of redundant binary management.
-# =============================================================================
+{{/*
+Source-only maintainer note:
+External resources are limited to assets that are not managed by package managers.
+*/}}
 
 {{/* 1. Platform Normalization */ -}}
 {{- $os_std := "linux" -}}
@@ -23,15 +23,13 @@
     path = "win32yank.exe"
 {{- end }}
 
-# [Architecture]: Deterministic bat Themes
-# [Rationale]: Ensure Catppuccin Mocha is available for delta/bat without manual intervention.
+{{/* Ensure Catppuccin Mocha is available for delta and bat without manual setup. */}}
 [".config/bat/themes/Catppuccin Mocha.tmTheme"]
     type = "file"
     url = "https://github.com/catppuccin/bat/raw/main/themes/Catppuccin%20Mocha.tmTheme"
     refreshPeriod = "168h"
 
-# [Architecture]: Sovereign Completion Assets (SSOT)
-# [Rationale]: Decouples completion definitions from binary packages and guarantees cross-platform parity.
+{{/* Completion definitions are fetched separately from binary packages for cross-platform parity. */}}
 [".config/zsh/completions/_eza"]
     type = "file"
     url = "https://raw.githubusercontent.com/eza-community/eza/main/completions/zsh/_eza"

--- a/.chezmoiignore.tmpl
+++ b/.chezmoiignore.tmpl
@@ -1,9 +1,8 @@
 {{- /* [Reference]: https://www.chezmoi.io/reference/special-files/chezmoiignore/ */ -}}
-# =============================================================================
-# [Architecture]: Deterministic Target Ignore Protocol (Zero-Drift)
-# [Rationale]: White-list first approach for managed Infrastructure directories.
-# Ensures declarative directory existence while ignoring dynamic side-effects.
-# =============================================================================
+{{/*
+Source-only maintainer note:
+Ignore dynamic target files while preserving directories that chezmoi manages declaratively.
+*/}}
 
 # --- 1. Secret & Cryptographic Boundaries ---
 **/.ssh/id_*
@@ -11,14 +10,16 @@
 **/.ssh/known_hosts*
 **/.ssh/*.backup
 .gnupg/**
-# [Rationale]: Ignore dynamic socket noise but preserve the base directory.
+{{/* Ignore dynamic socket noise but preserve the base directory. */}}
 .1password/**
 !.1password/
 !.1password/.keep
 
 # --- 2. Transient Cache & State Directories ---
-# [Rationale]: Declarative directory structure (via .keep) is managed by chezmoi.
-# Files generated inside (e.g., completions, history) are ignored.
+{{/*
+Declarative directory structure is managed through .keep files.
+Generated files inside these directories are ignored.
+*/}}
 .cache/**
 !.cache/
 !.cache/zsh/
@@ -50,7 +51,7 @@ package-lock.json
 pnpm-lock.yaml
 
 # --- 4. Repository Orchestration (Strict Isolation) ---
-# [Rationale]: Do NOT deploy repository management files to $HOME.
+{{/* Do not deploy repository management files to $HOME. */}}
 README.md
 LICENSE
 ARCHITECTURE.md
@@ -70,8 +71,10 @@ renovate.json5
 # --- 5. OS-Specific Overrides ---
 {{ if ne .osid "darwin" -}}
 {{- if not .is_wsl }}
-# [Rationale]: The WezTerm launcher shim is only valid on macOS and WSL.
-# Plain Linux and CI runners should not manage this target.
+{{/*
+The WezTerm launcher shim is only valid on macOS and WSL.
+Plain Linux and CI runners should not manage this target.
+*/}}
 .local/bin/wezterm
 {{- end }}
 Library/**

--- a/.chezmoiremove.tmpl
+++ b/.chezmoiremove.tmpl
@@ -1,36 +1,37 @@
-# =============================================================================
-# [Architecture]: Chezmoi Removal Manifest (Target-Path Convention)
-# [Rationale]: Patterns below MUST match the TARGET path (relative to $HOME).
-# =============================================================================
+{{/*
+Source-only maintainer note:
+Patterns below must match target paths relative to $HOME.
+*/}}
 
 .gitconfig
 .vale.ini
 
-# [Architecture]: Legacy Shell Purge (XDG Purism)
+{{/* Remove legacy shell startup files superseded by XDG-routed configuration. */}}
 .zshrc
 .bashrc
 .bash_profile
 .profile
 .zshrc2
 
-# [Architecture]: Completion Cache Purge
-# [Rationale]: Prevents Zsh from falling back to default home-dir dumps,
-# which causes significant 'System' time overhead during compaudit.
+{{/*
+Remove completion cache files that can make Zsh fall back to home-directory dumps.
+Those dumps increase compaudit overhead.
+*/}}
 .zcompdump*
 .cache/zsh/completions/_hyperfine
 
-# [Architecture]: Neovim Components Purge (2026 SOTA Migration)
+{{/* Remove legacy Neovim component paths from previous editor configurations. */}}
 .config/nvim/lua/plugins/fzf.lua
 
-# [Architecture]: Zero-Trust Identity Purge (Phase 50 Refactor)
+{{/* Remove legacy identity files superseded by generated Git identity includes. */}}
 .gitconfig.local
 .config/git/config_personal
 
-# [Architecture]: Legacy & Unidentified Artifact Purge
+{{/* Remove legacy artifact paths that should not remain in the target home directory. */}}
 --request
 
-# [Architecture]: Vale XDG Migration Purge (Phase 22)
+{{/* Remove the legacy Vale config path after XDG migration. */}}
 .config/vale/.vale.ini
 
-# [Architecture]: Agent Scoping Path Correction
+{{/* Remove the previous 1Password agent config path after scoped path correction. */}}
 Library/Group Containers/2BUA8C4S2C.com.1password/Library/Application Support/1Password/ssh/agent.toml

--- a/.chezmoiscripts/run_once_before_10-setup-workspace.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_10-setup-workspace.sh.tmpl
@@ -1,6 +1,6 @@
 #!/bin/zsh
 # [chezmoi-script]: Source: '.chezmoiscripts/run_...' vs Dry-run: '.chezmoiscripts/...'
-# [Rationale]: Guarantee the existence of all dynamically routed workspaces.
+# Ensure all dynamically routed workspace directories exist before later scripts run.
 
 set -euo pipefail
 
@@ -18,7 +18,7 @@ echo "📁 [Workspace] Provisioning dynamically routed workspace directories..."
 # [Policy]: Target mapping for {{ $name }}
 RAW_DIR="{{ $normalized_dir }}"
 
-# [Architecture]: Strip wildcard suffixes (e.g., /Jitera*) to safely resolve the base directory
+# Strip wildcard suffixes (e.g., /Jitera*) to safely resolve the base directory.
 BASE_DIR="${RAW_DIR%%\**}"
 
 if [[ ! -d "$BASE_DIR" ]]; then

--- a/.chezmoiscripts/run_onchange_after_20-setup-runtimes.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_20-setup-runtimes.sh.tmpl
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
 {{/* [Reference]: https://www.chezmoi.io/user-guide/use-scripts-to-perform-actions/ */}}{{ "" -}}
-# [Architecture]: Runtime Convergence Engine (Mise Delegate)
+# Runtime convergence is delegated to mise after chezmoi applies source state.
 # [Trigger]: config.toml.tmpl hash: {{ include "dot_config/mise/config.toml.tmpl" | sha256sum }}
 # [Trigger]: tools.yaml hash: {{ include ".chezmoidata/tools.yaml" | sha256sum }}
 
 set -euo pipefail
 
-# [Architecture]: Subshell Context Isolation
-# [Rationale]: Path injection is required here because this subshell executes
-# before Zsh initialization is fully bootstrapped with the new configuration.
+# This script runs before the new Zsh environment is fully initialized.
+# PATH injection is required because this subshell executes before Zsh bootstrap completes.
 export PNPM_HOME="{{ .paths.xdg_data }}/pnpm"
 export PATH="$PNPM_HOME:{{ .paths.home }}/.local/bin:$PATH"
 
@@ -21,10 +20,10 @@ fi
 
 echo "📦 [Phase 20] Executing Runtime Convergence via Mise..."
 
-# [Architecture]: Phase 1 - Tool Installation (Idempotent)
+# Phase 1 installs declared tools idempotently.
 "$MISE_BIN" install
 
-# [Architecture]: Phase 2 - Task Orchestration (Idempotent Setup)
+# Phase 2 runs the idempotent setup task graph.
 "$MISE_BIN" run setup
 
 echo "✅ [Phase 20] Runtime convergence complete."

--- a/.chezmoiscripts/run_onchange_after_21-generate-completions.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_21-generate-completions.sh.tmpl
@@ -1,6 +1,6 @@
 #!/bin/zsh
-# [Architecture]: Compile-time Completion & Init Engine (Hardened Phase)
-# [Rationale]: Optimized for startup speed. Pure asset generation logic.
+# Generate static Zsh completions and init assets during convergence.
+# Prebuilt assets keep interactive shell startup fast.
 # [Trigger]: Ecosystem Schema: {{ include ".chezmoidata/tools.yaml" | sha256sum }}
 
 set -euo pipefail
@@ -97,7 +97,7 @@ EOF
 fi
 
 # --- Phase 4: Unified Asset Compilation ---
-# [Rationale]: Use deterministic paths and verify readability before zcompile.
+# Use managed paths and verify readability before zcompile.
 # Generated assets from third-party CLIs may contain bashisms that fail Zsh's strict AOT parser.
 # We gracefully catch compilation failures to allow JIT parsing fallback without breaking convergence.
 local -a compile_targets
@@ -115,7 +115,7 @@ for f in "${compile_targets[@]}"; do
   fi
 done
 
-# --- Phase 5: Sovereign Cache Invalidation ---
+# --- Phase 5: Completion Cache Invalidation ---
 ZSH_CACHE_DIR="{{ .paths.xdg_cache }}/zsh"
 local -a stale_dumps
 stale_dumps=("$ZSH_CACHE_DIR"/zcompdump*(N) "${ZDOTDIR:-$HOME}"/.zcompdump*(N))

--- a/.chezmoiscripts/run_onchange_after_22-bat-cache.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_22-bat-cache.sh.tmpl
@@ -1,6 +1,6 @@
 #!/bin/zsh
 {{ "" -}}
-# [Architecture]: bat Syntax Cache Convergence (Mise Delegate)
+# Delegate bat syntax cache convergence to mise-managed tooling.
 # [Trigger]: Theme Hash: {{ include (joinPath .paths.home ".config/bat/themes/Catppuccin Mocha.tmTheme") | sha256sum }}
 {{/* [Reference]: https://www.chezmoi.io/user-guide/use-scripts-to-perform-actions/ */}}{{ "" -}}
 

--- a/.chezmoiscripts/run_onchange_after_22-vale-sync.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_22-vale-sync.sh.tmpl
@@ -1,6 +1,6 @@
 #!/bin/zsh
 {{ "" -}}
-# [Architecture]: Deterministic Prose Style Convergence (Mise Delegate)
+# Delegate prose style synchronization to mise-managed Vale tooling.
 # [Trigger]: Vale Config: {{ include "dot_config/vale/vale.ini.tmpl" | sha256sum }}
 {{/* [Reference]: https://www.chezmoi.io/user-guide/use-scripts-to-perform-actions/ */}}{{ "" -}}
 

--- a/.chezmoiscripts/run_onchange_after_23-compile-pbfile.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_23-compile-pbfile.sh.tmpl
@@ -1,6 +1,6 @@
 #!/bin/zsh
-# [Architecture]: Atomic Native Compilation
-# [Rationale]: Ensures the Swift clipboard bridge is compiled for the local architecture (AOT).
+# Compile the native clipboard bridge for the local architecture.
+# Ahead-of-time compilation keeps pbfile available as a local executable.
 # [Trigger]: pbfile.swift Hash: {{ include "dot_local/share/pbcopy/pbfile.swift" | sha256sum }}
 
 {{ if eq .osid "darwin" -}}

--- a/.chezmoiscripts/run_onchange_after_50-converge-identities.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_50-converge-identities.sh.tmpl
@@ -1,9 +1,9 @@
 #!/bin/zsh
 {{ "" -}}
 # =============================================================================
-# [Architecture]: Atomic Identity Convergence (Phase 50)
-# [Rationale]: Extracts public keys directly from the Chezmoi AST (in-memory) and
-# provisions all downstream Git/SSH configurations in an O(1) idempotent pass.
+# Phase 50 converges generated identity files atomically.
+# Public keys are read from chezmoi template data and never from generated files.
+# The pass provisions downstream Git and SSH configuration idempotently.
 # Logic is strictly encapsulated in .chezmoitemplates.
 # [Reference]: https://www.chezmoi.io/reference/special-directories/chezmoitemplates/
 # [Trigger]: {{ .ssh_keys_hash }}
@@ -17,12 +17,12 @@ SSH_SOCKET_DIR="$SSH_STATE_DIR/sockets"
 GIT_CONFIG_DIR="{{ .paths.xdg_config }}/git/identities"
 ALLOWED_SIGNERS="{{ .paths.xdg_config }}/git/allowed_signers"
 
-# [Architecture]: Ensure all SSH/Git state directories exist.
+# Ensure all SSH and Git state directories exist before writing generated files.
 # Including XDG-compliant state and socket directories to prevent bind errors.
 mkdir -p "$SSH_DIR" "$SSH_STATE_DIR" "$SSH_SOCKET_DIR" "$GIT_CONFIG_DIR" "$(dirname "$ALLOWED_SIGNERS")"
 chmod 700 "$SSH_DIR" "$SSH_STATE_DIR"
 
-# [Architecture]: Enforce clean state for generated artifacts.
+# Remove stale generated Git identity includes before writing the new set.
 rm -rf "$GIT_CONFIG_DIR"
 mkdir -p "$GIT_CONFIG_DIR"
 TEMP_SIGNERS=$(mktemp)
@@ -32,13 +32,13 @@ echo "🔐 [Identity] Converging Content-Addressable Sovereign Identities..."
 {{ $home := .paths.home -}}
 {{ range .identities -}}
 # --- Provisioning Identity: {{ .name }} ({{ .email }}) ---
-# [Architecture]: Content-Addressable Path Resolution
+# Generated public key paths include identity hash material.
 PUBKEY_FILE="$SSH_DIR/id_{{ .key_type }}_{{ .email }}_{{ .key_hash }}.pub"
 echo {{ .public_key | quote }} > "$PUBKEY_FILE"
 chmod 600 "$PUBKEY_FILE"
 
 CONFIG_FILE="$GIT_CONFIG_DIR/config_{{ .email }}_{{ .key_hash }}"
-# [Architecture]: Delegate logic to isolated template.
+# Delegate generated Git config content to the shared identity template.
 cat << 'EOF' > "$CONFIG_FILE"
 {{ includeTemplate "git_identity_config.tmpl" (dict "name" .name "email" .email "public_key" .public_key "key_type" .key_type "key_hash" .key_hash "home" $home) }}
 EOF
@@ -50,7 +50,7 @@ echo "  ✅ Synced context routing: {{ .email }} [Hash: {{ .key_hash }}]"
 {{ end -}}
 
 {{ if not .identities -}}
-# [Architecture]: Graceful fallback for uninitialized CI environments.
+# CI can verify file generation even when no user identities are mapped.
 echo "ci-bot@example.com namespaces=\"git\" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI_CI_FALLBACK_KEY_STUB" >> "$TEMP_SIGNERS"
 echo "⚠️  [Identity] No sovereign identities mapped. CI fallback stub generated."
 {{ end -}}

--- a/.chezmoiscripts/run_onchange_after_51-sync-windows-agent.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_51-sync-windows-agent.sh.tmpl
@@ -1,6 +1,6 @@
 #!/bin/zsh
 {{ "" -}}
-# [Architecture]: WSL2 to Windows 1Password Agent Sync (Phase 51)
+# Phase 51 syncs the rendered 1Password agent config to the Windows host.
 
 set -euo pipefail
 

--- a/.chezmoiscripts/run_onchange_after_52-sync-wezterm-config.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_52-sync-wezterm-config.sh.tmpl
@@ -1,6 +1,6 @@
 #!/bin/zsh
 {{ "" -}}
-# [Architecture]: WSL2 to Windows WezTerm Config Sync (Phase 52)
+# Phase 52 syncs the rendered WezTerm config to the Windows host.
 # [Trigger]: WezTerm Config Hash: {{ include "dot_config/wezterm/wezterm.lua.tmpl" | sha256sum }}
 
 set -euo pipefail

--- a/.chezmoiscripts/run_onchange_after_90-enable-services.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_90-enable-services.sh.tmpl
@@ -1,8 +1,8 @@
 #!/bin/zsh
 {{ "" -}}
 # =============================================================================
-# [Architecture]: Service Orchestration (Phase 90)
-# [Rationale]: Declaratively manages user-level Systemd services.
+# Phase 90 manages user-level services after configuration files converge.
+# User services are enabled only when the current environment requires them.
 # [Trigger]: 1Password Bridge Hash: {{ include "dot_config/systemd/user/1password-bridge.service.tmpl" | sha256sum }}
 # =============================================================================
 

--- a/.chezmoiscripts/run_onchange_before_00-backup-legacy-dots.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_00-backup-legacy-dots.sh.tmpl
@@ -1,6 +1,6 @@
 #!/bin/sh
 # [chezmoi-script]: L0 (POSIX Shell) Tiering
-# [Rationale]: Guaranteed execution even without Zsh/Mise environment.
+# POSIX shell keeps the legacy backup path available before Zsh or mise exists.
 {{/*
 Source-only maintainer note:
 This script intentionally stays POSIX-compatible. BACKUP_ROOT is created lazily

--- a/.chezmoiscripts/run_onchange_before_00-install-windows-deps.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_00-install-windows-deps.sh.tmpl
@@ -13,8 +13,8 @@ install_winget_app() {
   if ! winget.exe list --id "$app_id" > /dev/null 2>&1; then
     echo "📦 [Infrastructure] Installing $app_id on Windows..."
 
-    # [Architecture]: Volatile Package Handling
-    # [Rationale]: Nightly builds often suffer from manifest hash drift.
+    # Nightly packages can have volatile WinGet manifests.
+    # Hash verification is bypassed only for nightly package IDs.
     # Conditional bypass is required to ensure non-interactive convergence.
     extra_flags=""
     if echo "$app_id" | grep -q "nightly"; then

--- a/.chezmoiscripts/run_onchange_before_00-validate-session.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_00-validate-session.sh.tmpl
@@ -1,7 +1,7 @@
 #!/bin/sh
 {{ "" -}}
-# [Architecture]: Sovereign Session Validation
-# [Rationale]: Prevents cascading failures by asserting 1Password availability.
+# Validate 1Password session availability before identity-dependent steps run.
+# Missing or locked 1Password sessions are handled before later provisioning steps.
 # [Reference]: https://developer.1password.com/docs/cli/reference/commands/account
 
 set -eu

--- a/.chezmoiscripts/run_onchange_before_10-setup-infrastructure.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_10-setup-infrastructure.sh.tmpl
@@ -1,12 +1,12 @@
 {{ if eq .osid "darwin" -}}
 #!/bin/zsh
 # [chezmoi-script]: Tier 1 (Zsh)
-# [Architecture]: macOS Provisioning Engine.
+# macOS provisioning installs the generated Brewfile before runtime setup.
 # dot_config/homebrew/Brewfile.tmpl hash: {{ include "dot_config/homebrew/Brewfile.tmpl" | sha256sum }}
 
 set -euo pipefail
 
-# [Architecture]: Localized Binary Resolution
+# Resolve bootstrap binaries through chezmoi before invoking installers.
 CURL_BIN="{{ lookPath "curl" }}"
 BASH_BIN="{{ lookPath "bash" }}"
 
@@ -49,7 +49,7 @@ rm "$TEMP_BREWFILE"
 {{ else if eq .osid "linux" -}}
 #!/bin/sh
 # [chezmoi-script]: L0 (POSIX Shell) Tiering
-# [Architecture]: OS-Agnostic Linux Provisioning Engine.
+# Linux provisioning installs the generated package list before runtime setup.
 # [Trigger]: Linux package list hash: {{ includeTemplate "linux-packages.list.tmpl" . | sha256sum }}
 
 set -eu
@@ -57,7 +57,7 @@ set -eu
 echo "🛡️  [Tier 1] Executing Infrastructure Assertion Gate..."
 
 # [Security]: Non-Interactive Sudo Assertion
-# [Rationale]: Prevents silent hang-ups during automated provisioning.
+# Non-interactive sudo avoids silent hangs during automated provisioning.
 if ! sudo -n true 2>/dev/null; then
   echo "❌ [Fatal] Non-interactive sudo is not configured."
   echo "👉 Action Required: Run 'sudo visudo' and configure passwordless sudo for this user."

--- a/.chezmoitemplates/git_identity_config.tmpl
+++ b/.chezmoitemplates/git_identity_config.tmpl
@@ -1,6 +1,6 @@
-{{- /* [Architecture]: Sovereign Identity Config Template */ -}}
+{{- /* Generated Git identity config fragment. */ -}}
 {{- /* [Security]: Decoupled template to prevent script pollution. */ -}}
-# [Architecture]: Auto-generated Identity Config for {{ .name }}
+# Auto-generated identity config for {{ .name }}
 
 [user]
     name = {{ .name | quote }}

--- a/.chezmoitemplates/linux-packages.list.tmpl
+++ b/.chezmoitemplates/linux-packages.list.tmpl
@@ -1,4 +1,4 @@
-{{- /* [Architecture]: Declarative Linux Package List */ -}}
+{{- /* Declarative Linux package list template. */ -}}
 {{- /* [Reference]: https://www.chezmoi.io/user-guide/advanced/install-packages-declaratively/ */ -}}
 {{- $os_id := "" -}}
 {{- if (hasKey .chezmoi "osRelease") -}}
@@ -7,8 +7,8 @@
   {{- end -}}
 {{- end -}}
 
-# [Architecture]: Declarative package list for Linux workstation.
-# [Rationale]: Centrally managed via .chezmoidata/packages.yaml
+# Linux workstation packages are centrally generated from repository data.
+# Package selections come from .chezmoidata/packages.yaml.
 
 # --- Common Headless Infrastructure ---
 {{ range .packages.headless.common -}}

--- a/.editorconfig
+++ b/.editorconfig
@@ -12,15 +12,15 @@ max_line_length = 100
 [*.sh]
 shell_variant = posix
 
-# [Rationale]: Support for chezmoi template files
+# Support chezmoi template files.
 [*.{sh,lua,toml,yaml,json}.tmpl]
 indent_size = 2
 
-# [Rationale]: Markdown trailing spaces are meaningful for line breaks
+# Preserve Markdown trailing spaces because they are meaningful line breaks.
 [*.md]
 trim_trailing_whitespace = false
 max_line_length = off
 
-# [Rationale]: Makefile requires physical tabs
+# Makefile recipes require physical tabs.
 [Makefile]
 indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,22 +1,22 @@
-# [Rationale]: Absolute EOL normalization for cross-platform convergence
+# Normalize text files to LF across platforms.
 * text=auto eol=lf
 
-# [Rationale]: Force LF for all scripts and templates to prevent execution failure on Linux
-# [Architecture]: Added *.tmpl to cover files like executable_doctor.tmpl that lack .sh extension.
+# Force LF for scripts and templates to prevent execution failures on Linux.
+# Include *.tmpl because some executable templates do not have a shell extension.
 *.tmpl text eol=lf
 *.sh text eol=lf
 *.zsh text eol=lf
 
-# [Rationale]: Prevent binary corruption in templates (if any)
+# Prevent binary corruption for image assets.
 *.png binary
 *.jpg binary
 
-# [Rationale]: GitHub Linguist Overrides
+# GitHub Linguist overrides.
 # Mark data and templates as their underlying language for better UI
 .chezmoidata/*.yaml linguist-language=yaml
 *.sh.tmpl linguist-language=shell
 *.lua.tmpl linguist-language=lua
 
-# [Rationale]: Exclude meta-tools from source archives (git archive)
+# Exclude repository meta files from git archive output.
 .github/ export-ignore
 repomix.config.json export-ignore

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -1,6 +1,6 @@
-# [Architecture]: Sovereign Infrastructure Validation Pipeline (2026 SOTA)
+# Chezmoi state validation stays separate from mise runtime integration.
 # [Reference]: https://mise.jdx.dev/continuous-integration.html
-# [Rationale]: Strictly decouples infrastructure state (chezmoi) from runtime provision (mise).
+# This workflow applies chezmoi first, then runs mise-managed integration checks.
 name: compliance
 
 on:
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        # [Architecture]: Target Node.js 24 environment. Hash will be pinned securely by Renovate.
+        # Checkout runs on Node.js 24 through FORCE_JAVASCRIPT_ACTIONS_TO_NODE24; Renovate pins the action hash.
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
@@ -51,7 +51,7 @@ jobs:
 
       - name: Phase 2 - Idempotency Proof (Static Convergence)
         run: |
-          # [Architecture]: Strict bit-for-bit state verification.
+          # Verify that the applied chezmoi state remains byte-for-byte converged.
           if ! chezmoi verify; then
             echo "❌ [Idempotency Failure] State drift detected."
             chezmoi status

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,4 +1,4 @@
-# [Architecture]: Sovereign Tier 0 (Bootstrap Toolchain)
+# Bootstrap toolchain used before repository-level mise config is available.
 # [Reference]: https://mise.jdx.dev/continuous-integration.html
 [tools]
 chezmoi = "2.70.2"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
-# [Rationale]: Zero-Speculation Local-First Hook Configuration.
-# Leverage binaries managed by 'mise' to ensure 1:1 parity between dev and CI.
+# Local hooks use binaries managed by mise.
+# This keeps developer and CI hook execution aligned.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
@@ -15,7 +15,7 @@ repos:
         name: shfmt
         entry: shfmt
         language: system
-        # [Rationale]: Target only pure shell scripts. Templates are excluded to avoid AST collision.
+        # Target only pure shell scripts; templates are excluded to avoid AST collisions.
         files: \.(sh|zsh|zshrc|zshenv)$
         args: ["-i", "2", "-ci", "-sr", "-w"]
 
@@ -23,7 +23,7 @@ repos:
         name: stylua
         entry: stylua
         language: system
-        # [Rationale]: Target only pure lua files. Templates are excluded to avoid AST collision.
+        # Target only pure Lua files; templates are excluded to avoid AST collisions.
         files: \.lua$
-        # [Rationale]: No --config-path needed. StyLua auto-detects .editorconfig by default.
+        # StyLua auto-detects .editorconfig, so no --config-path is needed.
         args: []

--- a/docs/llm/chezmoi-template-guidelines.md
+++ b/docs/llm/chezmoi-template-guidelines.md
@@ -29,7 +29,7 @@ Use Go Template comments for source-state-only rationale that should not appear
 in the rendered target file:
 
 ```gotemplate
-{{/* [Rationale]: Source-only explanation for maintainers. */}}
+{{/* Source-only explanation for maintainers. */}}
 ```
 
 Use this for:
@@ -47,11 +47,11 @@ explanation.
 Examples:
 
 ```sh
-# [Rationale]: Keep this visible in the rendered shell script.
+# Keep this visible in the rendered shell script.
 ```
 
 ```lua
--- [Rationale]: Keep this visible in the rendered Lua file.
+-- Keep this visible in the rendered Lua file.
 ```
 
 Use this for:
@@ -69,7 +69,8 @@ Prefer:
 
 ```gotemplate
 {{/*
-[Rationale]: This branch is source-state-only documentation.
+Source-only maintainer note:
+This branch is source-state-only documentation.
 It explains why the rendered output must not include these notes.
 */}}
 ```

--- a/dot_config/1Password/ssh/private_agent.toml.tmpl
+++ b/dot_config/1Password/ssh/private_agent.toml.tmpl
@@ -1,7 +1,7 @@
 {{- /* [Reference]: https://developer.1password.com/docs/ssh/agent/config/ */ -}}
-# [Architecture]: Sovereign SSH Agent Configuration (Account-Aware)
-# [Rationale]: Specifying 'account' is mandatory for disambiguation in multi-account environments.
-# Bypasses all Vault routing ambiguities by binding directly to Item UUID + Account ID.
+# Account-aware SSH agent configuration.
+# Specifying 'account' disambiguates keys in multi-account environments.
+# Bind directly to Item UUID and Account ID to avoid vault routing ambiguity.
 
 {{ range .identities -}}
 [[ssh-keys]]

--- a/dot_config/git/config.tmpl
+++ b/dot_config/git/config.tmpl
@@ -1,4 +1,4 @@
-{{- /* [LLM Context]
+{{- /* [Source Context]
 SSOT global Git config template for chezmoi.
 
 Design goals:

--- a/dot_config/homebrew/Brewfile.tmpl
+++ b/dot_config/homebrew/Brewfile.tmpl
@@ -1,4 +1,4 @@
-# [Rationale]: Declarative infrastructure for macOS workstation (2026).
+# Declarative package list for the macOS workstation.
 # [Reference]: https://www.chezmoi.io/user-guide/advanced/install-packages-declaratively/
 
 # --- Headless Infrastructure (Always Provisioned) ---

--- a/dot_config/mise/config.toml.tmpl
+++ b/dot_config/mise/config.toml.tmpl
@@ -1,16 +1,16 @@
 {{- /* [Reference]: https://mise.jdx.dev/configuration.html */ -}}
-# [Architecture]: Single Source of Truth (SSOT) for Toolchains.
-# [Rationale]: All tools are dynamically expanded from FQIs in tools.yaml.
+# Repository tool versions are generated from the central tool data.
+# Fully qualified tool identifiers are expanded from tools.yaml.
 
 [env]
-# [Rationale]: Skip Python GitHub attestation verification to reduce latency/noise.
+# Skip Python GitHub attestation verification to reduce mise install latency and noise.
 # [Reference]: https://mise.jdx.dev/lang/python.html
 MISE_PYTHON_GITHUB_ATTESTATIONS = "false"
 PNPM_HOME = "{{ .paths.xdg_data }}/pnpm"
 
 [tools]
-# [Architecture]: Deterministic Layering
-# [Rationale]: Explicitly define core runtimes before derivative backends (npm:, cargo:).
+# Core runtimes are declared before tools that depend on runtime backends.
+# This keeps npm: and cargo: tool resolution behind their runtime declarations.
 "node" = "{{ index .mise_tools "node" }}"
 "python" = "{{ index .mise_tools "python" }}"
 "go" = "{{ index .mise_tools "go" }}"

--- a/dot_config/mise/tasks/doctor/executable_toolchain.tmpl
+++ b/dot_config/mise/tasks/doctor/executable_toolchain.tmpl
@@ -30,8 +30,8 @@ else
 fi
 
 if [[ "$IS_CI" != "true" ]]; then
-  # [Architecture]: Tiered PATH Precedence Verification
-  # [Rationale]: Ensures infrastructure paths (mise/aqua) precede system binaries.
+  # Verify PATH precedence for mise and aqua before system binaries.
+  # This catches accidental fallback to globally installed tools.
   # Static index-0 checks are avoided to support dynamic mise activation.
   SYS_PATH="/usr/bin"
   LOCAL_BIN="$HOME_DIR/.local/bin"

--- a/dot_config/mise/tasks/integrate/executable_nvim.tmpl
+++ b/dot_config/mise/tasks/integrate/executable_nvim.tmpl
@@ -3,6 +3,6 @@
 
 set -euo pipefail
 
-# [Rationale]: Redirecting stdin from /dev/null prevents hanging on interactive prompts.
+# Redirecting stdin from /dev/null prevents hanging on interactive prompts.
 echo "📦 [Neovim] Converging plugins via lazy.nvim..."
 "{{ .paths.mise }}" exec aqua:neovim/neovim -- nvim --headless "+Lazy! restore" +qa < /dev/null

--- a/dot_config/mise/tasks/setup/executable_pnpm.tmpl
+++ b/dot_config/mise/tasks/setup/executable_pnpm.tmpl
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-# [Architecture]: Force PNPM_HOME to align with XDG Base Directory specification
+# Force PNPM_HOME to align with the XDG Base Directory specification.
 PNPM_HOME="{{ .paths.xdg_data }}/pnpm"
 
 echo "📦 [Node] Configuring pnpm global bin directory..."

--- a/dot_config/mise/tasks/setup/executable_security.tmpl
+++ b/dot_config/mise/tasks/setup/executable_security.tmpl
@@ -8,7 +8,7 @@ echo "🔒 [Security] Enforcing permissions on dynamic cryptographic assets..."
 
 SSH_DIR="{{ .paths.home }}/.ssh"
 
-# [Architecture]: 0700 directory permissions are now declaratively guaranteed
+# 0700 directory permissions are declared before SSH sockets are used.
 # by chezmoi's 'private_' source state attributes. This script only manages
 # files dynamically extracted post-provisioning.
 

--- a/dot_config/mise/tasks/update/executable_lazy-lock.tmpl
+++ b/dot_config/mise/tasks/update/executable_lazy-lock.tmpl
@@ -36,7 +36,7 @@ echo "📦 [Neovim] Headless plugin update initiated..."
 # --- 3. State Promotion ---
 chezmoi add "$LOCK_FILE"
 
-# [Architecture]: Diff against the specific managed file in the source state.
+# Diff against the specific managed file in the source state.
 if git diff --quiet -- "$CHEZMOI_DIR/dot_config/nvim/lazy-lock.json"; then
   echo "✅ [State] No plugin updates found. lazy-lock.json is up to date."
   git checkout -
@@ -48,13 +48,13 @@ fi
 echo "🚀 [State] Updates detected. Committing and generating Pull Request..."
 git add "$CHEZMOI_DIR/dot_config/nvim/lazy-lock.json"
 
-# [Architecture]: GPG/SSH signature is inherently applied here via user's Git configuration.
+# GPG/SSH signing is applied here through the user's Git configuration.
 git commit -m "chore(deps): atomic neovim plugin convergence" \
            -m "Automated lazy-lock.json update via update:lazy-lock task."
 
 git push -u origin "$BRANCH_NAME"
 
-# [Architecture]: Force local Fast-Forward merge in the PR body to protect SSH signatures.
+# The PR body asks maintainers to use local fast-forward merge to preserve signatures.
 # [Interop]: Standard 'dependencies' label applied.
 gh pr create --title "chore(deps): atomic neovim plugin convergence" \
              --label "dependencies" \

--- a/dot_config/nvim/init.lua.tmpl
+++ b/dot_config/nvim/init.lua.tmpl
@@ -1,12 +1,12 @@
--- [Architecture]: I/O Minimalist Bootstrap & Caching
--- [Rationale]: Enable native Lua loader immediately to bypass file stat operations.
+-- Enable the native Lua loader before loading the rest of the configuration.
+-- This reduces repeated Lua module lookup work during startup.
 -- [Reference]: https://neovim.io/doc/user/lua.html#vim.loader
 if vim.loader then
   vim.loader.enable()
 end
 
--- [Architecture]: Terminal Identity Propagation (OSC 1337 / Physical Bypass)
--- [Rationale]: Directly writes to /dev/tty to bypass Neovim's TUI buffer.
+-- Propagate Neovim pane state to WezTerm through OSC 1337.
+-- Direct writes to /dev/tty bypass Neovim's TUI buffer.
 -- This ensures the signal survives startup/exit and reaches the terminal server.
 -- [Reference]: https://wezterm.org/config/lua/pane/get_user_vars.html
 local function set_wezterm_var(name, value)
@@ -30,7 +30,7 @@ vim.api.nvim_create_autocmd({ "VimEnter", "VimLeave" }, {
 })
 
 -- [Provider]: Resolve Node.js host from the active executable path.
--- [Rationale]: Keeps mise as the source of truth while avoiding hardcoded
+-- Keep mise as the source of truth while avoiding hardcoded
 -- install paths. The resolved executable may be an npm wrapper; Neovim handles
 -- the provider check through its own provider implementation.
 -- [Reference]: https://neovim.io/doc/user/provider.html#provider-nodejs

--- a/dot_config/nvim/lua/config/keymaps.lua.tmpl
+++ b/dot_config/nvim/lua/config/keymaps.lua.tmpl
@@ -1,6 +1,6 @@
--- [Architecture]: Protocol-Driven Outbound Navigation (Smart Splits)
--- [Rationale]: Emits an OSC 1337 signal when reaching the vim boundary,
--- delegating the pane switch to WezTerm's event listener.
+-- Smart Splits outbound navigation uses OSC 1337 user variables.
+-- When Neovim reaches a window boundary, it delegates pane movement
+-- to WezTerm's event listener.
 local function signal_move_to_wezterm(direction)
   if vim.env.TERM_PROGRAM ~= "WezTerm" then return end
   local osc = string.format("\027]1337;SetUserVar=MOVE_SIGNAL=%s\007", vim.base64.encode(direction))

--- a/dot_config/nvim/lua/config/lazy.lua
+++ b/dot_config/nvim/lua/config/lazy.lua
@@ -11,7 +11,7 @@ if not vim.loop.fs_stat(lazypath) then
 end
 vim.opt.rtp:prepend(lazypath)
 
--- [Rationale]: Detect CI environment to disable non-deterministic background tasks.
+-- Detect CI so background update checks can be disabled.
 local is_ci = os.getenv("CI") == "true"
 
 -- Initialize lazy.nvim with correct path conventions and noise suppression.
@@ -20,16 +20,16 @@ require("lazy").setup({
     -- Core LazyVim framework.
     { "LazyVim/LazyVim", import = "lazyvim.plugins" },
 
-    -- [Rationale]: Prettier extra ensures Neovim uses the 'prettier' binary
-    -- from $PATH (provided via mise) for Markdown, JSON, and YAML.
+    -- Prettier extra uses the 'prettier' binary from $PATH for Markdown,
+    -- JSON, and YAML.
     { import = "lazyvim.plugins.extras.formatting.prettier" },
 
-    -- [Rationale]: Use project-local ESLint for diagnostics and code actions
+    -- Use project-local ESLint for diagnostics and code actions
     -- while preserving Prettier as the formatting owner.
     -- [Reference]: https://www.lazyvim.org/extras/linting/eslint
     { import = "lazyvim.plugins.extras.linting.eslint" },
 
-    -- Language-specific extras for 2026 SOTA workflows.
+    -- Language-specific extras used by the managed editor baseline.
     { import = "lazyvim.plugins.extras.lang.python" },
     { import = "lazyvim.plugins.extras.lang.typescript" },
     { import = "lazyvim.plugins.extras.lang.json" },
@@ -46,9 +46,9 @@ require("lazy").setup({
     -- Debug workflow extra.
     { import = "lazyvim.plugins.extras.dap.core" },
 
-    -- [Architecture]: 2026 SOTA Engines
-    -- [Rationale]: Replaces legacy mini-animate, fzf-lua, and nvim-cmp with
-    -- unified, Rust-backed, or native-speed alternatives.
+    -- Editor UI and completion extras.
+    -- These extras replace legacy mini-animate, fzf-lua, and nvim-cmp with
+    -- maintained LazyVim defaults.
     -- [Reference]: https://www.lazyvim.org/extras/editor/snacks_picker
     { import = "lazyvim.plugins.extras.editor.snacks_picker" },
     { import = "lazyvim.plugins.extras.coding.blink" },
@@ -64,7 +64,7 @@ require("lazy").setup({
     enabled = false,
     hererocks = false,
   },
-  -- [Rationale]: Disable auto-checker in CI to maintain absolute idempotency.
+  -- Disable the auto-checker in CI to keep runs idempotent.
   checker = { enabled = not is_ci },
   performance = {
     rtp = {

--- a/dot_config/nvim/lua/config/options.lua.tmpl
+++ b/dot_config/nvim/lua/config/options.lua.tmpl
@@ -36,12 +36,12 @@ opt.termguicolors = true
 opt.ignorecase = true
 opt.smartcase = true
 
--- [Strategy]: 2026 Sovereign Spell Enforcement
+-- Spell checking starts disabled and can be enabled per editing context.
 opt.spell = false
 opt.spelllang = { "en" }
 opt.spelloptions = "camel"
 
--- [Architecture]: WSL2 Deterministic Clipboard Provider
+-- WSL clipboard provider uses win32yank for Windows interoperability.
 -- [Reference]: :help provider-clipboard
 if vim.fn.has("wsl") == 1 then
   vim.g.clipboard = {

--- a/dot_config/nvim/lua/plugins/chezmoi.lua
+++ b/dot_config/nvim/lua/plugins/chezmoi.lua
@@ -1,6 +1,6 @@
--- [Architecture]: Deterministic Chezmoi Integration
--- [Rationale]: Enable high-fidelity syntax highlighting via Treesitter gotmpl
--- and provide seamless source-target synchronization.
+-- Chezmoi integration for source-state template editing.
+-- Treesitter gotmpl highlighting keeps source and target syntax easier to review
+-- while chezmoi.nvim handles source-target synchronization.
 -- [Reference]: https://www.chezmoi.io/user-guide/advanced/ide-integration/#neovim
 
 return {
@@ -8,10 +8,8 @@ return {
     "xvzc/chezmoi.nvim",
     dependencies = { "nvim-lua/plenary.nvim" },
     init = function()
-      -- [Architecture]: Deterministic Filetype Detection
-      -- [Rationale]: Force Neovim to recognize all .tmpl files as Go templates
-      -- during the startup phase. This guarantees that Treesitter attaches
-      -- correctly before the buffer is fully initialized.
+      -- Register .tmpl files as Go templates before buffers finish initializing.
+      -- This lets Treesitter attach consistently for chezmoi source files.
       vim.filetype.add({
         extension = {
           tmpl = "gotmpl",
@@ -20,7 +18,7 @@ return {
     end,
     config = function()
       require("chezmoi").setup({
-        -- [Rationale]: Use direct edit mode for operational determinism.
+        -- Direct edit mode keeps chezmoi source-state edits explicit.
         edit = {
           watch = true,
           force = false,
@@ -38,7 +36,7 @@ return {
     "nvim-treesitter/nvim-treesitter",
     opts = function(_, opts)
       if type(opts.ensure_installed) == "table" then
-        -- [Rationale]: 'gotmpl' is the definitive parser for Go templates.
+        -- 'gotmpl' is the parser used for Go templates.
         vim.list_extend(opts.ensure_installed, { "gotmpl" })
       end
     end,

--- a/dot_config/nvim/lua/plugins/core.lua
+++ b/dot_config/nvim/lua/plugins/core.lua
@@ -1,5 +1,5 @@
--- [Architecture]: Unified UI & Performance Engine (2026 SOTA Corrected)
--- [Rationale]: Explicitly return modified opts table to ensure lazy.nvim applies overrides.
+-- UI and performance plugin overrides.
+-- Return the modified opts table so lazy.nvim applies overrides.
 -- [Reference]: https://github.com/folke/snacks.nvim
 
 return {

--- a/dot_config/nvim/lua/plugins/edit.lua
+++ b/dot_config/nvim/lua/plugins/edit.lua
@@ -1,4 +1,4 @@
--- [Architecture]: High-Fidelity Search, Replace, and Edit Engine
+-- Search, replace, and edit plugins.
 -- [Reference]: https://github.com/echasnovski/mini.surround
 
 return {

--- a/dot_config/nvim/lua/plugins/lint.lua
+++ b/dot_config/nvim/lua/plugins/lint.lua
@@ -1,6 +1,6 @@
--- [Architecture]: Asynchronous Prose Linting Engine (Idempotent Config)
--- [Rationale]: Switches to 'opts' pattern to ensure custom vale settings
--- survive LazyVim's markdown extra merging while maintaining path-agnostic parsing.
+-- Configure prose and shell linting without replacing LazyVim setup hooks.
+-- The opts pattern keeps custom Vale settings across LazyVim's markdown extra
+-- merging while maintaining path-agnostic parsing.
 -- [Reference]: https://github.com/mfussenegger/nvim-lint
 
 return {

--- a/dot_config/nvim/lua/plugins/lsp.lua
+++ b/dot_config/nvim/lua/plugins/lsp.lua
@@ -1,5 +1,5 @@
--- [Architecture]: Environment-Inherited LSP Configuration
--- [Rationale]: Eliminates runtime shell execution (uv python find) inside Lua.
+-- LSP configuration inherits tool paths from the parent shell environment.
+-- This avoids running shell discovery commands from Lua during startup.
 -- Relies on the parent shell environment established by 'mise activate'.
 -- [Reference]: https://docs.basedpyright.com/latest/configuration/language-server-settings/
 
@@ -35,9 +35,8 @@ return {
       },
       servers = {
         basedpyright = {
-          -- [Architecture]: Zero-Speculation Path Resolution
-          -- [Rationale]: By omitting settings.python.pythonPath, BasedPyright
-          -- defaults to the 'python' binary available in the current PATH,
+          -- Omit pythonPath so BasedPyright resolves Python from PATH.
+          -- BasedPyright defaults to the python binary available in the current PATH,
           -- which is correctly set by mise during the shell session.
           settings = {
             basedpyright = {

--- a/dot_config/nvim/lua/plugins/oil.lua
+++ b/dot_config/nvim/lua/plugins/oil.lua
@@ -1,6 +1,6 @@
--- [Architecture]: Text-based Directory Editor
--- [Rationale]: Enables bulk renaming and rapid filesystem traversal
--- by treating directories as standard editable buffers.
+-- Text-based directory editing.
+-- Treating directories as editable buffers enables bulk renaming
+-- and rapid filesystem traversal.
 return {
   {
     "stevearc/oil.nvim",

--- a/dot_config/nvim/lua/plugins/trouble.lua
+++ b/dot_config/nvim/lua/plugins/trouble.lua
@@ -1,10 +1,10 @@
--- [Architecture]: Diagnostic & LSP Reference Aggregator
--- [Rationale]: Provides a deterministic list of all code issues and
--- references, eliminating "hidden" errors.
+-- Diagnostic and LSP reference aggregation.
+-- Trouble centralizes code issues and references in a reviewable list,
+-- reducing the chance of hidden diagnostics.
 return {
   {
     "folke/trouble.nvim",
-    opts = {}, -- Default 2026 config is highly optimized.
+    opts = {}, -- Default options are sufficient for this integration.
     keys = {
       { "<leader>xx", "<cmd>Trouble diagnostics toggle<cr>", desc = "Diagnostics (Trouble)" },
       {

--- a/dot_config/ssh/conf.d/github.tmpl
+++ b/dot_config/ssh/conf.d/github.tmpl
@@ -1,4 +1,4 @@
-{{- /* [Architecture]: Zero-Trust SSH Routing */ -}}
+{{- /* GitHub host routing leaves identity selection to Git core.sshCommand. */ -}}
 {{- /* [Security]: IdentityFile is deliberately omitted. Routing is strictly handled by Git's core.sshCommand */ -}}
 Host github.com
     HostName github.com

--- a/dot_config/ssh/config.tmpl
+++ b/dot_config/ssh/config.tmpl
@@ -1,7 +1,7 @@
-{{- /* [Architecture]: Defensive Schema Extraction */ -}}
+{{- /* Extract optional SSH agent path without assuming the data key exists. */ -}}
 {{- $ssh_auth_sock := "" -}}
 {{- if hasKey . "paths" }}{{ if hasKey .paths "ssh_auth_sock" }}{{ $ssh_auth_sock = .paths.ssh_auth_sock }}{{ end }}{{ end -}}
-# [Rationale]: Modular & XDG-compliant SSH configuration (2026).
+# Modular SSH configuration routed through XDG paths.
 # [Security]: Hardened defaults with ControlPersist for high-performance infrastructure.
 
 # ================================================================
@@ -24,12 +24,12 @@ Host *
 {{ end }}    ForwardAgent yes
 
     # --- Reliability & Automation ---
-    # [2026 Best Practice]: Avoid hang on new hosts while maintaining security.
+    # Avoid hanging on first connection to a new host while still recording host keys.
     StrictHostKeyChecking accept-new
     ServerAliveInterval 60
     ServerAliveCountMax 5
     HashKnownHosts yes
 
     # --- XDG Compliance ---
-    # [Rationale]: Prevent ~/.ssh/known_hosts pollution.
+    # Store known_hosts under XDG state instead of ~/.ssh.
     UserKnownHostsFile {{ .paths.xdg_state }}/ssh/known_hosts

--- a/dot_config/starship.toml.tmpl
+++ b/dot_config/starship.toml.tmpl
@@ -1,7 +1,7 @@
 {{- /* [Reference]: https://starship.rs/config/ */ -}}
-# [Architecture]: Deterministic Infrastructure Prompt (Sovereign Edition)
-# [Rationale]: Reverts manual file-detection overrides to leverage Starship's
-# native Rust-backed optimized scanning, ensuring 1:1 parity with 'mise' states.
+# Prompt modules rely on Starship native detection.
+# Manual file-detection overrides are avoided so Starship's scanning behavior
+# stays aligned with managed runtime state.
 
 command_timeout = 3000
 scan_timeout = 100
@@ -57,10 +57,10 @@ deleted = "✘"
 ignore_submodules = true
 
 # =============================================================================
-# Language Modules: Native Detection Protocol
-# [Rationale]: Rely on standard detection to ensure long-term compatibility
+# Language Modules: Native Detection
+# Rely on standard detection to ensure long-term compatibility
 # with ecosystem evolution (e.g. pyproject.toml, pnpm-workspace.yaml).
-# Performance is guaranteed by scan_timeout and WebGpu rendering.
+# Performance is bounded by scan_timeout and terminal rendering settings.
 # =============================================================================
 
 [python]

--- a/dot_config/systemd/user/1password-bridge.service.tmpl
+++ b/dot_config/systemd/user/1password-bridge.service.tmpl
@@ -1,7 +1,7 @@
 {{- if and .is_wsl (ne .npiperelay_wsl "") -}}
-# [Architecture]: Declarative WSL2 SSH Agent Bridge
-# [Rationale]: Abstracted from imperative scripts to ensure state persistence
-# and direct control via XDG compliant Systemd configurations.
+# WSL2 SSH agent bridge managed by the user systemd instance.
+# systemd keeps the bridge persistent across shell sessions
+# and direct control via XDG-compliant systemd configuration.
 [Unit]
 Description=1Password SSH Agent Bridge (WSL2 to Windows)
 After=network.target

--- a/dot_config/vale/vale.ini.tmpl
+++ b/dot_config/vale/vale.ini.tmpl
@@ -1,15 +1,15 @@
 {{- /* [Reference]: https://vale.sh/docs/vale-ini */ -}}
-# [Architecture]: Deterministic Prose Linter Configuration
-# [Rationale]: Enforce Google Style Guide via XDG-compliant pathing.
+# Vale configuration is routed through XDG-managed paths.
+# Google style checks use the managed StylesPath below.
 
 # --- Global Settings ---
 StylesPath = {{ .paths.xdg_data }}/vale/styles
 MinAlertLevel = suggestion
 
-# [Architecture]: External Style Dependencies
-# [Rationale]: Declarative package management for Vale styles.
+# Vale style packages are installed declaratively.
+# The Google package is resolved by Vale package management.
 Packages = Google
 
 [*.md]
-# [Rationale]: Core standard for documentation within the Eternal Platform.
+# Markdown prose uses Google style checks by default.
 BasedOnStyles = Google

--- a/dot_config/wezterm/wezterm.lua.tmpl
+++ b/dot_config/wezterm/wezterm.lua.tmpl
@@ -22,18 +22,18 @@ end
 
 local config = wezterm.config_builder()
 
--- [Architecture]: Infrastructure Sovereignty
+-- Disable WezTerm update checks because this repository owns convergence.
 config.check_for_updates = false
 config.audible_bell = "Disabled"
 config.scrollback_lines = 100000
 
--- [Architecture]: 2026 Modern UI Standards
+-- Window chrome and padding are kept minimal and explicit.
 config.window_decorations = "RESIZE"
 config.window_background_opacity = 1.0
 config.window_padding = { left = 12, right = 12, top = 10, bottom = 8 }
 config.hide_tab_bar_if_only_one_tab = true
 
--- [Architecture]: Sovereign Typography & Rendering
+-- Font fallback and rendering settings are explicit for cross-language text.
 config.front_end = "WebGpu"
 config.colors = wezterm.get_builtin_color_schemes()["Dracula"]
 config.key_map_preference = "Physical"
@@ -44,15 +44,15 @@ config.bold_brightens_ansi_colors = true
 config.allow_square_glyphs_to_overflow_width = "Always"
 config.use_cap_height_to_scale_fallback_fonts = true
 
--- [Architecture]: Linguistic Interop
+-- IME and composed-key settings preserve Japanese input behavior.
 config.use_ime = true
 config.send_composed_key_when_left_alt_is_pressed = true
 
--- [Architecture]: SRE Diagnostic Clarity
+-- Underline rendering is tuned for diagnostic readability.
 config.underline_thickness = "2pt"
 config.underline_position = "-2pt"
 
--- [Architecture]: Operational Determinism
+-- Window behavior is fixed to avoid accidental layout changes.
 config.adjust_window_size_when_changing_font_size = false
 config.window_close_confirmation = "AlwaysPrompt"
 config.selection_word_boundary = " \t\n{}[]()\"'`,"
@@ -62,9 +62,9 @@ config.inactive_pane_hsb = {
 }
 
 -- ============================================================================
--- [Architecture]: Cross-OS Multiplexer Engine
+-- Cross-OS multiplexer routing
 -- ============================================================================
--- [Rationale]: WSL domain enumeration is delegated to WezTerm's native logic.
+-- WSL domain enumeration is delegated to WezTerm's native logic.
 -- On Windows, the rendered config must explicitly target the active WSL domain
 -- to avoid WezTerm falling back to the built-in "local" domain.
 -- [Reference]: https://wezterm.org/config/lua/config/default_domain.html
@@ -80,7 +80,7 @@ else
 end
 
 -- ============================================================================
--- [Architecture]: Smart Splits (Zero-CLI Protocol Implementation)
+-- Smart Splits protocol bridge
 -- ============================================================================
 
 local function is_nvim_pane(pane)
@@ -116,7 +116,7 @@ local function direction_keys(key, direction)
 end
 
 -- ============================================================================
--- [Architecture]: Keyboard Driven Multiplexer & Command Palette
+-- Keyboard-driven multiplexer and command palette bindings
 -- ============================================================================
 config.leader = { key = "b", mods = "CTRL", timeout_milliseconds = 1000 }
 config.keys = {

--- a/dot_config/zsh/dot_zshrc.tmpl
+++ b/dot_config/zsh/dot_zshrc.tmpl
@@ -1,6 +1,6 @@
-# [Architecture]: Deterministic Zsh Configuration (Sovereign Anchor)
-# [Rationale]: Optimized for 2026 SOTA workflows. Uses 'mise activate' for
-# dynamic environment-switching and context-aware toolchains.
+# Zsh startup is ordered around XDG paths, mise activation, and generated assets.
+# Use 'mise activate' for dynamic environment switching and context-aware
+# toolchains.
 # [Reference]: https://mise.jdx.dev/installing-mise.html#shells
 
 # --- Path Management ---
@@ -11,7 +11,7 @@ path=(
   $path
 )
 
-# [Architecture]: Selective fpath (Startup Isolation)
+# fpath includes generated completions before default completion discovery runs.
 fpath=(
   "$XDG_CACHE_HOME/zsh/completions"
   "$XDG_CONFIG_HOME/zsh/completions"
@@ -22,9 +22,8 @@ fpath=(
 alias vrun='op run -- '
 
 # --- Infrastructure Activation ---
-# [Architecture]: Atomic Environment Injection
-# [Rationale]: Replaces manual shim management with the official activation hook.
-# This ensures [env] blocks in .mise.toml are dynamic and context-aware.
+# mise activation replaces manual shim management.
+# The activation hook keeps [env] blocks dynamic and context-aware.
 if command -v mise >/dev/null 2>&1; then
   eval "$(mise activate zsh)"
 fi
@@ -53,7 +52,7 @@ alias ...='cd ../..'
 alias mkdirp='mkdir -p'
 
 # =============================================================================
-# [Architecture]: Sovereign Clipboard Protocol
+# Clipboard bridge
 # =============================================================================
 {{ if eq .osid "darwin" -}}
 pbcopy() {
@@ -107,7 +106,7 @@ add-zsh-hook chpwd _osc7_cwd
 _osc7_cwd
 
 # =============================================================================
-# [Architecture]: JIT (Just-In-Time) Completion Engine
+# Lazy completion initialization
 # =============================================================================
 ZSH_COMPDUMP_DIR="$XDG_CACHE_HOME/zsh"
 zstyle ':completion:*:*:git:*' script "$XDG_CONFIG_HOME/zsh/completions/git-completion.bash"

--- a/dot_local/bin/symlink_wezterm.tmpl
+++ b/dot_local/bin/symlink_wezterm.tmpl
@@ -1,4 +1,4 @@
-{{- /* [Architecture]: Deterministic Target Resolution (Zero-Trust Interop) */ -}}
+{{- /* Resolve the WezTerm executable path across macOS and WSL boundaries. */ -}}
 {{- /* [Reference]: https://www.chezmoi.io/reference/templates/functions/output/ */ -}}
 {{- $osid := "linux" -}}
 {{- if hasKey . "osid" }}{{ $osid = .osid }}{{ end -}}

--- a/dot_zshenv.tmpl
+++ b/dot_zshenv.tmpl
@@ -1,14 +1,14 @@
-{{- /* [Rationale]: XDG Base Directory bootstrap. Minimal footprint in $HOME. */ -}}
+{{- /* Bootstrap XDG paths early while keeping the home directory footprint small. */ -}}
 export ZDOTDIR="{{ .paths.xdg_config }}/zsh"
 
-# [Architecture]: Deep XDG Integration
+# XDG base directories are exported before shell startup reads downstream config.
 export XDG_CONFIG_HOME="{{ .paths.xdg_config }}"
 export XDG_DATA_HOME="{{ .paths.xdg_data }}"
 export XDG_STATE_HOME="{{ .paths.xdg_state }}"
 export XDG_CACHE_HOME="{{ .paths.xdg_cache }}"
 
 # =============================================================================
-# [Architecture]: Strict XDG Purism (Zero $HOME Pollution)
+# Route tool state away from $HOME where the tool supports an XDG path.
 # =============================================================================
 {{/* [Reference]: https://nodejs.org/api/repl.html#environment-variable-options */ -}}
 export NODE_REPL_HISTORY="$XDG_STATE_HOME/node/repl_history"
@@ -17,40 +17,40 @@ export npm_config_userconfig="$XDG_CONFIG_HOME/npm/npmrc"
 {{/* [Reference]: https://docs.npmjs.com/cli/v11/using-npm/config#environment-variables */ -}}
 export npm_config_cache="$XDG_CACHE_HOME/npm"
 {{/* [Reference]: https://docs.python.org/3/using/cmdline.html#envvar-PYTHON_HISTORY */ -}}
-{{/* [Rationale]: Natively supported in Python 3.13+ to prevent ~/.python_history pollution. */ -}}
+{{/* Python 3.13+ supports PYTHON_HISTORY for routing REPL history out of $HOME. */ -}}
 export PYTHON_HISTORY="$XDG_STATE_HOME/python/history"
 
 # =============================================================================
 
-# [Architecture]: WSL2 to Windows Interop (Identity Relay)
-# [Rationale]: Propagate authentication context to the Windows host seamlessly.
+# WSL exports the 1Password biometric unlock flag to the Windows host.
+# WSLENV carries the authentication context across the WSL/Windows boundary.
 {{ if .is_wsl -}}
 export OP_BIOMETRIC_UNLOCK_ENABLED="true"
 export WSLENV="OP_BIOMETRIC_UNLOCK_ENABLED/u:$WSLENV"
 {{ end -}}
 
-# [Rationale]: Identity Bridge Persistence for SSH operations.
+# SSH_AUTH_SOCK points Git and SSH clients at the managed agent bridge.
 export SSH_AUTH_SOCK="{{ .ssh_auth_sock }}"
 
-# [Rationale]: Node.js Toolchain Persistence.
+# PNPM_HOME follows the XDG data directory used by the managed Node.js toolchain.
 export PNPM_HOME="{{ .paths.xdg_data }}/pnpm"
 
-# [Architecture]: Ripgrep Configuration Linkage
+# ripgrep reads its managed configuration through RIPGREP_CONFIG_PATH.
 export RIPGREP_CONFIG_PATH="$XDG_CONFIG_HOME/ripgrep/config"
 
 {{/* [Reference]: https://vale.sh/docs/vale-ini#search-process */}}
-# [Architecture]: Vale Configuration Routing
+# Vale reads its managed configuration through VALE_CONFIG_PATH.
 export VALE_CONFIG_PATH="$XDG_CONFIG_HOME/vale/vale.ini"
 
 # =============================================================================
-# [Architecture]: Infrastructure Foundation
-# [Rationale]: Enforce XDG compliance for Cloud SDK and Nx.
+# Cloud SDK and Nx state are routed through XDG paths.
+# Keep generated caches and configuration out of repository and home-directory roots.
 # =============================================================================
 {{/* [Reference]: https://docs.cloud.google.com/sdk/docs/configurations */}}
 export CLOUDSDK_CONFIG="$XDG_CONFIG_HOME/gcloud"
 
-# [Architecture]: Hermetic Python Binding for gcloud
-# [Rationale]: Bind strictly to mise-managed python shim to ensure execution determinism.
+# gcloud uses the mise-managed Python shim for consistent execution.
+# This avoids falling back to a system Python with different packages or versioning.
 export CLOUDSDK_PYTHON="{{ .paths.xdg_data }}/mise/shims/python"
 
 {{/* [Reference]: https://nx.dev/docs/reference/environment-variables */}}

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,5 +1,5 @@
-// [Architecture]: Deterministic Dependency Governance
-// [Rationale]: Enforces immutable action digests via Renovate to prevent supply-chain attacks.
+// Renovate keeps GitHub Actions digests pinned for dependency governance.
+// Immutable action digests reduce supply-chain drift in workflow updates.
 // [Reference]: https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigests
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",


### PR DESCRIPTION
## Summary

Normalize high-noise comment vocabulary for issue #136 PR 3.

This PR replaces unsupported authority-signaling phrasing with concrete
maintenance wording across repository comments while preserving dotfiles
behavior.

## Why

PR 1 corrected stale references and metadata in #137, and PR 2 added reusable
comment guidance and fixed source/target routing in #139.

This final slice applies that guidance across the remaining repository
comments so humans and LLM-assisted workflows see durable, source-appropriate
maintenance context instead of decorative or time-sensitive labels.

## Changes

- Replace broad `[Architecture]` and `[Rationale]` labels with plain,
  concrete comments where the label did not add maintenance value.
- Remove unsupported `Sovereign`, `Zero-Trust`, `SOTA`, `Best Practice`, and
  year-based authority claims from comments.
- Normalize comment wording across:
  - root-level bootstrap and repository metadata files
  - `.chezmoidata` package and tool metadata comments
  - chezmoi scripts and template fragments
  - chezmoi external, ignore, remove, and config templates
  - zsh and zshenv templates
  - SSH, Git, 1Password, Homebrew, Starship, Vale, and systemd templates
  - mise config and task comments
  - Neovim Lua comments
  - WezTerm Lua comments
  - GitHub Actions workflow comments
  - EditorConfig and pre-commit comments
  - Renovate comments
- Convert source-only chezmoi template rationale to Go Template comments where
  the note does not need to appear in rendered target files.
- Preserve useful labels and tool metadata, including `[Security]`,
  `[Reference]`, `[Trigger]`, `[MISE]`, and generated/configuration warnings.
- Preserve Renovate metadata and tool-parsed comments.
- Leave runtime output strings unchanged, including identity-related
  `Sovereign Identity` messages, because runtime output is not a comment.

## Validation

- `git status --short`: reviewed expected modified files
- `git diff --stat`: reviewed
- `git diff --check`: no output
- `pre-commit run --all-files`: passed
  - trim trailing whitespace: Passed
  - fix end of files: Passed
  - check yaml: Passed
  - check for added large files: Passed
  - shfmt: Passed
  - stylua: Passed
- `chezmoi diff`: reviewed where chezmoi templates were touched; rendered
  impact is comment-only
- `repomix`: packed successfully as `repomix-dotfiles-after-pr141-issue136.xml`
- Focused post-change inspection confirms remaining high-noise vocabulary
  matches are limited to:
  - runtime output strings in identity-related scripts/tasks
  - policy text in `docs/llm/comment-guidelines.md` that intentionally names
    discouraged terms

## Risk and rollback

Risk is low because this PR changes comments only and does not change
provisioning behavior, shell startup order, identity routing, SSH behavior,
Neovim behavior, WezTerm behavior, mise task semantics, pre-commit hook
semantics, EditorConfig semantics, or GitHub Actions semantics.

Rollback is a normal revert of this PR. Reverting restores the previous comment
wording without requiring target-state cleanup.

## Review notes

- Runtime output strings containing `Sovereign Identity` were intentionally left
  unchanged because changing them would alter command output rather than comment
  hygiene.
- `docs/llm/comment-guidelines.md` still names avoided terms because it is the
  policy document that explains them.
- Chezmoi-rendered diffs include trigger hash changes caused by source comment
  edits; generated commands and configuration values are unchanged.
- Neovim changes are limited to comments; `lazy-lock.json` is untouched.
- `.editorconfig` and `.pre-commit-config.yaml` changes are comment-only;
  sections, values, hooks, regexes, formatter arguments, and file ordering are
  unchanged.

## Out of scope

- Provisioning behavior changes
- Identity routing changes
- SSH agent, Git signing, or 1Password behavior changes
- Shell startup order or command execution changes
- Neovim plugin, keymap, option, provider, lazy-loading, or lockfile changes
- WezTerm behavior changes
- mise task semantics, tool versions, runtime versions, dependencies, or
  lockfile changes
- GitHub Actions workflow semantics changes
- EditorConfig or pre-commit behavior changes
- Runtime output string normalization

## Linked issue

Closes #136
