### PR TITLE
Link Chezmoi action graph from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Detailed LLM-assisted maintenance rules live in:
 
 - [Repository agent guidance](./AGENTS.md)
 - [LLM collaboration guidance](./docs/llm/README.md)
+- [Chezmoi action graph](./docs/chezmoi/action-graph.md)
 - [Workflow documentation](./docs/workflows/README.md)
 
 ## References

--- a/docs/llm/README.md
+++ b/docs/llm/README.md
@@ -23,6 +23,8 @@ provisioning behavior.
   validation review, link review, and LLM failure modes.
 - [Chezmoi template guidelines](./chezmoi-template-guidelines.md):
   source-state and rendered-target guidance for Go Template files.
+- [Chezmoi action graph](../chezmoi/action-graph.md): repository-owned
+  action graph and script contracts for current behavior.
 
 ## Related workflow docs
 

--- a/docs/llm/routing.md
+++ b/docs/llm/routing.md
@@ -135,6 +135,9 @@ cleanup into a Worker scope unless the assigned issue explicitly includes it.
 
 ### Chezmoi template changes
 
+Use [Chezmoi action graph](../chezmoi/action-graph.md) for the
+repository-owned action graph and script contracts before behavior-preserving
+refactoring.
 Inspect source-state and rendered-target impact. Be careful with Go Template
 comments, whitespace trimming, shebang placement, blank lines, and target-language
 syntax. See [Chezmoi template guidelines](./chezmoi-template-guidelines.md).


### PR DESCRIPTION
## Summary

Add minimal discoverability links to the Chezmoi action graph document.

## Why

PR #144 added the repository-owned action graph and script contracts for issue
#143. This PR makes that document easier to find from existing README and LLM
routing entry points without duplicating the detailed content.

## Changes

- Link the Chezmoi action graph from the README LLM collaboration section.
- Add the Chezmoi action graph to the LLM collaboration entry points.
- Route behavior-preserving Chezmoi template refactoring through the action
  graph from LLM routing guidance.

## Validation

- [x] `git diff --check`
- [x] `pre-commit run --all-files`
- [x] Markdown relative links resolve, when Markdown links change
- [x] `repomix`, when LLM guidance or snapshot routing changes
- [ ] `mise run doctor`, when setup, toolchain, rendered config, or task behavior changes
- [x] GitHub Actions CI passes

## Risk and rollback

**Risk:** Low. This is documentation-only and adds repository-relative links to
an existing document.

**Rollback:** Revert this PR to remove the added routing links.

## Review notes

This PR intentionally does not rewrite `docs/chezmoi/action-graph.md`, add a new
`docs/chezmoi/README.md`, or modify `ARCHITECTURE.md`.

## Out of scope

- Changing Chezmoi script behavior
- Adding, removing, or normalizing trigger hashes
- Changing provisioning, identity, SSH, WSL bridge, shell, editor, package,
  toolchain, lockfile, or GitHub Actions behavior
- Editing generated `repomix-*.xml` files

## Linked issue

Refs #143
