### PR TITLE
docs(context): define architecture contract

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -1,0 +1,82 @@
+# Context architecture
+
+## Purpose
+
+This directory is the durable architecture entry point for language-model-agnostic
+repository context.
+
+It defines the organization for reusable context guidance, dotfiles-specific
+extensions, surface capsules, workflow guidance, and Repomix context while
+leaving existing documentation, root routers, and repository behavior unchanged.
+
+Use [Context migration map](./migration-map.md) to compare future child issues
+against the current migration plan.
+
+## Architecture layers
+
+| Target path | Responsibility |
+| --- | --- |
+| `docs/context/core/**` | Reusable context guidance that can move to another repository with minimal edits. |
+| `docs/context/local/**` | Dotfiles-specific extension layer that records local repository identity, boundaries, glossary, validation routing, and surface registry. |
+| `docs/context/local/surfaces/**` | Compact local surface capsules that prevent predictable assistant mistakes and route reviewers to the right local evidence. |
+| `docs/context/local/workflows/**` | Local issue, pull request, validation, merge, and closure workflow guidance aligned with this architecture. |
+| `docs/context/repomix/**` | Tracked guidance for consuming Repomix context artifacts and keeping generated context separate from source documentation. |
+| `.context/repomix/**` | Future generated Repomix output storage. Generated artifacts in this path remain read-only evidence, not editable source. |
+
+## Separation contract
+
+Reusable core guidance must avoid dotfiles-specific, chezmoi-specific,
+workstation-specific, and operator-specific assumptions.
+
+Repository-specific assumptions belong under `docs/context/local/**`.
+Surface-specific constraints belong under `docs/context/local/surfaces/**`.
+Repomix consumption guidance belongs under `docs/context/repomix/**`.
+Generated Repomix output belongs under `.context/repomix/**`.
+
+Root routers such as `AGENTS.md`, `repomix-instruction.md`, and
+`.github/copilot-instructions.md` remain current migration inputs until later
+issues explicitly change them.
+
+## Migration contract
+
+Current guidance surfaces are migration inputs, not permanent architecture
+anchors:
+
+- `AGENTS.md`
+- `repomix-instruction.md`
+- `.github/copilot-instructions.md`
+- `docs/llm/**`
+- `docs/workflows/**`
+- `docs/chezmoi/**`
+
+Future migration issues should distill durable requirements before moving,
+compressing, or deleting any old surface. Prefer preserving constraints,
+decision rules, validation requirements, and failure-prevention guidance over
+copying full prose.
+
+The issue #185 / PR #186 hardening is a migration requirement. Future work must
+preserve the discipline to inspect broadly, patch narrowly, avoid invented local
+state, require validation evidence, and record useful out-of-scope findings
+without expanding the active patch.
+
+## Non-goals for this contract
+
+This contract excludes:
+
+- performing the full documentation migration
+- relocating `repomix-instruction.md`
+- moving generated Repomix output to `.context/repomix/**`
+- updating `repomix.config.json`
+- converting `AGENTS.md` into the final root context manifest
+- adding `.github/instructions/**`
+- preserving obsolete documentation by archiving it
+- changing repository behavior, scripts, tasks, CI semantics, versions,
+  dependencies, or lockfiles
+
+## Roadmap use
+
+After each child issue merges, compare the resulting repository state against
+this contract and the migration map before creating the next child issue.
+
+The expected next step after this contract is a separately scoped issue for the
+`docs/context/**` skeleton and Repomix routing work.

