### PR TITLE
docs(llm): harden review and inspection guidance

### DIFF
--- a/docs/llm/diff-output-guardrails.md
+++ b/docs/llm/diff-output-guardrails.md
@@ -32,14 +32,15 @@ Use guarded scripts when:
 
 Use non-patch output when the deliverable is not a repository change, such as:
 
+- reusable prompt
 - issue body
 - pull request body
+- review comment
 - commit message
 - review summary
 - command bundle
 - validation bundle
 - inspection bundle
-- reusable prompt
 
 Label non-patch deliverables clearly. Do not present them as apply-ready patches.
 
@@ -139,7 +140,14 @@ Examples:
 - validation command bundle
 
 When generated Markdown includes nested triple-backtick fences, wrap the outer
-chat block with quadruple backticks.
+chat block with quadruple backticks. This applies to prompts, issue bodies, PR
+bodies, review comments, command bundles, validation bundles, inspection
+bundles, reusable prompts, and any other generated Markdown deliverable that
+contains an inner triple-backtick block.
+
+Patch blocks are different: patch code fences must contain only patch content.
+Do not add explanatory prose, labels, validation notes, or nested non-patch
+Markdown inside a patch block.
 
 ## Generated-file discipline
 

--- a/docs/llm/local-state-inspection.md
+++ b/docs/llm/local-state-inspection.md
@@ -54,16 +54,20 @@ repomix --config repomix.config.json
 When several facts are needed, ask for a compact inspection bundle instead of
 one command at a time.
 
+Prefer `zsh` for repository inspection bundles when shell-specific behavior
+matters in this repository. Avoid zsh read-only variable names such as `status`;
+use names such as `exit_code` or `rc` when capturing command results.
+
 A useful pre-work bundle:
 
-```sh
+```zsh
 set +e
 
 run() {
   printf '\n===== %s =====\n' "$*"
   "$@"
-  status=$?
-  printf -- '----- exit code: %s -----\n' "$status"
+  exit_code=$?
+  printf -- '----- exit code: %s -----\n' "$exit_code"
 }
 
 run git branch --show-current
@@ -76,6 +80,8 @@ run find .github -maxdepth 3 -type f
 Keep inspection bundles diagnostic:
 
 - use read-only commands
+- tailor commands to the touched surface instead of always using a generic
+  repository-wide bundle
 - avoid printing secrets or unredacted environment values
 - continue after failures so later state is still visible
 - keep validation pass claims separate from diagnostic output
@@ -117,6 +123,40 @@ exited successfully.
 
 Do not infer one check from another. Local `pre-commit run --all-files` does not
 prove GitHub Actions passed.
+
+## Redaction-safe output capture
+
+For longer inspection bundles, it is acceptable to write output under `/tmp/**`
+for later attachment or pasting after review. Keep the path temporary, avoid
+secrets, and redact local usernames, home directories, install paths, account
+metadata, and other machine-specific values before sharing.
+
+Example pattern:
+
+```zsh
+mkdir -p /tmp/dotfiles-inspection
+output_file="/tmp/dotfiles-inspection/$(date +%Y%m%d%H%M%S)-inspection.txt"
+
+{
+  set +e
+
+  run() {
+    printf '\n===== %s =====\n' "$*"
+    "$@"
+    rc=$?
+    printf -- '----- exit code: %s -----\n' "$rc"
+  }
+
+  run git status --short
+  run git diff --stat
+  run rg -n "pattern" docs README.md
+} >"$output_file" 2>&1
+
+printf 'Inspection output written to %s\n' "$output_file"
+```
+
+Do not treat captured output as shareable until it has been reviewed and
+redacted.
 
 ## Validation evidence handling
 

--- a/docs/llm/review-protocol.md
+++ b/docs/llm/review-protocol.md
@@ -23,6 +23,29 @@ Review in this order:
 Do not start with style preferences when scope, behavior, or validation may be
 wrong.
 
+Inspect broadly enough to notice correctness, safety, docs-impact, and follow-up
+findings. Patch narrowly enough to stay inside the assigned issue or PR slice.
+Preserve useful findings that are outside the current patch scope instead of
+silently dropping them or mixing them into the current diff.
+
+## Finding classification
+
+Classify findings before deciding whether they should change the current patch.
+
+Blocking findings affect correctness, safety, scope alignment, behavior
+preservation, required validation, broken links, or reviewability for the
+assigned issue or PR slice. Fix or request correction before recommending
+approval.
+
+Non-blocking follow-ups are useful improvements that do not block the current
+change. Record them with the observed issue, why they are not blocking, and the
+evidence a future issue would need. Do not implement them in the current patch
+unless the Commander or maintainer explicitly expands the scope.
+
+Out-of-scope findings belong outside the current patch even when they are
+correct. Report them clearly, avoid losing the evidence, and do not create
+follow-up issues automatically unless the maintainer asks for that action.
+
 ## Scope alignment
 
 Compare the diff against the assigned issue, PR slice, Worker prompt, or
@@ -64,6 +87,23 @@ Pay special attention to:
 - runtime versions, tool versions, dependencies, and lockfiles
 
 Do not assume a behavior change is safe because it is small.
