### PR TITLE
refactor(mise): move setup orchestration to file task

### DIFF
--- a/docs/chezmoi/action-graph.md
+++ b/docs/chezmoi/action-graph.md
@@ -269,6 +269,8 @@ Official mise semantics used here:
 - file tasks must be executable for mise to detect them
 - grouped file-task directories create task names such as `setup:bat` and
   `doctor:nvim`
+- `_default` file tasks define group-level task names such as `setup` and
+  `doctor`
 - `# [MISE]` comments are supported task metadata comments
 
 Repository-local contract:
@@ -276,7 +278,7 @@ Repository-local contract:
 - `run_onchange_after_20-setup-runtimes.sh.tmpl` delegates to:
   - `mise install`
   - `mise run setup`
-- The rendered `setup` task depends on:
+- The rendered `setup` group-level file task depends on:
   - `setup:security`
   - `setup:pnpm`
   - `setup:bat`

--- a/docs/chezmoi/data-contract-boundary.md
+++ b/docs/chezmoi/data-contract-boundary.md
@@ -128,7 +128,7 @@ convention.
 | Git identity fragment | `.chezmoitemplates/git_identity_config.tmpl` | Reusable template fragment | Centralizes the generated per-identity Git config shape used during identity convergence. |
 | Linux package fragment | `.chezmoitemplates/linux-packages.list.tmpl` | Reusable template fragment | Converts static package data plus host OS release data into the Linux package list used by infrastructure setup. |
 | External resources | `.chezmoiexternal.toml.tmpl` | Templated source-state externals | Declares non-package-manager assets and WSL2-specific external entries. |
-| Mise task taxonomy | `dot_config/mise/config.toml.tmpl` and `dot_config/mise/tasks/**` | Repository-local task data and scripts | Uses rendered data to expose setup, doctor, integrate, sync, and update tasks. |
+| Mise task taxonomy | `dot_config/mise/tasks/**` | Repository-local task scripts | Uses rendered data to expose setup, doctor, integrate, sync, and update tasks. |
 
 ## Static .chezmoidata contracts
 
@@ -229,7 +229,7 @@ Current consumers:
 | --- | --- |
 | `.chezmoiscripts/*` | Uses `paths.*`, `osid`, `is_wsl`, `op_status`, `identities`, `ssh_keys_hash`, and WSL2 bridge values for provisioning, setup, identity convergence, bridge sync, and service enablement. |
 | `.chezmoiexternal.toml.tmpl` | Uses architecture and WSL2 data to select external source-state entries. |
-| `dot_config/mise/config.toml.tmpl` | Uses `mise_tools`, `paths.xdg_data`, and `paths.op` to render user-level mise configuration. |
+| `dot_config/mise/config.toml.tmpl` | Uses `mise_tools`, `paths.xdg_data`, and `paths.op` to render user-level mise settings and tools. |
 | `dot_config/mise/tasks/**` | Uses `paths.*`, `identities`, `is_wsl`, and tool paths for setup, doctor, integrate, sync, and update tasks. |
 | rendered Git surfaces | Use `paths.op_sign`, `paths.xdg_config`, `paths.home`, `identities`, and SSH key metadata for signing and scoped identity routing. |
 | rendered SSH surfaces | Use `paths.xdg_config`, `paths.xdg_state`, and SSH socket data for config includes, control sockets, known-hosts paths, and agent routing. |
@@ -294,7 +294,7 @@ action graph table.
 | `.chezmoiscripts/run_onchange_after_90-enable-services.sh.tmpl` | None | `is_wsl`, `npiperelay_wsl` | None | WSL2 bridge service enablement. |
 | `.chezmoiexternal.toml.tmpl` | None | architecture and WSL2 data | None | Non-package-manager external source-state resources. |
 | `dot_config/homebrew/Brewfile.tmpl` | `packages.headless.*`, `packages.gui.*`, `packages.media.*` | Host branch selected by script/template context | None | macOS package declaration surface. |
