### PR TITLE
chore(tools): add Codex app and scc

### DIFF
--- a/.chezmoidata/completions.yaml
+++ b/.chezmoidata/completions.yaml
@@ -20,3 +20,5 @@ completions:
     pnpm: "pnpm"
     zoxide: "aqua:ajeetdsouza/zoxide"
     gcloud: "gcloud"
+    codex: "npm:@openai/codex"
+    scc: "go:github.com/boyter/scc/v3"

--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -56,6 +56,7 @@ packages:
       - notion
       - raycast
       - visual-studio-code
+      - codex-app
       - 1password
       - 1password-cli
     windows:

--- a/.chezmoidata/tools.yaml
+++ b/.chezmoidata/tools.yaml
@@ -43,6 +43,7 @@ mise_tools:
   "aqua:starship/starship": "1.25.1" # renovate: datasource=github-releases packageName=starship/starship
   "aqua:junegunn/fzf": "v0.72.0" # renovate: datasource=github-releases packageName=junegunn/fzf
   "aqua:sharkdp/hyperfine": "1.20.0" # renovate: datasource=github-releases packageName=sharkdp/hyperfine
+  "go:github.com/boyter/scc/v3": "3.7.0" # renovate: datasource=github-releases packageName=boyter/scc
 
   # --- 6. Data & GTM Operations ---
   "aqua:noahgorstein/jqp": "0.8.0" # renovate: datasource=github-releases packageName=noahgorstein/jqp

--- a/.chezmoiscripts/run_onchange_after_21-generate-completions.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_21-generate-completions.sh.tmpl
@@ -25,6 +25,8 @@ export PATH="{{ .paths.home }}/.local/bin:$PATH"
 {{- $id_pnpm := index $tool_keys "pnpm" -}}
 {{- $id_zoxide := index $tool_keys "zoxide" -}}
 {{- $id_gcloud := index $tool_keys "gcloud" -}}
+{{- $id_codex := index $tool_keys "codex" -}}
+{{- $id_scc := index $tool_keys "scc" -}}
 
 MISE_BIN="{{ .paths.mise }}"
 COMP_DIR="{{ .paths.xdg_cache }}/zsh/completions"
@@ -62,6 +64,8 @@ generate_comp "{{ $id_helm }}" "helm" completion zsh > "$COMP_DIR/_helm"
 generate_comp "{{ $id_k9s }}" "k9s" completion zsh > "$COMP_DIR/_k9s"
 generate_comp "{{ $id_lazygit }}" "lazygit" completion zsh > "$COMP_DIR/_lazygit"
 generate_comp "{{ $id_pnpm }}" "pnpm" completion zsh > "$COMP_DIR/_pnpm" || true
+generate_comp "{{ $id_codex }}" "codex" completion zsh > "$COMP_DIR/_codex"
+generate_comp "{{ $id_scc }}" "scc" completion --shell zsh > "$COMP_DIR/_scc"
 
 "$MISE_BIN" exec "{{ $id_delta }}" -- delta --generate-completion zsh 2>/dev/null > "$COMP_DIR/_delta" || true
 


### PR DESCRIPTION
## Summary

Add Codex Desktop App to the macOS GUI package inventory, add scc as a
mise-managed Go tool, and generate Zsh completions for Codex and scc through
the existing completion pipeline.

## Why

Codex Desktop App and scc are useful local development tools, but they should
follow the repository's existing ownership split:

- GUI applications belong in the OS package inventory.
- Versioned CLI tools belong in mise-managed tool data.
- Shell completions should be generated from the existing completion pipeline.

This keeps Codex CLI under the existing `npm:@openai/codex` mise tool instead of
adding Homebrew or winget CLI ownership.

Windows Codex Desktop App is intentionally excluded from this PR. The current
Windows provisioning script installs packages through `winget.exe install --id`
without a data contract for source-specific installs such as `--source msstore`.
Because Codex Desktop App currently requires the Microsoft Store source path,
Windows package ownership should be handled in a separately scoped change if the
repository later adds source-aware winget package support.

## Changes

- Add `codex-app` to the macOS Homebrew cask package inventory.
- Add `go:github.com/boyter/scc/v3` as a mise-managed tool.
- Add Codex and scc to the completion tool-key inventory.
- Generate `_codex` and `_scc` through the existing Zsh completion generation
  script.

## Validation

- [x] `git diff --check`
- [x] `pre-commit run --all-files`
- [ ] Markdown relative links resolve, when Markdown links change
- [ ] `repomix`, when LLM guidance or snapshot routing changes
- [x] `mise run doctor`, when setup, toolchain, rendered config, or task behavior changes
- [x] GitHub Actions CI passes

Additional local validation completed:

- `brew info --cask codex-app`: passed
- `brew list --cask codex-app`: confirmed not installed after smoke test
- `brew info --cask codex`: passed
- `brew list --cask codex`: confirmed not installed
- `mise x npm:@openai/codex@0.128.0 -- codex --version`: passed
- `mise x npm:@openai/codex@0.128.0 -- codex completion zsh`: passed
- `mise x go:github.com/boyter/scc/v3@3.7.0 -- scc --version`: passed
- `scc completion --shell zsh`: verified output starts with `#compdef scc`
- `chezmoi apply --verbose`: passed
- `exec zsh`: completed
- Zsh completion behavior: verified after shell restart

## Risk and rollback

**Risk:**

- `codex-app` adds a macOS GUI application to Homebrew cask convergence.
- `scc` adds a mise-managed Go tool and may require the configured Go runtime.
- Codex and scc completion generation touches the rendered shell completion path.
- Windows Codex Desktop App is not installed by this change.

**Rollback:**

Revert this pull request to remove the `codex-app` cask entry, the `scc` mise
tool entry, the Codex and scc completion keys, and `_codex` / `_scc` generation
from the completion script.

If `codex-app` was installed locally through Homebrew, remove it with:

```zsh
brew uninstall --cask codex-app
```

## Review notes

- Codex CLI remains managed by `npm:@openai/codex`.
- Codex CLI is intentionally not added to Homebrew or winget package ownership.
- Codex Desktop App is intentionally added only to macOS Homebrew casks.
- Windows package ownership for Codex Desktop App is intentionally not included
  because the current Windows provisioning script does not have a source-aware
  winget data contract for Microsoft Store installs.
- scc is managed through mise's Go backend rather than Linux package-manager
  entries.
- scc completion is generated with `scc completion --shell zsh`.

## Out of scope

- Do not add Codex CLI to Homebrew or winget packages.
- Do not add Codex Desktop App to Windows package ownership.
- Do not add Microsoft Store source-specific package handling.
- Do not add unrelated developer tools.
- Do not change CI, Neovim, identity, SSH, or WSL2 behavior.

## Linked issue

N/A — self-contained tooling update.