+
+## Documentation impact scanning
+
+When code, scripts, tasks, source-state files, operator commands, or documented
+behavior are deleted, renamed, or semantically changed, scan documentation for
+stale references before treating the change as complete.
+
+At minimum, review affected references in `README.md`, `AGENTS.md`, `.github/`,
+`docs/`, and `repomix-instruction.md` when those surfaces could describe the
+changed behavior. Keep the resulting patch limited to current-scope stale or
+misleading documentation. Preserve adjacent but non-blocking findings as
+follow-ups instead of expanding the PR.
+
+Durable documentation should not retain transient issue-specific, PR-specific,
+or conversation-specific meta wording unless the document intentionally has a
+historical decision log. Prefer wording that describes the current repository
+contract, audit basis, or behavior without embedding temporary review context.
 
 ## Validation evidence
 
@@ -130,6 +170,8 @@ Check that docs:
 - use dotfiles-specific terminology
 - avoid monorepo-specific assumptions
 - avoid unsupported claims about tool behavior
+- avoid transient issue-specific or conversation-specific meta wording unless a
+  historical decision log is intentional
 - link to durable repository files when relevant
 
 ## Common LLM failure modes
@@ -147,6 +189,9 @@ Watch for:
 - closing keywords on non-final PRs
 - incidental template comment rewrites
 - unsupported claims about rendered output
+- missing documentation impact scans after deletion, rename, or semantic change
+- durable docs retaining transient issue-specific or conversation-specific meta
+  wording
 
 Request targeted corrections rather than broad rewrites.
 

--- a/docs/workflows/validation-workflow.md
+++ b/docs/workflows/validation-workflow.md
@@ -71,6 +71,26 @@ updates repository-relative links.
 Do not require `chezmoi diff` unless `.chezmoiignore.tmpl` or other
 rendered-output-sensitive template files change.
 
+## Documentation impact scanning
+
+Plan a documentation impact scan when a change deletes, renames, or
+semantically changes code, scripts, mise tasks, source-state files, operator
+commands, documented behavior, or validation entry points. The scan checks
+whether durable docs still describe the old name, behavior, command, phase, task,
+or file as current.
+
+Choose search terms from the changed surface, such as the old filename, new
+filename, task name, command name, script phase, documented behavior phrase, and
+operator-facing command. Focus on likely documentation surfaces first:
+
+```sh
+rg -n "old-name|new-name|task-name|command-name" README.md AGENTS.md .github docs repomix-instruction.md
+```
+
+The scan is validation planning, not permission to broaden the patch. Fix stale
+current-scope documentation that would make the PR misleading. Report adjacent
+or non-blocking findings as follow-ups unless the issue explicitly scopes them.
+
 ## Markdown relative link validation
 
 Use this helper when documentation changes introduce repository-relative links:
@@ -220,6 +240,18 @@ Use:
 - focused review of changed workflow semantics
 
 Do not claim CI passed until the user provides CI evidence.
+
+## Documentation impact and stale-reference reporting
+
+When a docs impact scan finds stale references, report how they were handled:
+
+- updated in the current patch because they were current-scope and misleading
+- reported as non-blocking follow-ups because they were useful but outside scope
+- left unchanged because they were historical records or intentionally scoped
+  decision logs
+
+Do not mark the scan complete unless the searched terms and touched surfaces are
+clear from command output, review notes, or maintainer confirmation.
 
 ## Avoid heavyweight checks by default
 


### PR DESCRIPTION
## Summary

Harden LLM review, diff-output, inspection, and validation guidance so future
Worker Threads inspect broadly, patch narrowly, and preserve useful follow-up
findings without expanding the current patch scope.

## Why

Issue #185 identified recurring review and inspection gaps around finding
classification, transient meta wording in durable docs, nested Markdown fences,
generic inspection bundles, zsh status capture, redaction-safe inspection
output, and documentation impact scanning after deletion, rename, or semantic
changes.

## Changes

- Classify blocking findings, non-blocking follow-ups, and out-of-scope findings
  in the LLM review protocol.
- Make the inspect broadly / patch narrowly principle explicit.
- Warn durable documentation away from transient issue-specific or
  conversation-specific meta wording unless a historical decision log is
  intentional.
- Strengthen nested triple-backtick handling for generated prompts, issue bodies,
  PR bodies, review comments, command bundles, validation bundles, and inspection
  bundles.
- Keep patch blocks strictly patch-only.
- Harden local inspection bundle guidance for zsh, zsh read-only variable names,
  `exit_code` / `rc` status capture, redaction-safe `/tmp/**` output, and
  touched-surface tailoring.
- Add validation-planning guidance for documentation impact scans after deletion,
  rename, or semantic changes.

## Validation

- [x] `git diff --check`
- [x] `pre-commit run --all-files`
- [x] Markdown relative links resolve, when Markdown links change
  - Not run; no Markdown links changed.
- [x] `repomix`
- [x] GitHub Actions CI passes
  - Pending until the PR runs in GitHub Actions.

## Risk and rollback

**Risk:** Overly broad review guidance could be misread as permission to expand
patch scope.

**Rollback:** Revert this pull request to restore the previous LLM and workflow
guidance.

## Review notes

This is documentation-only and does not change repository behavior, chezmoi
scripts, mise tasks, runtime versions, dependencies, lockfiles, GitHub Actions,
or CI semantics.

The guidance intentionally separates broad inspection from narrow patch scope and
routes useful adjacent findings to non-blocking follow-up reporting.

## Out of scope

- File moves or directory reorganization
- New `core/`, `repo/`, or `surfaces/` structures
- Broad LLM guidance rewrites
- Router/index expansion
- Repository behavior changes
- Chezmoi script changes
- Mise task changes
- Tool, runtime, dependency, or lockfile changes
- GitHub Actions or CI behavior changes
- Automatic creation of follow-up issues

## Linked issue

Closes #185