-| `dot_config/mise/config.toml.tmpl` | `mise_tools` | `paths.xdg_data`, `paths.op` | None | Rendered user-level mise settings, tools, and task config. |
+| `dot_config/mise/config.toml.tmpl` | `mise_tools` | `paths.xdg_data`, `paths.op` | None | Rendered user-level mise settings and tools. |
 | `dot_config/mise/tasks/**` | Rendered tool config indirectly | `paths.*`, `identities`, `is_wsl`, tool paths | None | Rendered setup, doctor, integrate, sync, and update task behavior. |
 | `dot_config/git/config.tmpl` | None | `paths.op_sign`, `paths.xdg_config`, `identities`, identity metadata | Generated identity files from `git_identity_config.tmpl` | SSH signing and scoped Git identity routing. |
 | `dot_config/ssh/config.tmpl` and `private_dot_ssh/symlink_config.tmpl` | None | `paths.xdg_config`, `paths.xdg_state`, SSH socket data | None | SSH config include, socket, and state path routing. |

--- a/docs/chezmoi/mise-task-boundary.md
+++ b/docs/chezmoi/mise-task-boundary.md
@@ -86,7 +86,7 @@ Repository-local contracts used here:
 - `.mise.toml` owns the bootstrap toolchain declaration needed before rendered
   user-level mise configuration is available.
 - `dot_config/mise/config.toml.tmpl` owns the rendered user-level mise tool and
-  task configuration.
+  settings configuration.
 - `dot_config/mise/tasks/**` owns rendered user-level mise file tasks.
 - The `executable_` source-state prefix makes rendered task files executable;
   the source-state files are tracked as `100644` and this issue does not change
@@ -102,11 +102,11 @@ filling the gap with community convention.
 
 ## Repository-local task taxonomy
 
-Current task ownership is split across one TOML task and rendered file tasks.
+Current task ownership is represented by rendered file tasks.
 
 | Task surface | Current owner | Repository-local role |
 | --- | --- | --- |
-| `setup` | `dot_config/mise/config.toml.tmpl` | Orchestrates setup subtasks through `depends = ["setup:security", "setup:pnpm", "setup:bat", "setup:vale"]`. |
+| `setup` | `dot_config/mise/tasks/setup/executable__default.tmpl` | Orchestrates setup subtasks through `depends = ["setup:security", "setup:pnpm", "setup:bat", "setup:vale"]`. |
 | `setup:*` | `dot_config/mise/tasks/setup/*` | Converges local setup artifacts after runtime tools and rendered config are available. |
 | `doctor` | `dot_config/mise/tasks/doctor/executable__default.tmpl` | Orchestrates repository-local health checks and exits non-zero when one or more doctor subtasks fail. |
 | `doctor:*` | `dot_config/mise/tasks/doctor/*` | Performs focused health probes for security, identity, Neovim, Vale, toolchain, npm backend, HubSpot CLI, and completions. |
@@ -158,7 +158,7 @@ Current tasks:
 
 Current orchestration:
 
-- `setup` is defined in `dot_config/mise/config.toml.tmpl`.
+- `setup` is defined by `dot_config/mise/tasks/setup/executable__default.tmpl`.
 - `setup` depends on `setup:security`, `setup:pnpm`, `setup:bat`, and
   `setup:vale`.
 - `run_onchange_after_20-setup-runtimes.sh.tmpl` runs `mise run setup`.
@@ -319,8 +319,8 @@ PR:
   remain separate from the broader `setup` orchestrator.
 - Review whether `sync:wezterm` should be wired into the same boundary as the
   current WezTerm sync script or kept as a separate operator task.
-- Review whether task dependencies should remain in `dot_config/mise/config.toml.tmpl`
-  or move into file-task metadata.
+- Review whether future task metadata should be represented in file-task
+  metadata or rendered configuration.
 - Review whether `update:lazy-lock` should keep its current alias metadata.
 - Review whether doctor task warnings, guide paths, and hard failures should be
   made more uniform.

--- a/dot_config/mise/config.toml.tmpl
+++ b/dot_config/mise/config.toml.tmpl
@@ -32,7 +32,3 @@ npm.package_manager = "pnpm"
 
 [settings.github]
 credential_command = "{{ .paths.op }} read 'op://Development/mise-cli-token/credential'"
-
-[tasks.setup]
-description = "Provision all ecosystem dependencies"
-depends = ["setup:security", "setup:pnpm", "setup:bat", "setup:vale"]

--- a/dot_config/mise/tasks/setup/executable__default.tmpl
+++ b/dot_config/mise/tasks/setup/executable__default.tmpl
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# [MISE] description="Provision all ecosystem dependencies"
+# [MISE] depends=["setup:security", "setup:pnpm", "setup:bat", "setup:vale"]
+{{/* [Reference]: https://mise.jdx.dev/tasks/file-tasks.html */}}{{ "" -}}
+
+set -euo pipefail
+
+:


