### PR TITLE
docs(chezmoi): document mise task taxonomy

### DIFF
--- a/docs/chezmoi/action-graph.md
+++ b/docs/chezmoi/action-graph.md
@@ -18,6 +18,8 @@ For the bootstrap, 1Password, identity, SSH, and WSL2 bridge boundary, see
 [Bootstrap and identity boundary](./bootstrap-identity-boundary.md).
 For the focused mise task delegation boundary, see
 [Mise task boundary](./mise-task-boundary.md).
+For the repository-local target mise task taxonomy used to review future task
+ownership changes, see [Mise task taxonomy](./mise-task-taxonomy.md).
 For read-only mise task source drift inspection, see
 [Mise task source drift inspection](./mise-task-source-drift-inspection.md).
 For the static, dynamic, and reusable template data ownership boundary, see
@@ -452,7 +454,10 @@ requirements for issue #143 unless a future Commander decision scopes them.
   - evaluate whether additional package, tool, or identity-adjacent constants
     should move to `.chezmoidata/`
 - Mise task taxonomy:
-  - clarify task group responsibilities without changing task behavior
+  - use [Mise task taxonomy](./mise-task-taxonomy.md) as the repository-local
+    target review model for future task ownership decisions
+  - keep future task renaming or regrouping in separately scoped
+    behavior-preserving issues
 - Bootstrap and password-manager boundary hardening:
   - separately audit `.bootstrap-identity.sh`, 1Password CLI usage, and WSL2
     relay assumptions

--- a/docs/chezmoi/data-contract-boundary.md
+++ b/docs/chezmoi/data-contract-boundary.md
@@ -23,7 +23,8 @@ the read-only
 [Chezmoi script contract inspection](./script-contract-inspection.md) workflow,
 the [Chezmoi script trigger audit](./script-trigger-audit.md), the
 [Bootstrap and identity boundary](./bootstrap-identity-boundary.md), the
-[Mise task boundary](./mise-task-boundary.md), and
+[Mise task boundary](./mise-task-boundary.md), the
+[Mise task taxonomy](./mise-task-taxonomy.md), and
 [WSL2 convergence validation](./wsl2-convergence-validation.md).
 
 ## Scope and non-goals
@@ -128,7 +129,7 @@ convention.
 | Git identity fragment | `.chezmoitemplates/git_identity_config.tmpl` | Reusable template fragment | Centralizes the generated per-identity Git config shape used during identity convergence. |
 | Linux package fragment | `.chezmoitemplates/linux-packages.list.tmpl` | Reusable template fragment | Converts static package data plus host OS release data into the Linux package list used by infrastructure setup. |
 | External resources | `.chezmoiexternal.toml.tmpl` | Templated source-state externals | Declares non-package-manager assets and WSL2-specific external entries. |
-| Mise task taxonomy | `dot_config/mise/tasks/**` | Repository-local task scripts | Uses rendered data to expose setup, doctor, integrate, sync, and update tasks. |
+| Mise task taxonomy | [`dot_config/mise/tasks/`](../../dot_config/mise/tasks/) and [Mise task taxonomy](./mise-task-taxonomy.md) | Repository-local task scripts and target review model | Uses rendered data to expose current setup, doctor, integrate, sync, and update tasks while documenting target roles for future scoped ownership decisions. |
 
 ## Static .chezmoidata contracts
 

--- a/docs/chezmoi/mise-task-boundary.md
+++ b/docs/chezmoi/mise-task-boundary.md
@@ -16,7 +16,8 @@ the read-only
 [Chezmoi script contract inspection](./script-contract-inspection.md) workflow,
 the [Chezmoi script trigger audit](./script-trigger-audit.md), the
 [Bootstrap and identity boundary](./bootstrap-identity-boundary.md), the
-[Chezmoi data contract boundary](./data-contract-boundary.md), and the
+[Chezmoi data contract boundary](./data-contract-boundary.md), the
+[Mise task taxonomy](./mise-task-taxonomy.md), and the
 [Mise task source drift inspection](./mise-task-source-drift-inspection.md)
 workflow.
 
@@ -116,9 +117,11 @@ Current task ownership is represented by rendered file tasks.
 | `sync:*` | `dot_config/mise/tasks/sync/*` | Performs explicit synchronization workflows that copy or bridge rendered state to another surface. |
 | `update:*` | `dot_config/mise/tasks/update/*` | Performs mutation-oriented maintenance workflows that can create branches, commits, or pull requests. |
 