--- a/docs/context/migration-map.md
+++ b/docs/context/migration-map.md
@@ -1,0 +1,90 @@
+# Context migration map
+
+## Purpose
+
+This map shows how future child issues should distill current guidance surfaces
+into the target context architecture.
+
+This map is a planning contract for future child issues. It does not authorize
+broad file moves, deletion, archival, root router rewrites, Repomix routing
+changes, or behavior changes in issue #188.
+
+## Current surface classification
+
+| Current surface | Classification | Target treatment | Issue #188 action |
+| --- | --- | --- | --- |
+| `AGENTS.md` | Root guidance input. | Distill later into a concise root context manifest that points to `docs/context/README.md`. | No change. |
+| `repomix-instruction.md` | Repomix instruction input. | Distill and relocate later under `docs/context/repomix/**`, then update Repomix routing in the same scoped issue. | No move. |
+| `.github/copilot-instructions.md` | Vendor-specific adapter input. | Thin later into an adapter that points to the language-model-agnostic context architecture. Keep Copilot-specific guidance out of the primary architecture. | No change. |
+| `docs/llm/**` | Reusable assistant guidance and local failure-prevention input. | Distill repository-agnostic rules into `docs/context/core/**` and dotfiles-specific rules into `docs/context/local/**`. | No move or deletion. |
+| `docs/workflows/**` | Local workflow guidance input. | Distill issue, PR, validation, merge, and closure rules into `docs/context/local/workflows/**`. | No move or deletion. |
+| `docs/chezmoi/**` | Local surface evidence input. | Compress durable chezmoi, mise, WSL2, Neovim, identity, and GitHub Actions constraints into `docs/context/local/surfaces/**`. | No move or deletion. |
+
+## Target area map
+
+| Target area | Accepts | Rejects |
+| --- | --- | --- |
+| `docs/context/core/**` | Repository-agnostic context principles, evidence discipline, routing, output selection, review classification, validation evidence, and drift control. | Dotfiles-specific, chezmoi-specific, workstation-specific, operator-specific, or issue-specific assumptions. |
+| `docs/context/local/**` | Dotfiles repository profile, behavior boundaries, local glossary, validation map, surface registry, and local routing. | Reusable guidance that should live in `docs/context/core/**`. |
+| `docs/context/local/surfaces/**` | Compact capsules for behavior-sensitive local surfaces such as chezmoi, mise, WSL2, Neovim, identity, and GitHub Actions. | Full domain manuals or copied legacy docs. |
+| `docs/context/local/workflows/**` | Local workflow rules for issues, pull requests, validation, merge, closure, Commander coordination, and Worker coordination. | Generic assistant guidance that should live in `docs/context/core/**`. |
+| `docs/context/repomix/**` | Tracked guidance for generating, consuming, validating, and routing Repomix context. | Generated Repomix output. |
+| `.context/repomix/**` | Generated Repomix context artifacts after a later routing issue creates this path. | Hand-edited source documentation. |
+
+## Migration requirements
+
+Future child issues must preserve these requirements while distilling old
+surfaces:
+
+- Treat local repository state as unknown unless current evidence provides it.
+- Treat generated Repomix output as read-only evidence, not editable source.
+- Inspect enough context to avoid local mistakes, but patch only the assigned
+  scope.
+- Preserve issue #185 / PR #186 review, inspection, validation, and output
+  hardening.
+- Claim validation passed only with command output, CI evidence, or explicit
+  maintainer confirmation.
+- Record useful out-of-scope findings without implementing them in the active
+  issue.
+- Prefer distillation over wholesale copying.
+- Prefer deletion over archival only after a later scoped issue migrates or
+  intentionally discards durable content.
+- Keep child issues independently reviewable.
+
+## Distillation rules
+
+When migrating an old surface, classify each paragraph before moving it:
+
+1. Reusable context rule: move or rewrite under `docs/context/core/**`.
+2. Dotfiles-local rule: move or rewrite under `docs/context/local/**`.
+3. Surface-specific constraint: compress into a capsule under
+   `docs/context/local/surfaces/**`.
+4. Local workflow rule: move or rewrite under `docs/context/local/workflows/**`.
+5. Repomix consumption rule: move or rewrite under `docs/context/repomix/**`.
+6. Generated artifact or stale historical detail: skip copying it; discard it
+   only when a scoped issue confirms no durable requirement remains.
+7. Vendor adapter detail: keep only in the relevant adapter surface, with the
+   language-model-agnostic context architecture as the primary target.
+
+Old file boundaries are not durable requirements. Preserve durable requirements,
+routing decisions, validation expectations, and failure-prevention rules.
+
+## Future child issue checkpoints
+
+After each child issue merges, compare the repository against this map:
+
+- Did the change keep reusable core guidance separate from local extensions?
+- Did it avoid turning surface capsules into long domain manuals?
+- Did it preserve issue #185 / PR #186 hardening?
+- Did it avoid broad file moves or deletion unless explicitly scoped?
+- Did it avoid behavior, script, task, CI, version, dependency, and lockfile
+  changes?
+- Did it keep generated artifacts separate from tracked source documentation?
+- Did it update or validate Markdown links when links changed?
+- Did it report out-of-scope findings instead of mixing them into the patch?
+
+## Next handoff
+
+The next child issue can use this map to scope the `docs/context/**` skeleton and
+Repomix routing work. That later issue should decide the exact file list from the
+post-merge repository state rather than treating this map as a prewritten patch.


### PR DESCRIPTION
## Summary

Define the first durable context architecture contract and migration map under
`docs/context/**`.

## Why

Issue #188 needs a small documentation-only contract before later child issues
move, compress, or delete the existing LLM, workflow, and chezmoi guidance
surfaces.

This keeps the migration reviewable and preserves the issue #185 / PR #186
hardening before the broader architecture replacement proceeds.

## Changes

- Add `docs/context/README.md` as the initial architecture contract.
- Add `docs/context/migration-map.md` as the migration map for current guidance
  surfaces.
- Define target responsibilities for reusable core guidance, local extensions,
  local surface capsules, local workflows, tracked Repomix guidance, and future
  generated Repomix output storage.
- Record migration requirements for broad inspection, narrow patching,
  validation evidence, generated artifact discipline, and out-of-scope findings.

## Validation

- [x] `git diff --check`
- [x] `pre-commit run --all-files`
- [x] Markdown relative links resolve, when Markdown links change
- [x] `repomix`, when LLM guidance or snapshot routing changes
- [ ] `mise run doctor`, when setup, toolchain, rendered config, or task behavior changes
- [x] GitHub Actions CI passes

Validation evidence:

- `git diff --check`: no output
- `pre-commit run --all-files`: passed
- `vale docs/context/`: 0 errors, 0 warnings, 2 accepted suggestions
- Markdown relative links resolve
- `repomix`: packed successfully with Repomix v1.14.0

`mise run doctor` was not run because this PR is documentation-only and does not
change setup, toolchain, rendered config, or task behavior.

## Risk and rollback

**Risk:** Low. This PR adds documentation-only architecture guidance and does not
move existing guidance surfaces or change repository behavior.

**Rollback:** Revert this PR to remove the initial `docs/context/**` contract and
migration map.

## Review notes

The remaining Vale contraction suggestions are intentionally accepted as formal
contract wording:

- `does not authorize`
- `are not durable requirements`

This PR intentionally avoids root router rewrites, Repomix routing changes, and
legacy documentation movement. Those belong to later child issues.

## Out of scope

- Do not perform the full documentation migration.
- Do not move or delete `docs/llm/**`, `docs/workflows/**`, or `docs/chezmoi/**`.
- Do not relocate `repomix-instruction.md`.
- Do not move generated Repomix output to `.context/repomix/**`.
- Do not update `repomix.config.json`.
- Do not convert `AGENTS.md` into the final root context manifest.
- Do not add `.github/instructions/**`.
- Do not change repository behavior, scripts, tasks, CI semantics, versions,
  dependencies, or lockfiles.

## Linked issue

Closes #188
Refs #187