### PR DESCRIPTION
## Summary

Move the repository-owned `setup` orchestration from rendered TOML task
configuration into the `setup` grouped mise file-task default.

## Why

The `setup:*` subtasks are already represented as rendered mise file tasks, and
`doctor` already uses a grouped file-task default. Moving `setup` to the same
ownership model keeps task orchestration in the rendered file-task surface while
preserving the existing task name, description, dependency metadata, and phase 20
runtime delegation.

## Changes

- Add `dot_config/mise/tasks/setup/executable__default.tmpl` as the grouped
  `setup` file-task default.
- Preserve the `setup` task description:
  `Provision all ecosystem dependencies`.
- Preserve the `setup` dependency metadata:
  `setup:security`, `setup:pnpm`, `setup:bat`, and `setup:vale`.
- Remove only the rendered `[tasks.setup]` definition from
  `dot_config/mise/config.toml.tmpl`.
- Update focused contract docs so they no longer describe
  `dot_config/mise/config.toml.tmpl` as the owner of `setup` orchestration.

## Validation

- [x] `git diff --check`
  - No output; exit code 0.
- [x] `pre-commit run --all-files`
  - Passed:
    - `trim trailing whitespace`
    - `fix end of files`
    - `check yaml`
    - `check for added large files`
    - `shfmt`
    - `stylua`
- [x] Markdown relative links resolve, when Markdown links change
  - `All checked Markdown links resolve.`
- [x] `chezmoi execute-template < dot_config/mise/tasks/setup/executable__default.tmpl`
  - Rendered the expected `# [MISE]` description and depends metadata without
    shell syntax errors.
- [x] `chezmoi execute-template < dot_config/mise/config.toml.tmpl`
  - No longer renders `[tasks.setup]`, the setup description, or the setup
    dependency metadata.
- [x] `chezmoi apply`
  - Completed successfully and delegated phase 20 runtime convergence to
    `mise run setup`.
- [x] `mise tasks info setup`
  - Reported:
    - `Task: setup`
    - `Description: Provision all ecosystem dependencies`
    - `Source: ~/.config/mise/tasks/setup/_default`
    - `Depends on: setup:security, setup:pnpm, setup:bat, setup:vale`
- [x] `mise tasks deps setup`
  - Showed only the preserved setup dependency graph.
- [x] `mise run doctor`
  - Completed successfully with:
    `System Health Evaluation Complete (Zero Drift)`.
- [x] `repomix`
  - Packed successfully to `repomix-dotfiles.xml`.
  - Security check reported no suspicious files.
- [x] GitHub Actions CI passes
  - Pending after PR creation.

## Risk and rollback

**Risk:** Moving `setup` ownership can affect mise task discovery if the rendered
file task is not executable or if mise resolves the task differently than the
former TOML definition.

**Rollback:** Revert this PR to restore the rendered `[tasks.setup]` definition
in `dot_config/mise/config.toml.tmpl`, remove the grouped `setup` file-task
default, and restore the previous contract documentation wording.

## Review notes

The `mise tasks deps setup` tree output did not display dependencies in the same
order as the metadata line, but `mise tasks info setup` reported the preserved
depends metadata in the scoped order:

`setup:security`, `setup:pnpm`, `setup:bat`, `setup:vale`.

The remaining documentation references to `dot_config/mise/config.toml.tmpl`
describe the phase 20 script trigger hash or inspection command surfaces, not
ownership of `setup` orchestration.

## Out of scope

- Do not change `.chezmoiscripts/*`.
- Do not change the `setup` dependency list.
- Do not change the behavior of any `setup:*` subtask.
- Do not adopt, remove, or normalize unmanaged local target-state tasks such as
  `setup:nvim-provider` or `setup:python-provider`.
- Do not change `doctor`, `doctor:*`, `integrate:*`, `sync:*`, or `update:*`
  behavior.
- Do not change package lists, tool versions, runtime versions, dependencies, or
  lockfiles.
- Do not change provisioning, identity, 1Password, SSH, WSL2, shell startup,
  Neovim, WezTerm, Starship, Git, Homebrew, mise, GitHub Actions, or CI
  behavior.
- Do not add, remove, or normalize chezmoi script trigger hashes.

## Linked issue

Closes #166
Refs #165