-The current taxonomy is descriptive, not normative. Future task grouping,
-renaming, dependency cleanup, or logic migration should be scoped separately.
-Use [Mise task source drift inspection](./mise-task-source-drift-inspection.md)
+The current table is descriptive, not normative. For target role boundaries
+and future review criteria, see [Mise task taxonomy](./mise-task-taxonomy.md).
+That taxonomy is a repository-local review model expected to evolve through
+future scoped issues; it is not authorization to change tasks by itself. Use
+[Mise task source drift inspection](./mise-task-source-drift-inspection.md)
 when local mise task visibility needs to be compared with repository-managed
 source-state ownership before changing task boundaries.
 
@@ -329,10 +332,11 @@ PR:
 - Review whether `update:lazy-lock` should keep its current alias metadata.
 - Review whether doctor task warnings, guide paths, and hard failures should be
   made more uniform.
-- Review whether task names should distinguish convergence, validation,
-  synchronization, and mutation more explicitly.
-- Consider generating task documentation from mise only after the desired task
-  taxonomy is settled.
+- Use [Mise task taxonomy](./mise-task-taxonomy.md) to review whether task
+  names should distinguish setup, convergence, validation, repair,
+  synchronization, integration, and update responsibilities more explicitly.
+- Consider generating task documentation from mise only after the repository-local
+  target taxonomy is stable enough for generated documentation.
 
 Future changes in these areas can be behavior-sensitive because they may affect
 chezmoi script execution, mise task resolution, CI, local validation, or

--- a/docs/chezmoi/mise-task-source-drift-inspection.md
+++ b/docs/chezmoi/mise-task-source-drift-inspection.md
@@ -32,7 +32,7 @@ This document covers read-only inspection of:
 
 This document does not:
 
-- define the desired future mise task taxonomy
+- replace the target taxonomy in [Mise task taxonomy](./mise-task-taxonomy.md)
 - rename or regroup `setup:*`, `doctor:*`, `integrate:*`, `sync:*`, or `update:*`
   tasks
 - introduce a `converge:*`, `repair:*`, or other future task group
@@ -80,6 +80,9 @@ Repository-local conventions used here:
   evidence is reported as unmanaged local target-state drift.
 - Drift reporting is evidence collection, not authorization to mutate target
   state.
+- Future taxonomy decisions should use [Mise task taxonomy](./mise-task-taxonomy.md)
+  for target roles and this workflow for source-state versus local target-state
+  evidence.
 
 If official mise or chezmoi documentation does not define a repository-local
 ownership convention, this document labels the convention as repository-local.
@@ -315,4 +318,5 @@ Before using drift evidence to guide a future task refactor, verify:
   normalizing them
 - prior observed examples such as `setup:nvim-provider` and
   `setup:python-provider` were treated as drift examples only
-- future taxonomy or cleanup decisions were deferred to separately scoped issues
+- future taxonomy decisions used [Mise task taxonomy](./mise-task-taxonomy.md) and
+  cleanup decisions were deferred to separately scoped issues

