### PR TITLE
docs(readme): clarify supported bootstrap hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,99 +1,221 @@
-# Deterministic Infrastructure Engine
+# dotfiles
 
-[![Infrastructure Compliance](https://github.com/tsubasahomma/dotfiles/actions/workflows/compliance.yml/badge.svg)](https://github.com/tsubasahomma/dotfiles/actions/workflows/compliance.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Compliance](https://github.com/tsubasahomma/dotfiles/actions/workflows/compliance.yml/badge.svg)](https://github.com/tsubasahomma/dotfiles/actions/workflows/compliance.yml)
 [![Built with chezmoi](https://img.shields.io/badge/built%20with-chezmoi-50b0f0.svg)](https://chezmoi.io/)
+[![Managed with mise](https://img.shields.io/badge/managed%20with-mise-blue.svg)](https://mise.jdx.dev/)
 
-A zero-drift, deterministic provisioning engine for macOS Tahoe (26.4.1+) and WSL2 (Ubuntu 24.04+).
+This repository is a chezmoi-managed source-state repository for personal
+workstation configuration.
+
+It uses chezmoi to render host-specific dotfiles, mise to install declared
+runtime tools, and 1Password to provide identity metadata for Git, SSH signing,
+and SSH agent routing.
 
 ## Overview
 
-This repository enforces infrastructure as a deterministic state. It leverages `chezmoi` for state management and `mise-en-place` for hermetic toolchain isolation, using 1Password as the Single Source of Truth (SSOT) for identity and secrets.
+Use this repository to bootstrap and maintain a converged workstation on macOS
+or Windows 11 with Windows Subsystem for Linux 2 (WSL2) Ubuntu 24.04+.
 
-## Prerequisites (Tier -2)
+The README is the first-run entry point. It explains the supported bootstrap
+path and links to focused contract documents for behavior details.
 
-The following manual configurations are **Hard Blocking Requirements**. They must be established to satisfy foundational security and communication gates before automation can evaluate identity templates.
+## Bootstrap model
 
-### 1. Universal (macOS & WSL2)
+First-run bootstrap has two separate prerequisite tracks:
 
-- **1Password Desktop**: [Install and sign in](https://1password.com/downloads/).
-- **1Password CLI (op)**: [Install](https://developer.1password.com/docs/cli/get-started/) and enable [App Integration](https://developer.1password.com/docs/cli/app-integration/).
-- **1Password SSH Key Schema**: The engine requires specific metadata to route Git identities. Each SSH Key item must be tagged and structured as follows:
+- `GITHUB_TOKEN` covers bootstrap-time GitHub access for mise tool resolution
+  and GitHub-hosted metadata or downloads.
+- 1Password identity preparation covers full identity, Git, SSH signing, SSH
+  agent, and identity-routing convergence.
 
-| Attribute   | Value / Field Label  | Requirement                                               |
-| :---------- | :------------------- | :-------------------------------------------------------- |
-| **Tag**     | `dotfiles-ssh-key`   | Mandatory for discovery                                   |
-| **Section** | `dotfiles`           | Field grouping                                            |
-| **Field**   | `dotfiles_git_name`  | Your Git display name                                     |
-| **Field**   | `dotfiles_git_email` | Your Git email address                                    |
-| **Field**   | `dotfiles_git_dirs`  | Comma-separated globs (e.g., `~/src/work,~/src/personal`) |
+You can supply `GITHUB_TOKEN` manually. You don't need to source it from
+1Password, and it doesn't replace the required 1Password identity prerequisites.
 
-#### Quick Provisioning (CLI)
+## Bootstrap a new machine
 
-You can create a compliant item using the `op` CLI (assuming a 'Development' vault exists):
+### Before you start
 
-```bash
-op item create --category='SSH Key' --title='Personal' \
-  --vault='Development' --tags='dotfiles-ssh-key' \
-  'dotfiles.dotfiles_git_name[text]=Your Name' \
-  'dotfiles.dotfiles_git_email[email]=user@example.com' \
-  'dotfiles.dotfiles_git_dirs[text]=~/src/github.com/yourname/,~/src/gitlab.com/yourname/*'
-```
+Prepare these generic requirements before running the bootstrap command:
 
-### 2. macOS Specific
+- A shell with `sh` and `curl` available.
+- A GitHub token for bootstrap-time access.
+- 1Password Desktop installed and signed in.
+- 1Password CLI integration enabled.
+- Required 1Password SSH Key items created with the repository-defined tags and
+  fields.
+- Any host-specific prerequisites for the supported host path you are
+  bootstrapping.
 
-- **Full Disk Access (FDA)**: Grant FDA to your terminal emulator (e.g., WezTerm) in `System Settings > Privacy & Security > Full Disk Access`. This is required to prevent TCC-related deadlocks during automated provisioning of protected directories.
+### Create a GitHub token
 
-### 3. WSL2 Specific
+Create a token by following GitHub's official
+[fine-grained personal access token documentation](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token).
 
-- **npiperelay.exe (Architecture Dependency)**:
-  - **Requirement**: Must be available in the Windows PATH.
-  - **Installation**: `winget.exe install albertony.npiperelay`
-  - **Rationale**: The `chezmoi init` phase executes Go templates that call the 1Password CLI (`op`) to fetch identity metadata. Without the relay bridging the WSL2 socket to the Windows Named Pipe, the template evaluation will fail, blocking the entire bootstrap.
-- **Non-interactive Sudo**: Configure `visudo` to allow the infrastructure engine to provision system packages without interactive prompts.
-  ```bash
-  # Execute 'sudo visudo' and append the following:
-  ${USER} ALL=(ALL) NOPASSWD:ALL
-  ```
+Use the minimum access needed for this repository and the GitHub-hosted resources
+that mise resolves during bootstrap. Keep the token value available for the
+first-run command.
 
-## Installation (Bootstrap)
+> [!IMPORTANT]
+> Treat the token as a secret. Don't paste a real token into issue comments,
+> pull request descriptions, logs, or shared validation output.
 
-Initialize the engine using the following command. This command injects a `GITHUB_TOKEN` to bypass API rate limits during the initial toolchain convergence.
+### Prepare 1Password
+
+Full identity, Git, SSH signing, and SSH agent convergence requires prepared
+1Password identity prerequisites:
+
+- Install 1Password Desktop and sign in.
+- Enable 1Password CLI integration.
+- Create the required SSH Key items in 1Password.
+
+Each repository-managed identity comes from a 1Password SSH Key item with the
+`dotfiles-ssh-key` tag. The item must include the standard SSH Key public key
+metadata and these repository-defined fields:
+
+| Location | Name                 | Purpose                                                          |
+| -------- | -------------------- | ---------------------------------------------------------------- |
+| Tag      | `dotfiles-ssh-key`   | Marks SSH Key items for identity discovery.                      |
+| Section  | `dotfiles`           | Groups repository-specific identity metadata.                    |
+| Field    | `dotfiles_git_name`  | Git author name for the identity.                                |
+| Field    | `dotfiles_git_email` | Git author email for the identity.                               |
+| Field    | `dotfiles_git_dirs`  | Comma-separated directory globs for scoped Git identity routing. |
+
+For the detailed identity contract, see
+[Bootstrap and identity boundary](./docs/chezmoi/bootstrap-identity-boundary.md).
+
+### Prepare your host
+
+Host-specific prerequisites are separate from the generic first-run command.
+Prepare only the supported path that applies to the host you are bootstrapping.
+
+> [!NOTE]
+> This README documents only macOS and Windows 11 with WSL2 Ubuntu 24.04+.
+> Other Linux distributions aren't currently supported first-run targets.
+
+#### macOS
+
+Grant Full Disk Access to the terminal emulator when the host needs to provision
+or inspect protected directories.
+
+#### Windows 11 with WSL2 Ubuntu 24.04+
+
+Prepare Windows 11 with WSL2 Ubuntu 24.04+ as a WSL-to-Windows bridge path,
+not as generic Linux.
+
+WSL2 convergence requires:
+
+- Windows 11 as the host operating system.
+- Ubuntu 24.04 or later as the WSL2 distribution.
+- Windows interop commands available from WSL2, including `cmd.exe`,
+  `powershell.exe`, `wslpath`, and `winget.exe`.
+- Windows-side 1Password Desktop installed and signed in.
+- 1Password CLI integration enabled on the Windows side.
+- `op.exe` discoverable from WSL2.
+- `npiperelay.exe` installed and discoverable from WSL2.
+- User-level systemd available for the 1Password bridge service path.
+- Non-interactive `sudo` configured in WSL2 for Ubuntu package provisioning.
+
+Install `npiperelay.exe` on the Windows side when it isn't already available:
 
 ```zsh
-# Read the PAT from 1Password (SSOT) or provide it manually
-export GITHUB_TOKEN=$(op read "op://Development/mise-cli-token/credential")
-
-# Initialize and apply the state
-sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply <your-github-username>
+winget.exe install albertony.npiperelay
 ```
 
-## Verification
+Configure non-interactive `sudo` before first-run package provisioning. The
+WSL2 Ubuntu provisioning path checks `sudo -n true` before installing system
+packages.
 
-Run the diagnostic suite to verify toolchain integrity and identity routing.
+Use `sudo visudo` and add a rule for the target WSL2 Ubuntu user:
+
+```sudoers
+<linux-username> ALL=(ALL) NOPASSWD:ALL
+```
+
+Replace `<linux-username>` with the WSL2 Ubuntu user that runs
+`chezmoi init --apply`.
+
+For WSL2 validation boundaries, see
+[WSL2 convergence validation](./docs/chezmoi/wsl2-convergence-validation.md).
+
+### Run chezmoi init
+
+Run the supported first-run bootstrap command:
+
+```zsh
+GITHUB_TOKEN=<token> sh -c "$(curl -fsLS https://get.chezmoi.io)" -- init --apply <github-username>
+```
+
+Replace `<token>` with the GitHub token value and `<github-username>` with the
+GitHub account that owns this dotfiles repository.
+
+### Verify convergence
+
+After bootstrap completes, run the repository health check:
 
 ```zsh
 mise run doctor
 ```
 
-## Maintenance
+If the check fails, follow the task output and the focused contract documents
+linked below.
 
-- **Update Toolchains**: `mise install`
-- **Update Neovim Locks**: `mise run update:lazy-lock`
-- **Check Drift**: `chezmoi verify`
-- **De-provisioning (Purge)**: Restore the host toward a clean environment by following the [operational purge guidance in ARCHITECTURE.md](./ARCHITECTURE.md#de-provisioning-purge-sequence).
+## Maintain this repository
 
-## LLM collaboration
+After bootstrap completes, use these commands:
 
-Detailed LLM-assisted maintenance rules live in:
+```zsh
+mise run doctor
+chezmoi verify
+mise run integrate:nvim
+mise run update:lazy-lock
+```
 
-- [Repository agent guidance](./AGENTS.md)
-- [LLM collaboration guidance](./docs/llm/README.md)
-- [Chezmoi action graph](./docs/chezmoi/action-graph.md)
-- [Workflow documentation](./docs/workflows/README.md)
+Use focused issues and pull requests for behavior changes. Keep documentation
+changes scoped to the issue that authorizes them.
 
-## References
+## Troubleshoot first-run failures
 
-- [chezmoi Documentation](https://www.chezmoi.io/user-guide/command-overview/)
-- [mise-en-place Documentation](https://mise.jdx.dev/)
-- [1Password CLI Reference](https://developer.1password.com/docs/cli/reference/)
+Use the failing surface to choose the next check:
+
+- GitHub access or download failures: recreate the GitHub token with the minimum
+  required read access and retry the bootstrap command.
+- 1Password missing or locked: sign in to 1Password Desktop, enable
+  1Password CLI integration, and confirm the required SSH Key item metadata
+  exists.
+- WSL2 Ubuntu package provisioning failures: confirm non-interactive `sudo`
+  with `sudo -n true`, then rerun `chezmoi apply`.
+- WSL2 bridge failures: review Windows interop, `op.exe`, `npiperelay.exe`, user
+  systemd, and SSH agent bridge state with the WSL2 contract document.
+- Post-bootstrap drift: run `mise run doctor` and use the focused contract
+  documents to route the failure.
+
+## Reference documentation
+
+Use these focused documents when the README isn't enough:
+
+| Document                                                                         | Use it for                                                     |
+| -------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| [Bootstrap and identity boundary](./docs/chezmoi/bootstrap-identity-boundary.md) | 1Password, identity discovery, SSH signing, and agent routing. |
+| [WSL2 convergence validation](./docs/chezmoi/wsl2-convergence-validation.md)     | WSL2 bridge assumptions and local validation boundaries.       |
+| [Chezmoi action graph](./docs/chezmoi/action-graph.md)                           | Script phases, rendered surfaces, and validation routing.      |
+
+External references:
+
+- [chezmoi documentation](https://www.chezmoi.io/user-guide/command-overview/)
+- [mise documentation](https://mise.jdx.dev/)
+- [1Password CLI documentation](https://developer.1password.com/docs/cli/)
+
+## Safety boundaries
+
+This README is documentation only. It doesn't change provisioning, identity,
+1Password, SSH, WSL2, shell startup, Neovim, WezTerm, Starship, Git, Homebrew,
+mise, GitHub Actions, CI, package lists, tool versions, runtime versions,
+dependencies, or lockfiles.
+
+Don't edit generated `repomix-*.xml` files. Treat Repomix snapshots as read-only
+repository evidence.
+
+Don't treat GitHub Actions CI as proof of local WSL2 convergence. Local
+Windows 11 and WSL2 health depends on interactive Windows interop, 1Password
+Desktop state, SSH agent bridge state, user systemd behavior, and host runtime
+state.


### PR DESCRIPTION
## Summary

Rewrite `README.md` as the first-run bootstrap entry point for the supported
macOS and Windows 11 with WSL2 Ubuntu 24.04+ host paths.

## Why

The previous README structure did not make the supported first-run bootstrap
model obvious enough. Issue #180 scopes a documentation-only rewrite that makes
the token-only `chezmoi init --apply` path primary while keeping 1Password
identity prerequisites explicit.

## Changes

- Present a single primary first-run bootstrap command with inline
  `GITHUB_TOKEN=<token>`.
- Keep the primary first-run path free of `op read` and `gh` usage.
- Explain that `GITHUB_TOKEN` covers bootstrap-time GitHub access for mise tool
  resolution and GitHub-hosted metadata or downloads.
- Explain that `GITHUB_TOKEN` can be supplied manually and does not replace
  required 1Password identity prerequisites.
- Document required 1Password Desktop, 1Password CLI integration, and SSH Key
  item metadata prerequisites.
- Separate generic prerequisites from host-specific prerequisites.
- Narrow documented first-run support to macOS and Windows 11 with WSL2 Ubuntu
  24.04+.
- Restore WSL2 Ubuntu `sudo visudo` and `npiperelay.exe` prerequisite guidance.
- Keep post-bootstrap verification centered on `mise run doctor`.
- Link focused repository contract documents for identity, WSL2 validation, and
  the chezmoi action graph.

## Validation

- [x] `git diff --check`
  - No output; exit code 0.
- [x] `pre-commit run --all-files`
  - Passed:
    - `trim trailing whitespace`
    - `fix end of files`
    - `check yaml`
    - `check for added large files`
    - `shfmt`
    - `stylua`
- [x] Markdown relative links resolve, when Markdown links change
  - `All README relative links resolve.`
- [x] `repomix`, when LLM guidance or snapshot routing changes
  - Packed successfully to `repomix-dotfiles.xml`.
  - Security check reported no suspicious files.
- [ ] `mise run doctor`, when setup, toolchain, rendered config, or task behavior changes
  - Not run; this PR is README-only and does not change setup, toolchain,
    rendered config, task behavior, or health-check behavior.
- [x] GitHub Actions CI passes
  - Pending after PR creation.

## Risk and rollback

**Risk:** The README could overstate bootstrap guarantees or omit a first-run
prerequisite that is required by the current source state.

**Rollback:** Revert this PR to restore the previous README content.

## Review notes

This PR is documentation-only and behavior-preserving. It does not change any
chezmoi script, mise task, package list, tool version, runtime version,
dependency, lockfile, provisioning behavior, identity behavior, SSH behavior,
WSL2 behavior, shell startup behavior, Neovim behavior, WezTerm behavior,
GitHub Actions workflow, or CI behavior.

The README intentionally documents only macOS and Windows 11 with WSL2 Ubuntu
24.04+ as supported first-run targets. Other Linux distributions are not
documented as supported first-run targets because they are not currently
validated.

## Out of scope

- Do not change `.bootstrap-identity.sh`.
- Do not change `.chezmoi.toml.tmpl`.
- Do not change `.chezmoiexternal.toml.tmpl`.
- Do not change `.chezmoiscripts/*`.
- Do not change `dot_config/mise/**`.
- Do not change `.chezmoidata/*`.
- Do not change package lists, tool versions, runtime versions, dependencies, or
  lockfiles.
- Do not change provisioning, identity, 1Password, SSH, WSL2, shell startup,
  Neovim, WezTerm, Starship, Git, Homebrew, mise, GitHub Actions, or CI
  behavior.
- Do not add bootstrap fallback logic.
- Do not add, remove, or normalize chezmoi script trigger hashes.
- Do not pursue WSL2-like GitHub Actions CI.
- Do not pursue automated `lazy-lock.json` update PRs.
- Do not edit generated `repomix-*.xml` files.

## Linked issue

Closes #180
Refs #179
