### PR TITLE
docs(context): route Repomix artifacts

### DIFF
--- a/.chezmoiignore.tmpl
+++ b/.chezmoiignore.tmpl
@@ -58,8 +58,8 @@ ARCHITECTURE.md
 AGENTS.md
 docs/**
 .github/**
+.context/repomix/**
 repomix-*.xml
-repomix-instruction.md
 repomix.config.json
 .editorconfig
 .gitattributes

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ pnpm-lock.yaml
 # --- AI & Editor Contexts ---
 repomix-*.xml
 repomix-output.*
+.context/repomix/**
+!.context/repomix/.gitkeep
 .vscode/
 .history/
 .cursorrules

--- a/docs/chezmoi/script-contract-inspection.md
+++ b/docs/chezmoi/script-contract-inspection.md
@@ -311,7 +311,6 @@ root = Path(".").resolve()
 files = list(Path("docs").rglob("*.md")) + [
     Path("AGENTS.md"),
     Path("README.md"),
-    Path("repomix-instruction.md"),
     Path(".github/copilot-instructions.md"),
     Path(".github/pull_request_template.md"),
 ]

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -7,7 +7,7 @@ repository context.
 
 It defines the organization for reusable context guidance, dotfiles-specific
 extensions, surface capsules, workflow guidance, and Repomix context while
-leaving existing documentation, root routers, and repository behavior unchanged.
+leaving legacy documentation inputs and repository behavior unchanged.
 
 Use [Context migration map](./migration-map.md) to compare future child issues
 against the current migration plan.
@@ -21,7 +21,7 @@ against the current migration plan.
 | `docs/context/local/surfaces/**` | Compact local surface capsules that prevent predictable assistant mistakes and route reviewers to the right local evidence. |
 | `docs/context/local/workflows/**` | Local issue, pull request, validation, merge, and closure workflow guidance aligned with this architecture. |
 | `docs/context/repomix/**` | Tracked guidance for consuming Repomix context artifacts and keeping generated context separate from source documentation. |
-| `.context/repomix/**` | Future generated Repomix output storage. Generated artifacts in this path remain read-only evidence, not editable source. |
+| `.context/repomix/**` | Generated Repomix output storage. Generated artifacts in this path remain read-only evidence, not editable source. |
 
 ## Separation contract
 
@@ -33,9 +33,8 @@ Surface-specific constraints belong under `docs/context/local/surfaces/**`.
 Repomix consumption guidance belongs under `docs/context/repomix/**`.
 Generated Repomix output belongs under `.context/repomix/**`.
 
-Root routers such as `AGENTS.md`, `repomix-instruction.md`, and
-`.github/copilot-instructions.md` remain current migration inputs until later
-issues explicitly change them.
+Root routers such as `AGENTS.md` and `.github/copilot-instructions.md` remain
+current migration inputs until later issues explicitly change them.
 
 ## Migration contract
 
@@ -43,11 +42,13 @@ Current guidance surfaces are migration inputs, not permanent architecture
 anchors:
 
 - `AGENTS.md`
-- `repomix-instruction.md`
 - `.github/copilot-instructions.md`
 - `docs/llm/**`
 - `docs/workflows/**`
 - `docs/chezmoi/**`
+
+The Repomix instruction router now lives at
+[docs/context/repomix/instructions.md](./repomix/instructions.md).
 
 Future migration issues should distill durable requirements before moving,
 compressing, or deleting any old surface. Prefer preserving constraints,
@@ -64,9 +65,10 @@ without expanding the active patch.
 This contract excludes:
 
 - performing the full documentation migration
-- relocating `repomix-instruction.md`
-- moving generated Repomix output to `.context/repomix/**`
-- updating `repomix.config.json`
+- distilling full reusable core guidance
+- distilling full repository-specific local guidance
+- creating full local surface capsules
+- migrating workflow guidance
 - converting `AGENTS.md` into the final root context manifest
 - adding `.github/instructions/**`
 - preserving obsolete documentation by archiving it
@@ -78,5 +80,6 @@ This contract excludes:
 After each child issue merges, compare the resulting repository state against
 this contract and the migration map before creating the next child issue.
 
-The expected next step after this contract is a separately scoped issue for the
-`docs/context/**` skeleton and Repomix routing work.
+The expected next step after the skeleton and Repomix routing work is a
+separately scoped issue for distilling reusable guidance into
+`docs/context/core/**`.

--- a/docs/context/core/README.md
+++ b/docs/context/core/README.md
@@ -1,0 +1,20 @@
+# Core context skeleton
+
+## Purpose
+
+This directory is the future home for reusable, repository-agnostic context
+guidance.
+
+Future child issues should distill durable rules here only when they can be
+transplanted to another repository with minimal edits.
+
+## Current status
+
+This issue creates the routing skeleton only. Do not copy legacy manuals into
+this directory during the Repomix routing step.
+
+## Routing
+
+Use [Context migration map](../migration-map.md) before moving guidance into this
+layer. Keep dotfiles-specific, chezmoi-specific, workstation-specific, and
+operator-specific assumptions out of core guidance.

--- a/docs/context/local/README.md
+++ b/docs/context/local/README.md
@@ -1,0 +1,20 @@
+# Local context skeleton
+
+## Purpose
+
+This directory is the dotfiles repository-specific extension layer for the
+context architecture.
+
+Future child issues should place local repository identity, behavior boundaries,
+glossary, validation routing, surface registry, and local workflow routing here.
+
+## Current status
+
+This issue creates the routing skeleton only. Keep existing `docs/llm/**`,
+`docs/workflows/**`, and `docs/chezmoi/**` documents in place as migration
+inputs.
+
+## Routing
+
+Use [Context migration map](../migration-map.md) before distilling local guidance.
+Move reusable guidance to `docs/context/core/**` instead of duplicating it here.

--- a/docs/context/local/surfaces/README.md
+++ b/docs/context/local/surfaces/README.md
@@ -1,0 +1,19 @@
+# Local surface skeleton
+
+## Purpose
+
+This directory is the future home for compact dotfiles surface capsules.
+
+Surface capsules should prevent predictable LLM mistakes and route reviewers to
+the correct local evidence. They should not become full domain manuals.
+
+## Current status
+
+This issue creates the routing skeleton only. Existing
+[chezmoi documentation](../../../chezmoi/) remains migration evidence until a
+later scoped issue distills it.
+
+## Future capsule candidates
+
+Future child issues may add concise capsules for surfaces such as chezmoi, mise,
+WSL2, Neovim, identity, and GitHub Actions.

--- a/docs/context/local/workflows/README.md
+++ b/docs/context/local/workflows/README.md
@@ -1,0 +1,19 @@
+# Local workflow skeleton
+
+## Purpose
+
+This directory is the future home for local issue, pull request, validation,
+merge, and closure workflow guidance aligned with the context architecture.
+
+## Current status
+
+This issue creates the routing skeleton only. Existing
+[workflow documentation](../../../workflows/README.md) remains the migration input
+until a later scoped issue distills it.
+
+## Routing
+
+Future workflow guidance should preserve validation-evidence discipline,
+Commander / Worker boundaries, scoped issue handling, and out-of-scope finding
+reporting while avoiding generic assistant guidance that belongs in
+`docs/context/core/**`.

--- a/docs/context/migration-map.md
+++ b/docs/context/migration-map.md
@@ -6,19 +6,19 @@ This map shows how future child issues should distill current guidance surfaces
 into the target context architecture.
 
 This map is a planning contract for future child issues. It does not authorize
-broad file moves, deletion, archival, root router rewrites, Repomix routing
-changes, or behavior changes in issue #188.
+broad file moves, deletion, archival, root router rewrites, additional Repomix
+routing changes, or behavior changes beyond the active child issue scope.
 
 ## Current surface classification
 
-| Current surface | Classification | Target treatment | Issue #188 action |
+| Source or legacy surface | Classification | Target treatment | Current status |
 | --- | --- | --- | --- |
-| `AGENTS.md` | Root guidance input. | Distill later into a concise root context manifest that points to `docs/context/README.md`. | No change. |
-| `repomix-instruction.md` | Repomix instruction input. | Distill and relocate later under `docs/context/repomix/**`, then update Repomix routing in the same scoped issue. | No move. |
-| `.github/copilot-instructions.md` | Vendor-specific adapter input. | Thin later into an adapter that points to the language-model-agnostic context architecture. Keep Copilot-specific guidance out of the primary architecture. | No change. |
-| `docs/llm/**` | Reusable assistant guidance and local failure-prevention input. | Distill repository-agnostic rules into `docs/context/core/**` and dotfiles-specific rules into `docs/context/local/**`. | No move or deletion. |
-| `docs/workflows/**` | Local workflow guidance input. | Distill issue, PR, validation, merge, and closure rules into `docs/context/local/workflows/**`. | No move or deletion. |
-| `docs/chezmoi/**` | Local surface evidence input. | Compress durable chezmoi, mise, WSL2, Neovim, identity, and GitHub Actions constraints into `docs/context/local/surfaces/**`. | No move or deletion. |
+| `AGENTS.md` | Root guidance input. | Distill later into a concise root context manifest that points to `docs/context/README.md`. | No change in issue #190. |
+| `repomix-instruction.md` | Former root Repomix instruction input. | Relocated under `docs/context/repomix/**`; keep generated output under `.context/repomix/**`. | Moved to `docs/context/repomix/instructions.md` in issue #190. |
+| `.github/copilot-instructions.md` | Vendor-specific adapter input. | Thin later into an adapter that points to the language-model-agnostic context architecture. Keep Copilot-specific guidance out of the primary architecture. | No change in issue #190. |
+| `docs/llm/**` | Reusable assistant guidance and local failure-prevention input. | Distill repository-agnostic rules into `docs/context/core/**` and dotfiles-specific rules into `docs/context/local/**`. | No move or deletion in issue #190. |
+| `docs/workflows/**` | Local workflow guidance input. | Distill issue, PR, validation, merge, and closure rules into `docs/context/local/workflows/**`. | No move or deletion in issue #190. |
+| `docs/chezmoi/**` | Local surface evidence input. | Compress durable chezmoi, mise, WSL2, Neovim, identity, and GitHub Actions constraints into `docs/context/local/surfaces/**`. | No move or deletion in issue #190. |
 
 ## Target area map
 
@@ -29,7 +29,7 @@ changes, or behavior changes in issue #188.
 | `docs/context/local/surfaces/**` | Compact capsules for behavior-sensitive local surfaces such as chezmoi, mise, WSL2, Neovim, identity, and GitHub Actions. | Full domain manuals or copied legacy docs. |
 | `docs/context/local/workflows/**` | Local workflow rules for issues, pull requests, validation, merge, closure, Commander coordination, and Worker coordination. | Generic assistant guidance that should live in `docs/context/core/**`. |
 | `docs/context/repomix/**` | Tracked guidance for generating, consuming, validating, and routing Repomix context. | Generated Repomix output. |
-| `.context/repomix/**` | Generated Repomix context artifacts after a later routing issue creates this path. | Hand-edited source documentation. |
+| `.context/repomix/**` | Generated Repomix context artifacts. | Hand-edited source documentation. |
 
 ## Migration requirements
 
@@ -85,6 +85,7 @@ After each child issue merges, compare the repository against this map:
 
 ## Next handoff
 
-The next child issue can use this map to scope the `docs/context/**` skeleton and
-Repomix routing work. That later issue should decide the exact file list from the
-post-merge repository state rather than treating this map as a prewritten patch.
+After the skeleton and Repomix routing issue merges, the next child issue can use
+this map to scope reusable guidance distillation into `docs/context/core/**`.
+That later issue should decide the exact file list from the post-merge repository
+state rather than treating this map as a prewritten patch.

--- a/docs/context/repomix/README.md
+++ b/docs/context/repomix/README.md
@@ -1,0 +1,21 @@
+# Repomix context routing
+
+## Purpose
+
+This directory contains tracked guidance for generating and consuming Repomix
+context artifacts.
+
+Use [Repomix instruction router](./instructions.md) as the instruction file
+configured by `repomix.config.json`.
+
+## Generated output
+
+Repomix generated output is routed to [`.context/repomix/`](../../../.context/repomix/).
+Generated output in that directory is read-only evidence and must not be edited
+directly or tracked as source documentation.
+
+## Scope boundary
+
+This directory contains Repomix consumption guidance only. Reusable context rules
+belong under `docs/context/core/**`, and dotfiles-specific extensions belong
+under `docs/context/local/**`.

--- a/docs/context/repomix/instructions.md
+++ b/docs/context/repomix/instructions.md
@@ -3,12 +3,12 @@
 This file provides instruction routing for LLMs consuming Repomix snapshots of
 this repository.
 
-Use [AGENTS.md](./AGENTS.md) as the primary repository-wide guidance.
+Use [AGENTS.md](../../../AGENTS.md) as the primary repository-wide guidance.
 
-Use [docs/llm/README.md](./docs/llm/README.md) and
-[docs/workflows/README.md](./docs/workflows/README.md) for detailed LLM
+Use [docs/llm/README.md](../../llm/README.md) and
+[docs/workflows/README.md](../../workflows/README.md) for detailed LLM
 collaboration and workflow guidance. Use
-[docs/llm/comment-guidelines.md](./docs/llm/comment-guidelines.md) when reviewing
+[docs/llm/comment-guidelines.md](../../llm/comment-guidelines.md) when reviewing
 or changing comments and references.
 
 This repository is a chezmoi-managed dotfiles source-state repository. Preserve

--- a/docs/llm/README.md
+++ b/docs/llm/README.md
@@ -32,7 +32,7 @@ provisioning behavior.
   validation, merge, and closure workflows.
 - [Repository agent guidance](../../AGENTS.md): repository-wide agent boundaries
   and validation expectations.
-- [Repomix instruction router](../../repomix-instruction.md): Repomix snapshot
+- [Repomix instruction router](../context/repomix/instructions.md): Repomix snapshot
   instruction entry point.
 
 ## Repository posture

--- a/docs/llm/review-protocol.md
+++ b/docs/llm/review-protocol.md
@@ -95,10 +95,10 @@ behavior are deleted, renamed, or semantically changed, scan documentation for
 stale references before treating the change as complete.
 
 At minimum, review affected references in `README.md`, `AGENTS.md`, `.github/`,
-`docs/`, and `repomix-instruction.md` when those surfaces could describe the
-changed behavior. Keep the resulting patch limited to current-scope stale or
-misleading documentation. Preserve adjacent but non-blocking findings as
-follow-ups instead of expanding the PR.
+`docs/`, and `docs/context/repomix/instructions.md` when those surfaces could
+describe the changed behavior. Keep the resulting patch limited to
+current-scope stale or misleading documentation. Preserve adjacent but
+non-blocking findings as follow-ups instead of expanding the PR.
 
 Durable documentation should not retain transient issue-specific, PR-specific,
 or conversation-specific meta wording unless the document intentionally has a
@@ -133,7 +133,7 @@ Check links to current files, especially:
 - [GitHub Copilot instructions](../../.github/copilot-instructions.md)
 - [Pull request template](../../.github/pull_request_template.md)
 - [Change request issue form](../../.github/ISSUE_TEMPLATE/change-request.yml)
-- [Repomix instruction router](../../repomix-instruction.md)
+- [Repomix instruction router](../context/repomix/instructions.md)
 - [Repomix config](../../repomix.config.json)
 - [Workflow docs](../workflows/README.md)
 - [LLM docs](./README.md)

--- a/docs/llm/routing.md
+++ b/docs/llm/routing.md
@@ -36,8 +36,8 @@ Start with these repository-wide entry points:
 - [LLM collaboration index](./README.md): LLM-specific guidance.
 - [Workflow documentation](../workflows/README.md): issue, PR, validation, merge,
   and closure workflows.
-- [Repomix instruction router](../../repomix-instruction.md): instructions for
-  LLMs consuming Repomix snapshots.
+- [Repomix instruction router](../context/repomix/instructions.md):
+  instructions for LLMs consuming Repomix snapshots.
 - [GitHub Copilot instructions](../../.github/copilot-instructions.md): thin
   router for tools that consume GitHub Copilot repository instructions directly.
 
@@ -104,9 +104,10 @@ If configuration discovery is unclear, use the explicit fallback:
 repomix --config repomix.config.json
 ```
 
-Do not edit generated `repomix-*.xml` files. Do not add alternate repository-owned
-Repomix configs, wrapper tasks, or skeleton snapshots unless a future issue
-explicitly scopes that work.
+Generated Repomix output is routed under `.context/repomix/**`. Do not edit
+generated `repomix-*.xml` files. Do not add alternate repository-owned Repomix
+configs, wrapper tasks, or skeleton snapshots unless a future issue explicitly
+scopes that work.
 
 ## Workflow routing
 
@@ -188,8 +189,9 @@ success from local validation.
 
 ### Repomix routing changes
 
-Keep `repomix.config.json` and `repomix-instruction.md` aligned. Validate with
-`repomix` and inspect whether generated snapshots include the intended guidance.
+Keep `repomix.config.json` and `docs/context/repomix/instructions.md` aligned.
+Validate with `repomix` and inspect whether generated snapshots include the
+intended guidance under `.context/repomix/**`.
 
 ## Uncertainty handling
 

--- a/docs/workflows/validation-workflow.md
+++ b/docs/workflows/validation-workflow.md
@@ -84,7 +84,7 @@ filename, task name, command name, script phase, documented behavior phrase, and
 operator-facing command. Focus on likely documentation surfaces first:
 
 ```sh
-rg -n "old-name|new-name|task-name|command-name" README.md AGENTS.md .github docs repomix-instruction.md
+rg -n "old-name|new-name|task-name|command-name" README.md AGENTS.md .github docs
 ```
 
 The scan is validation planning, not permission to broaden the patch. Fix stale
@@ -104,7 +104,6 @@ root = Path(".").resolve()
 files = list(Path("docs").rglob("*.md")) + [
     Path("AGENTS.md"),
     Path("README.md"),
-    Path("repomix-instruction.md"),
     Path(".github/copilot-instructions.md"),
     Path(".github/pull_request_template.md"),
 ]
@@ -149,14 +148,14 @@ PY
 Run `repomix` when changes affect:
 
 - `repomix.config.json`
-- `repomix-instruction.md`
+- `docs/context/repomix/instructions.md`
 - LLM routing docs
 - snapshot guidance
 - repository context generation
 
 Check that the command completes and that generated snapshots include the
-expected guidance without including generated `repomix-*.xml` artifacts as
-source.
+expected guidance and writes generated output under `.context/repomix/**` without
+including generated `repomix-*.xml` artifacts as source.
 
 ## Chezmoi template and rendered-output validation
 

--- a/repomix.config.json
+++ b/repomix.config.json
@@ -4,13 +4,13 @@
     "maxFileSize": 52428800
   },
   "output": {
-    "filePath": "repomix-dotfiles.xml",
+    "filePath": ".context/repomix/repomix-dotfiles.xml",
     "style": "xml",
     "parsableStyle": false,
     "fileSummary": true,
     "directoryStructure": true,
     "files": true,
-    "instructionFilePath": "repomix-instruction.md",
+    "instructionFilePath": "docs/context/repomix/instructions.md",
     "removeComments": false,
     "removeEmptyLines": false,
     "compress": false,
@@ -28,12 +28,11 @@
       "includeLogsCount": 50
     }
   },
-  "include": ["**/*"],
   "ignore": {
     "useGitignore": true,
     "useDotIgnore": false,
     "useDefaultPatterns": true,
-    "customPatterns": [".chezmoistate.json", "repomix-*.xml"]
+    "customPatterns": [".chezmoistate.json", "repomix-*.xml", ".context/repomix/**"]
   },
   "security": {
     "enableSecurityCheck": true


### PR DESCRIPTION
## Summary

Create the minimal `docs/context/**` skeleton and route Repomix instruction and
generated output artifacts into the new context architecture.

## Why

Issue #190 is the second child issue under parent issue #187. It makes the target
context paths real before later issues distill durable reusable, local, surface,
and workflow guidance.

This also moves generated Repomix output away from the repository root and keeps
generated context artifacts separate from tracked source documentation.

## Changes

- Add concise routing skeletons for:
  - `docs/context/core/**`
  - `docs/context/local/**`
  - `docs/context/local/surfaces/**`
  - `docs/context/local/workflows/**`
  - `docs/context/repomix/**`
- Move `repomix-instruction.md` to
  `docs/context/repomix/instructions.md`.
- Update `repomix.config.json` so Repomix reads the tracked instruction file from
  `docs/context/repomix/instructions.md`.
- Update `repomix.config.json` so generated output writes to
  `.context/repomix/repomix-dotfiles.xml`.
- Add `.context/repomix/.gitkeep` while ignoring generated Repomix XML output.
- Update `.chezmoiignore.tmpl` so `.context/repomix/**` does not deploy into the
  target home directory.
- Update Markdown and router references that pointed at the old root
  `repomix-instruction.md` path.
- Remove the default `"include": ["**/*"]` Repomix glob so ad hoc CLI
  `--include` snapshots can be focused.

## Validation

- [x] `git diff --check`
- [x] `pre-commit run --all-files`
- [x] Markdown relative links resolve, when Markdown links change
- [x] `repomix`, when LLM guidance or snapshot routing changes
- [ ] `mise run doctor`, when setup, toolchain, rendered config, or task behavior changes
- [x] GitHub Actions CI passes

Validation evidence:

- `git diff --check`: no output
- `pre-commit run --all-files`: passed
- Markdown relative links resolve
- `repomix`: packed successfully with output at
  `.context/repomix/repomix-dotfiles.xml`
- `test -f .context/repomix/repomix-dotfiles.xml`: exit code 0
- `git status --short --ignored .context/repomix`: generated Repomix XML files
  are ignored; `.context/repomix/.gitkeep` is tracked
- `git check-ignore -v .context/repomix/repomix-dotfiles.xml`: ignored by
  `.gitignore`
- `repomix --include docs/context/README.md -o /tmp/repomix-focused-issue190.xml`:
  packed 1 file
- `grep -q 'file path="dot_config/' /tmp/repomix-focused-issue190.xml`:
  exit code 1
- `chezmoi diff`: no output
- `chezmoi execute-template < .chezmoiignore.tmpl`: rendered
  `.context/repomix/**`
- `repomix --include-diffs --include "$changed_files" -o
  .context/repomix/repomix-dotfiles-issue190.xml`: packed successfully
- `git check-ignore -v .context/repomix/repomix-dotfiles-issue190.xml`:
  ignored by `.gitignore`

`mise run doctor` was not run because this PR is limited to documentation
routing, Repomix configuration, generated-artifact ignore rules, and
`.chezmoiignore.tmpl` rendered-output inspection. It does not change setup,
toolchain, rendered runtime config, task behavior, health-check behavior, scripts,
CI semantics, versions, dependencies, or lockfiles.

## Risk and rollback

**Risk:** Low to moderate. The documentation skeleton and link updates are low
risk. The Repomix output path and instruction path change operator workflow
routing, and removing the default include glob changes focused Repomix snapshot
behavior.

**Rollback:** Revert this PR to restore the root `repomix-instruction.md`,
repository-root Repomix output routing, previous ignore behavior, and previous
Repomix include defaults.

## Review notes

The context skeleton files are intentionally concise routers. This PR does not
distill reusable core guidance, repository-specific local guidance, local surface
capsules, or workflow guidance.

The removal of `"include": ["**/*"]` was a maintainer decision after validation
showed that focused CLI `--include` snapshots now work as intended. It is
included in this PR because it directly affects the usability of the new Repomix
routing, but it should be reviewed separately from the skeleton content.

Generated Repomix outputs remain read-only evidence and are ignored under
`.context/repomix/**`.

## Out of scope

- Do not perform the full documentation migration.
- Do not distill reusable guidance into `docs/context/core/**` beyond concise
  skeleton routing.
- Do not distill repository-specific guidance into `docs/context/local/**` beyond
  concise skeleton routing.
- Do not create full local surface capsules under
  `docs/context/local/surfaces/**`.
- Do not migrate workflow guidance into `docs/context/local/workflows/**`.
- Do not convert `AGENTS.md` into the final root context manifest.
- Do not delete `docs/llm/**`, `docs/workflows/**`, or `docs/chezmoi/**`.
- Do not archive obsolete docs merely to avoid deleting them.
- Do not add `.github/instructions/**`.
- Do not introduce Copilot-specific architecture as the primary target.
- Do not change chezmoi scripts.
- Do not change mise tasks.
- Do not change GitHub Actions semantics.
- Do not change runtime versions, tool versions, dependencies, or lockfiles.
- Do not hand-edit generated Repomix output.

## Linked issue

Closes #190
Refs #187