--- a/docs/chezmoi/mise-task-taxonomy.md
+++ b/docs/chezmoi/mise-task-taxonomy.md
@@ -1,0 +1,262 @@
+# Mise task taxonomy
+
+## Purpose
+
+This document defines the repository-local target taxonomy for mise task groups
+in this chezmoi-managed dotfiles source-state repository.
+
+Use it when future issues review whether a repository-owned mise task should
+stay in its current group, move to another group, split into multiple tasks, or
+receive a new name. The taxonomy is a review model for future scoped work. It is
+expected to evolve as the repository's task ownership, validation boundaries,
+and source-drift evidence become clearer.
+
+This document is documentation-only. It does not add, remove, rename, regroup,
+execute, or authorize changing any mise task. It does not change chezmoi scripts,
+mise task behavior, task metadata, executable bits, package lists, tool versions,
+runtime versions, dependencies, lockfiles, provisioning, identity, 1Password,
+SSH, WSL2, shell startup, Neovim, WezTerm, Starship, Git, Homebrew, GitHub
+Actions, or CI behavior.
+
+## Scope and non-goals
+
+This document covers repository-local intended roles for these target task
+groups:
+
+- `setup:*`
+- `converge:*`
+- `doctor:*`
+- `repair:*`
+- `integrate:*`
+- `sync:*`
+- `update:*`
+
+This document does not:
+
+- declare the current task layout to be ideal or final
+- create a `converge:*` or `repair:*` task group
+- rename, regroup, split, merge, add, remove, or normalize any task
+- change `setup`, `setup:*`, `doctor`, `doctor:*`, `integrate:*`, `sync:*`, or
+  `update:*` behavior
+- change task descriptions, aliases, dependencies, executable bits, or task
+  metadata
+- adopt, remove, rename, or normalize unmanaged local target-state tasks
+- replace [Mise task source drift inspection](./mise-task-source-drift-inspection.md)
+  when classifying local task visibility
+- authorize implementation work without a separately scoped issue
+
+## Official semantics boundary
+
+Official mise semantics used here:
+
+- tasks can be defined in `mise.toml` files or as standalone shell scripts
+- file tasks can live under default directories such as `.config/mise/tasks`
+- file tasks must be executable for mise to detect them
+- file tasks in grouped directories receive grouped task names such as
+  `setup:bat` or `doctor:nvim`
+- `_default` file tasks define the group-level task name
+- `mise run <task>` is the explicit task invocation form suitable for scripts and
+  documentation
+- `mise tasks ls`, `mise tasks info`, and `mise tasks deps` inspect task
+  visibility, metadata, and dependency graphs
+- task metadata such as `description`, `alias`, and `depends` is mise task
+  configuration metadata
+
+Official chezmoi semantics used here:
+
+- the repository is source state; rendered target files are what chezmoi manages
+  in the destination directory
+- the `dot_config` source-state attribute maps source files into `.config` in
+  the target state
+- the `executable_` source-state attribute makes rendered target files
+  executable
+- the `.tmpl` source-state attribute marks files as templates before they render
+  into target paths
+- `chezmoi managed` lists target-state entries managed by the current chezmoi
+  source state
+
+Repository-local conventions used here:
+
+- `dot_config/mise/tasks/**` is the repository-owned source-state surface for
+  rendered user-level mise file tasks.
+- `setup:*`, `converge:*`, `doctor:*`, `repair:*`, `integrate:*`, `sync:*`, and
+  `update:*` are repository-local taxonomy groups, not official mise taxonomy.
+- A task group name expresses the task's primary maintenance role in this
+  repository; it does not replace official mise task metadata.
+- Taxonomy decisions must be grounded in repository-owned source-state evidence,
+  not unmanaged local target-state drift.
+
+If official mise or chezmoi documentation does not define a repository-local
+ownership convention, this document labels the convention as repository-local.
+
+## Target task group roles
+
+### `setup:*`
+
+Target role: initial post-render setup only.
+
+Use `setup:*` for tasks that prepare the local environment after chezmoi renders
+source state and after required tools are available. A setup task may install or
+initialize supporting local artifacts when that action is part of first-time or
+post-render provisioning.
+
+A future issue should avoid putting repeated generated artifact convergence in
+`setup:*` when the task is safe and meaningful to rerun independently after the
+initial setup phase. Such work is a candidate for `converge:*`.
+
+### `converge:*`
+
+Target role: idempotent generated artifact or cache convergence.
+
+Use `converge:*` for tasks whose primary purpose is to make generated local
+artifacts match the current source state or tool inputs. A converge task should
+be safe to rerun and should not be limited to first-time setup.
+
+Examples of candidate responsibilities include cache rebuilds, generated support
+files, or other deterministic local artifacts. This document does not create
+those tasks. Moving existing work into `converge:*` requires a separate issue.
+
+### `doctor:*`
+
+Target role: validation and readiness checks.
+
+Use `doctor:*` for tasks that inspect current state, report readiness, and exit
+non-zero when a required condition is not met. A doctor task should prefer
+non-mutating diagnostics and actionable guidance.
+
+A future issue should avoid putting repair or state-changing recovery actions in
+`doctor:*` unless the issue explicitly preserves and documents the current
+behavior. When a task needs to mutate local state to fix a problem, it is a
+candidate for `repair:*` or for being split into `doctor:*` plus `repair:*`.
+
+### `repair:*`
+
+Target role: mutation or repair actions.
+
+Use `repair:*` for tasks whose primary purpose is to change local state to
+recover from drift, broken permissions, stale generated artifacts, or other
+repairable local conditions.
+
+A repair task should be explicit about the state it mutates and should not be
+hidden behind validation-only naming. This document does not create a
+`repair:*` group. Moving existing recovery behavior into `repair:*` requires a
+separate behavior-preserving issue with validation evidence.
+
+### `integrate:*`
+
+Target role: application integration restoration.
+
+Use `integrate:*` for tasks that restore application-level integration state
+that is not represented as static chezmoi source state alone. These tasks bridge
+repository-owned configuration with tool-managed application state.
+
+A future issue should distinguish integration restoration from general setup,
+validation, or update workflows before renaming or regrouping a task.
+
+### `sync:*`
+
+Target role: cross-surface synchronization.
+
+Use `sync:*` for tasks that copy, bridge, or synchronize rendered state across
+surfaces, such as from WSL2 to the Windows host, from source-controlled rendered
+state to a companion runtime surface, or between related local configuration
+surfaces.
+
+A sync task should make the source and destination surfaces explicit. If the
+workflow repairs local state rather than synchronizing across surfaces, it is a
+candidate for `repair:*` instead.
+
+### `update:*`
+
+Target role: local or automated maintenance workflows.
+
+Use `update:*` for tasks that intentionally update repository-managed state,
+refresh dependency or lockfile state, create branches, create commits, or open
+pull requests.
+
+An update task may be mutation-oriented by design, but it should include safety
+checks that prevent mixing unrelated local work with generated updates. Future
+automation should keep update workflows separate from setup, validation, and
+repair naming.
+
+## Decision questions for future task ownership
+
+Before renaming, regrouping, or splitting a task, a future issue should answer:
+
+1. What state does the task read?
+2. What state does the task mutate, if any?
+3. Is the task primarily first-time setup, repeated convergence, validation,
+   repair, integration restoration, cross-surface synchronization, or update
+   automation?
+4. Is the task safe to rerun independently after initial setup?
+5. Does the task need to run from a chezmoi script phase, a manual operator
+   command, CI, or more than one entry point?
+6. Does the task have repository source-state evidence under
+   `dot_config/mise/tasks/**`?
+7. Does `chezmoi managed` show a corresponding managed rendered target path?
+8. Does local `mise tasks ls` visibility match repository-owned source state, or
+   is there unmanaged local target-state drift?
+9. Would a rename change user-facing commands, script delegation, task
+   dependencies, task metadata, aliases, CI, or local validation behavior?
+10. Which validation evidence proves that behavior was preserved?
+
+## Review criteria for renaming or regrouping
+
+Future task renaming or regrouping requires a separately scoped issue. That
+issue should be behavior-preserving unless it explicitly scopes a behavior
+change.
+
+A reviewable task ownership issue should:
+
+- identify the current task name, source-state file, rendered target path, and
+  local mise visibility evidence
+- use [Mise task source drift inspection](./mise-task-source-drift-inspection.md)
+  before treating local task visibility as repository-owned state
+- state the current task role and the proposed target role
+- explain why the proposed group better matches the primary task responsibility
+- list every script, task dependency, alias, CI command, documentation reference,
+  and operator command affected by the rename or regrouping
+- preserve task behavior unless the issue explicitly scopes a behavior change
+- keep validation tasks separate from mutation or repair tasks unless the current
+  behavior is intentionally preserved and documented
+- keep initial post-render setup separate from repeated idempotent convergence
+- avoid adopting or deleting unmanaged local target-state tasks as incidental
+  cleanup
+- include rollback guidance for restoring the previous task name or grouping
+
+## Source drift evidence requirement
+
+Taxonomy decisions must not rely on `mise tasks ls` alone. Local mise visibility
+can include unmanaged target-state tasks that are not owned by the current
+chezmoi source state.
+
+Use [Mise task source drift inspection](./mise-task-source-drift-inspection.md)
+to compare:
+
+- repository source-state task files under `dot_config/mise/tasks/**`
+- rendered target task paths reported by `chezmoi managed`
+- locally visible tasks reported by `mise tasks ls`
+- selected task metadata from `mise tasks info`
+- selected dependency graphs from `mise tasks deps`
+
+A task visible locally without source-state and managed-target evidence should be
+reported as unmanaged local target-state drift, not adopted as taxonomy scope.
+
+## Review checklist
+
+Before approving a future taxonomy-driven task change, verify:
+
+- the issue explicitly scopes the task rename, regrouping, split, or migration
+- the task's primary role matches the proposed target group
+- validation-only work is not hidden behind mutation or repair behavior
+- mutation or repair behavior is not hidden behind validation-only naming
+- first-time setup is separated from repeated idempotent convergence where the
+  distinction affects future ownership
+- source-state, managed-target, and local visibility evidence were compared
+- unmanaged local target-state drift was reported without adopting or deleting it
+- affected scripts, task metadata, aliases, dependencies, CI, and documentation
+  were reviewed
+- behavior preservation claims are backed by command output, CI evidence, or
+  explicit confirmation
+- the change does not treat this taxonomy document as authorization to make
+  unscoped behavior changes


### PR DESCRIPTION
## Summary

Add a focused repository-local target mise task taxonomy document.

## Why

Future task renaming, regrouping, doctor boundary, repair boundary, and
chezmoi script delegation work needs a review model before behavior-preserving
implementation issues are scoped.

This PR documents the target taxonomy without changing any task behavior. It
also makes clear that the taxonomy is repository-local and expected to evolve
through future separately scoped issues.

## Changes

- Add `docs/chezmoi/mise-task-taxonomy.md`.
- Define target roles for:
  - `setup:*`
  - `converge:*`
  - `doctor:*`
  - `repair:*`
  - `integrate:*`
  - `sync:*`
  - `update:*`
- Distinguish validation and readiness checks from mutation or repair actions.
- Distinguish initial post-render setup from repeated idempotent convergence.
- Define review criteria for future task renaming or regrouping issues.
- Link focused chezmoi contract docs to the taxonomy where useful.
- Connect future taxonomy decisions to mise task source drift inspection.

## Validation

- [x] `git diff --check`
  - No output; exit code 0.
- [x] `pre-commit run --all-files`
  - Passed:
    - `trim trailing whitespace`
    - `fix end of files`
    - `check yaml`
    - `check for added large files`
    - `shfmt`
    - `stylua`
- [x] Markdown relative links resolve, when Markdown links change
  - `All checked Markdown links resolve.`
- [x] `repomix`, when LLM guidance or snapshot routing changes
  - Packed successfully to `repomix-dotfiles.xml`.
  - Security check reported no suspicious files.
- [ ] `mise run doctor`, when setup, toolchain, rendered config, or task behavior changes
  - Not run; this PR is documentation-only and does not change setup,
    toolchain, rendered config, or task behavior.
- [x] GitHub Actions CI passes
  - Pending after PR creation.

## Risk and rollback

**Risk:** Future contributors could mistake the taxonomy for authorization to
rename, regroup, create, or delete tasks.

**Rollback:** Revert this PR to remove the taxonomy document and restore the
previous focused documentation links.

## Review notes

The taxonomy is intentionally described as a repository-local target review
model, not as an official mise taxonomy or a final design.

`converge:*` and `repair:*` are documented as target taxonomy categories only.
This PR does not create those task groups.

Future task ownership changes should use the mise task source drift inspection
workflow before treating locally visible tasks as repository-owned source state.

## Out of scope

- Do not rename, add, remove, or regroup any mise task.
- Do not add a `converge:*` or `repair:*` task.
- Do not change `setup`, `setup:*`, `doctor`, `doctor:*`, `integrate:*`,
  `sync:*`, or `update:*` behavior.
- Do not change task descriptions, aliases, dependencies, executable bits, or
  task metadata.
- Do not change `.chezmoiscripts/*`.
- Do not change `dot_config/mise/config.toml.tmpl`.
- Do not change `dot_config/mise/tasks/**`.
- Do not change `.chezmoidata/*`, `.chezmoi.toml.tmpl`,
  `.chezmoiexternal.toml.tmpl`, or `.chezmoitemplates/*`.
- Do not adopt, remove, or normalize unmanaged local target-state tasks.
- Do not change package lists, tool versions, runtime versions, dependencies, or
  lockfiles.
- Do not change provisioning, identity, 1Password, SSH, WSL2, shell startup,
  Neovim, WezTerm, Starship, Git, Homebrew, mise, GitHub Actions, or CI
  behavior.
- Do not add, remove, or normalize chezmoi script trigger hashes.
- Do not edit generated `repomix-*.xml` files.

## Linked issue

Closes #170
Refs #165
