### PR TITLE
docs(context): distill reusable core guidance

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -16,7 +16,7 @@ against the current migration plan.
 
 | Target path | Responsibility |
 | --- | --- |
-| `docs/context/core/**` | Reusable context guidance that can move to another repository with minimal edits. |
+| `docs/context/core/**` | Reusable context guidance for principles, evidence, output, review, validation, generated artifacts, drift control, and out-of-scope findings. |
 | `docs/context/local/**` | Dotfiles-specific extension layer that records local repository identity, boundaries, glossary, validation routing, and surface registry. |
 | `docs/context/local/surfaces/**` | Compact local surface capsules that prevent predictable assistant mistakes and route reviewers to the right local evidence. |
 | `docs/context/local/workflows/**` | Local issue, pull request, validation, merge, and closure workflow guidance aligned with this architecture. |
@@ -47,8 +47,9 @@ anchors:
 - `docs/workflows/**`
 - `docs/chezmoi/**`
 
-The Repomix instruction router now lives at
-[docs/context/repomix/instructions.md](./repomix/instructions.md).
+Core reusable guidance now starts at
+[docs/context/core/README.md](./core/README.md). The Repomix instruction
+router lives at [docs/context/repomix/instructions.md](./repomix/instructions.md).
 
 Future migration issues should distill durable requirements before moving,
 compressing, or deleting any old surface. Prefer preserving constraints,
@@ -65,7 +66,6 @@ without expanding the active patch.
 This contract excludes:
 
 - performing the full documentation migration
-- distilling full reusable core guidance
 - distilling full repository-specific local guidance
 - creating full local surface capsules
 - migrating workflow guidance
@@ -80,6 +80,6 @@ This contract excludes:
 After each child issue merges, compare the resulting repository state against
 this contract and the migration map before creating the next child issue.
 
-The expected next step after the skeleton and Repomix routing work is a
-separately scoped issue for distilling reusable guidance into
-`docs/context/core/**`.
+After reusable core guidance is distilled, the expected next step is a
+separately scoped issue for distilling repository-specific guidance into
+`docs/context/local/**`.

--- a/docs/context/core/README.md
+++ b/docs/context/core/README.md
@@ -1,20 +1,33 @@
-# Core context skeleton
+# Core context guidance
 
 ## Purpose
 
-This directory is the future home for reusable, repository-agnostic context
-guidance.
+This directory contains reusable, repository-agnostic context guidance for
+LLM-assisted maintenance.
 
-Future child issues should distill durable rules here only when they can be
-transplanted to another repository with minimal edits.
+Copy this layer to another repository when the target repository wants shared
+rules for evidence handling, routing, output formats, review classification,
+validation reporting, generated artifacts, drift control, and out-of-scope
+findings.
 
-## Current status
+## Core documents
 
-This issue creates the routing skeleton only. Do not copy legacy manuals into
-this directory during the Repomix routing step.
+- [Context principles](./principles.md): reusable context architecture,
+  routing, scope, maintenance, and out-of-scope finding principles.
+- [Evidence discipline](./evidence.md): source hierarchy, unknown-state rules,
+  validation evidence, generated artifacts, and sensitive data handling.
+- [Output discipline](./output.md): output format selection, strict patch rules,
+  guarded scripts, non-patch deliverables, and whitespace discipline.
+- [Review discipline](./review.md): review priorities, finding classification,
+  validation review, drift control, and follow-up handling.
 
-## Routing
+## Reusable boundary
+
+Core guidance should describe durable rules that survive repository migration.
+Keep repository-specific identity, behavior boundaries, domain constraints,
+workflow procedures, and tool-specific operating details in the local context
+layer instead of duplicating them here.
 
 Use [Context migration map](../migration-map.md) before moving guidance into this
-layer. Keep dotfiles-specific, chezmoi-specific, workstation-specific, and
-operator-specific assumptions out of core guidance.
+layer. Old file boundaries are not durable requirements; preserve the reusable
+rule, not the legacy document shape.

--- a/docs/context/core/evidence.md
+++ b/docs/context/core/evidence.md
@@ -1,0 +1,105 @@
+# Evidence discipline
+
+## Purpose
+
+Use evidence discipline to ground LLM-assisted work in current repository state
+and to prevent invented facts, stale assumptions, and unsupported validation
+claims.
+
+## Source and evidence hierarchy
+
+Prefer the most specific current evidence available for the active task.
+
+A useful hierarchy is:
+
+1. explicit user instructions for the active task
+2. current file contents, diffs, command output, or CI evidence
+3. linked issue, pull request, or design-contract text
+4. repository guidance that applies to the touched surface
+5. generated or packed snapshots as read-only evidence
+6. general knowledge, only when it does not contradict repository evidence
+
+When sources conflict, call out the conflict and prefer current task evidence or
+current repository evidence over older summaries.
+
+## Unknown state rule
+
+Do not invent repository state.
+
+If a file, branch, diff, command result, validation result, pull request state,
+issue state, tool version, generated artifact, or CI result has not been provided
+or inspected, do not claim it as fact.
+
+Use conditional language only when the uncertainty matters, and request or run
+the smallest useful inspection needed to resolve it.
+
+## Inspection discipline
+
+Use read-only inspection before producing targeted changes when the current
+contents are not known.
+
+Good inspection is:
+
+- scoped to the task
+- sufficient to make hunk context or guidance accurate
+- careful with sensitive local data
+- explicit about command output and exit status when used as evidence
+- separate from validation pass claims
+
+Do not mix inspection output with generated patch content.
+
+## Current-file requirement for patches
+
+Do not produce a targeted patch against an existing file unless current file
+contents are known well enough for the hunk context to match.
+
+Acceptable evidence includes current file contents, current diffs, current
+inspection output, or a current generated snapshot that includes the file.
+
+If contents are incomplete or stale, obtain the missing context instead of
+writing a speculative patch.
+
+## Validation evidence
+
+A validation claim requires evidence.
+
+Evidence can be command output, exit status, CI result, directly inspected state,
+or explicit maintainer confirmation. Do not mark validation complete because a
+check is expected to pass, because another check passed, or because a patch looks
+safe.
+
+Report validation as evidence, not aspiration. If a check was not run, say so
+and explain why when the reason affects review.
+
+## Generated artifact discipline
+
+Generated, packed, rendered, or temporary artifacts are evidence unless the
+active task explicitly scopes editing their source mechanism.
+
+Do not hand-edit generated artifacts. Change the source files or generation
+configuration, then regenerate artifacts when validation requires it.
+
+If a generated snapshot conflicts with fresher local evidence, prefer the
+fresher evidence and call out the snapshot as stale.
+
+## Sensitive data handling
+
+Avoid requesting, printing, or preserving secrets and unnecessary local
+identifiers.
+
+Be careful with tokens, keys, account identifiers, private paths, environment
+variables, generated identity material, and unredacted machine-specific output.
+
+Prefer structural inspection over secret-bearing output. Ask for redaction when
+shared evidence may include sensitive data.
+
+## Evidence in final deliverables
+
+Make final deliverables distinguish facts from recommendations.
+
+For repository changes, cite or mention the evidence that supports scope,
+validation, and risk claims. For reviews, tie findings to exact files, commands,
+or observed behavior whenever possible.
+
+Do not overstate certainty. If a patch was not applied or validation was not run,
+say that directly.

--- a/docs/context/core/output.md
+++ b/docs/context/core/output.md
@@ -1,0 +1,140 @@
+# Output discipline
+
+## Purpose
+
+Use output discipline to choose a deliverable format that is accurate,
+reviewable, and safe to apply.
+
+The output format should match the task, available evidence, and expected
+application path.
+
+## Output format selection
+
+Use a strict unified diff when:
+
+- the user asks for a patch
+- the change modifies existing files
+- the change must be applied with `git apply`
+- multiple existing files must change atomically
+
+Use whole-file heredocs when:
+
+- creating new text files
+- replacing a short file in full with known current contents
+- hunk context would be fragile or noisy
+- the requested delivery path is a shell command that writes files
+
+Use guarded scripts when:
+
+- the edit is mechanical across known files
+- the script can fail if expected text is missing
+- a large handwritten patch would be harder to review safely
+
+Use non-patch output when the deliverable is not a repository edit, such as a
+review summary, issue body, pull request body, commit message, command bundle,
+validation bundle, or reusable prompt.
+
+## Strict unified diff requirements
+
+For repository changes intended for `git apply`, use Git extended unified diff
+format.
+
+A normal modified file should include:
+
+```diff
+diff --git a/path/to/file b/path/to/file
+--- a/path/to/file
++++ b/path/to/file
+@@ -1,3 +1,4 @@
+```
+
+A new file should include:
+
+```diff
+diff --git a/path/to/file b/path/to/file
+new file mode 100644
+--- /dev/null
++++ b/path/to/file
+@@ -0,0 +1,3 @@
+```
+
+A deleted file should include:
+
+```diff
+diff --git a/path/to/file b/path/to/file
+deleted file mode 100644
+--- a/path/to/file
++++ /dev/null
+@@ -1,3 +0,0 @@
+```
+
+Do not include placeholder hashes, pseudo-diffs, omitted context markers, or
+prose inside patch blocks.
+
+## Patch content boundary
+
+Patch blocks must contain only patch content.
+
+Keep explanations, validation notes, branch names, commit messages, and commands
+outside the patch block. When a patch is delivered as a downloadable file, keep
+that file limited to apply-ready patch content.
+
+Do not claim a patch is guaranteed to apply unless it was actually checked
+against the current repository state.
+
+## Whole-file heredocs
+
+Whole-file heredocs are useful when creating new text files or replacing a short
+known file.
+
+Use single-quoted heredoc delimiters so shell interpolation does not alter the
+file body. Choose delimiters that are unique to the target file.
+
+After a heredoc edit, inspect the diff and run validation that matches the
+touched surface.
+
+## Guarded scripts
+
+A guarded script should fail when expected state is absent.
+
+Good guarded scripts:
+
+- name target files explicitly
+- check old text before replacing it
+- avoid broad repository-wide rewrites
+- avoid generated artifacts unless explicitly scoped
+- ask the maintainer to inspect the resulting diff
+
+Do not use scripts to hide unclear changes or to bypass missing file context.
+
+## Non-patch deliverables
+
+Label non-patch deliverables clearly and do not present them as apply-ready
+patches.
+
+When generated Markdown contains nested code fences, choose an outer fence that
+will not terminate early. Keep reusable commands, issue bodies, pull request
+bodies, validation bundles, and review comments distinct from patch content.
+
+## Whitespace and final newline discipline
+
+Preserve whitespace precisely.
+
+- Avoid trailing whitespace.
+- Preserve intentional blank lines.
+- Keep indentation stable.
+- End text files with a final newline.
+- Do not rewrap unrelated lines.
+- Do not change rendered-output-sensitive whitespace as incidental cleanup.
+
+Whitespace-only changes should be scoped explicitly or avoided.
+
+## Validation after applying output
+
+After applying repository changes, inspect the resulting tree before claiming
+success.
+
+A typical documentation change should at least inspect status, diff summary, and
+whitespace errors before running the validation required by the touched surface.
+
+Do not infer remote CI status from local checks.

--- a/docs/context/core/principles.md
+++ b/docs/context/core/principles.md
@@ -1,0 +1,112 @@
+# Context principles
+
+## Purpose
+
+Use these principles to keep LLM-assisted maintenance scoped, evidence-based,
+and portable across repositories.
+
+Core context should help an assistant choose the right evidence, output format,
+review posture, and validation standard without embedding repository-specific
+assumptions.
+
+## Context is finite
+
+Treat context as a finite, curated resource.
+
+Prefer compact routing and durable rules over duplicated manuals. Add new core
+rules only when they prevent repeated mistakes or clarify decisions that apply
+across repositories.
+
+Avoid copying long legacy documents into core. Distill the rule, decision point,
+or failure-prevention requirement that remains useful after repository-specific
+examples are removed.
+
+## Separate reusable and local guidance
+
+Keep reusable guidance separate from local extensions.
+
+Core guidance may define general principles such as evidence hierarchy, patch
+strictness, generated artifact discipline, and validation reporting. Local
+guidance should define repository identity, domain behavior boundaries, surface
+capsules, workflow procedures, and tool-specific commands.
+
+When a rule contains repository names, host assumptions, toolchain details,
+private workflow roles, or issue-specific history, rewrite it before placing it
+in core or leave it for the local layer.
+
+## Route before editing
+
+Choose the target responsibility before changing files.
+
+Classify a candidate rule by what it governs:
+
+- reusable context principle
+- evidence or validation discipline
+- output format discipline
+- review classification
+- generated artifact handling
+- local repository behavior
+- local surface constraint
+- local workflow procedure
+- vendor-specific adapter detail
+
+Move or rewrite only the part that belongs in the active target. Do not preserve
+old file boundaries merely because they were the previous documentation shape.
+
+## Inspect broadly, patch narrowly
+
+Inspect enough context to avoid local mistakes, then change only the assigned
+scope.
+
+Broad inspection may include nearby files, current diffs, generated snapshots,
+validation output, linked issues, or relevant documentation. Narrow patching
+means the final change should avoid unrelated cleanup, opportunistic rewrites,
+and hidden behavior changes.
+
+Useful follow-up findings should be recorded separately instead of expanding the
+active patch.
+
+## Preserve behavior unless scoped otherwise
+
+Documentation and context changes must not imply behavior changes unless the
+assigned scope explicitly authorizes them.
+
+Do not change scripts, generated outputs, configuration semantics, dependency
+versions, lockfiles, CI behavior, or runtime behavior as incidental cleanup for a
+context update.
+
+When a behavior-sensitive rule is useful but local, record it for the local
+context layer rather than generalizing it into core.
+
+## Maintain drift control
+
+Context guidance drifts when it duplicates commands, repeats detailed local
+procedures, or preserves obsolete architecture language after a migration step.
+
+Prefer:
+
+- one concise router for each layer
+- focused documents with distinct responsibilities
+- relative links that resolve in the current tree
+- status wording that matches the current migration phase
+- deletion of obsolete prose only after durable rules are migrated or
+  intentionally discarded in a scoped issue
+
+Do not archive stale documentation merely to avoid deciding whether it still has
+unique durable value.
+
+## Preserve out-of-scope findings
+
+Out-of-scope findings are useful maintenance evidence, not permission to broaden
+the patch.
+
+Record:
+
+- what was found
+- why it is outside the active scope
+- why it may matter
+- what evidence is needed later
+- whether it should become follow-up work
+
+Do not implement the finding unless the active issue or task explicitly scopes
+it.

--- a/docs/context/core/review.md
+++ b/docs/context/core/review.md
@@ -1,0 +1,139 @@
+# Review discipline
+
+## Purpose
+
+Use review discipline to classify findings, preserve scope, and make readiness
+claims only when evidence supports them.
+
+A review should determine whether a change matches scope, preserves behavior,
+uses accurate evidence, reports validation honestly, and keeps follow-up work out
+of the active patch.
+
+## Review priorities
+
+Review in this order:
+
+1. scope fit
+2. behavior preservation
+3. evidence accuracy
+4. generated artifact discipline
+5. validation evidence
+6. output format correctness
+7. maintainability and drift risk
+8. prose, style, and link quality
+
+A lower-priority polish finding should not hide a higher-priority scope or
+behavior problem.
+
+## Finding classification
+
+Classify findings by required action:
+
+- Blocking: must be fixed before the change can be accepted.
+- Advisory: useful improvement, but not required for the active scope.
+- Follow-up: valid work that belongs in a later issue or task.
+- Non-issue: observed behavior is acceptable or intentionally scoped.
+
+Use blocking findings for scope violations, unsupported validation claims,
+generated artifact edits, stale or broken links, behavior changes outside scope,
+or output that cannot be applied through the intended path.
+
+Use follow-up findings when the work matters but would broaden the active patch.
+
+## Scope review
+
+Compare the diff with the active issue, task, or request.
+
+Check whether the change:
+
+- touches only authorized files or surfaces
+- avoids unrelated cleanup
+- leaves local or surface-specific work for the proper layer
+- avoids deleting or archiving migration inputs unless explicitly scoped
+- keeps vendor-specific adapters out of the primary architecture unless scoped
+
+If the patch discovers adjacent problems, record them separately rather than
+expanding the change.
+
+## Evidence review
+
+Verify that factual claims are supported by evidence.
+
+Check whether the change:
+
+- distinguishes current evidence from stale snapshots
+- avoids invented file, branch, issue, pull request, command, or CI state
+- uses current file contents for targeted patches
+- treats generated artifacts as evidence rather than editable source
+- avoids exposing sensitive local data
+
+Unsupported claims should be corrected or removed.
+
+## Validation review
+
+Validation must match the touched surface.
+
+A validation item should be marked complete only when command output, exit code,
+CI evidence, inspected state, or explicit maintainer confirmation supports it.
+
+Do not infer one validation result from another. Local checks do not prove remote
+CI, and a clean patch application does not prove semantic correctness.
+
+If validation was intentionally skipped, the reason should be specific and
+consistent with the touched surface.
+
+## Output review
+
+Check that the deliverable format matches the requested application path.
+
+For patches, verify strict unified diff format, sufficient current-file context,
+absence of prose inside patch content, stable whitespace, and final newlines.
+
+For non-patch deliverables, verify that they are clearly labeled and do not look
+like apply-ready repository changes.
+
+## Link and reference review
+
+When Markdown links change, verify that relative links resolve from the file
+where they appear.
+
+Prefer references that point to current repository files, active issue contracts,
+primary documentation, or observed validation evidence. Avoid preserving stale
+historical references when they no longer carry a durable requirement.
+
+## Maintenance and drift review
+
+A context change should reduce future ambiguity.
+
+Watch for:
+
+- duplicated guidance across layers
+- local rules leaking into reusable core
+- reusable rules duplicated in local docs
+- old roadmap wording after a migration step completes
+- long manuals where a router or compact capsule would be clearer
+- archived obsolete docs that should instead be migrated or discarded by scope
+
+Do not fix every drift concern in the active patch unless it is in scope.
+
+## Out-of-scope finding review
+
+A good out-of-scope finding is specific and actionable.
+
+It should explain what was found, why it is outside scope, why it matters, and
+what evidence a later issue should gather. It should not be implemented in the
+active change.
+
+## Review readiness
+
+A change is ready for human review when:
+
+- the diff matches the active scope
+- behavior boundaries are preserved or explicitly scoped
+- validation evidence is reported honestly
+- generated artifacts are not hand-edited
+- links introduced by the change resolve
+- remaining risks and follow-up findings are clear
+
+Do not declare merge readiness when required CI, validation, or review evidence
+is still pending.

--- a/docs/context/migration-map.md
+++ b/docs/context/migration-map.md
@@ -16,7 +16,7 @@ routing changes, or behavior changes beyond the active child issue scope.
 | `AGENTS.md` | Root guidance input. | Distill later into a concise root context manifest that points to `docs/context/README.md`. | No change in issue #190. |
 | `repomix-instruction.md` | Former root Repomix instruction input. | Relocated under `docs/context/repomix/**`; keep generated output under `.context/repomix/**`. | Moved to `docs/context/repomix/instructions.md` in issue #190. |
 | `.github/copilot-instructions.md` | Vendor-specific adapter input. | Thin later into an adapter that points to the language-model-agnostic context architecture. Keep Copilot-specific guidance out of the primary architecture. | No change in issue #190. |
-| `docs/llm/**` | Reusable assistant guidance and local failure-prevention input. | Distill repository-agnostic rules into `docs/context/core/**` and dotfiles-specific rules into `docs/context/local/**`. | No move or deletion in issue #190. |
+| `docs/llm/**` | Reusable assistant guidance and local failure-prevention input. | Distill repository-agnostic rules into `docs/context/core/**` and dotfiles-specific rules into `docs/context/local/**`. | Reusable core rules are distilled in issue #192; the legacy surface remains a migration input until later issues finish local and workflow migration. |
 | `docs/workflows/**` | Local workflow guidance input. | Distill issue, PR, validation, merge, and closure rules into `docs/context/local/workflows/**`. | No move or deletion in issue #190. |
 | `docs/chezmoi/**` | Local surface evidence input. | Compress durable chezmoi, mise, WSL2, Neovim, identity, and GitHub Actions constraints into `docs/context/local/surfaces/**`. | No move or deletion in issue #190. |
 
@@ -85,7 +85,7 @@ After each child issue merges, compare the repository against this map:
 
 ## Next handoff
 
-After the skeleton and Repomix routing issue merges, the next child issue can use
-this map to scope reusable guidance distillation into `docs/context/core/**`.
+After reusable core guidance is distilled, the next child issue can use this map
+to scope repository-specific guidance distillation into `docs/context/local/**`.
 That later issue should decide the exact file list from the post-merge repository
 state rather than treating this map as a prewritten patch.


### PR DESCRIPTION
## Summary

Distill reusable context guidance into `docs/context/core/**`.

## Why

Issue #192 needs the core context layer to move beyond a skeleton and preserve
durable reusable guidance from the existing LLM guidance surface without moving
local, workflow, or surface-specific material yet.

## Changes

- Add `docs/context/core/principles.md` for reusable context architecture,
  routing, scope, maintenance, and out-of-scope finding principles.
- Add `docs/context/core/evidence.md` for evidence hierarchy, unknown-state
  rules, validation evidence, generated artifacts, and sensitive data handling.
- Add `docs/context/core/output.md` for output format selection, strict patch
  rules, guarded scripts, non-patch deliverables, and whitespace discipline.
- Add `docs/context/core/review.md` for review priorities, finding
  classification, validation review, drift control, and follow-up handling.
- Update `docs/context/core/README.md` to route readers to the new core
  documents.
- Update `docs/context/README.md` and `docs/context/migration-map.md` only for
  current routing and roadmap wording.

## Validation

- [x] `git diff --check`
- [x] `pre-commit run --all-files`
- [x] Markdown relative links resolve, when Markdown links change
- [x] `repomix`, when LLM guidance or snapshot routing changes
- [ ] `mise run doctor`, when setup, toolchain, rendered config, or task behavior changes
- [x] GitHub Actions CI passes

Validation evidence:

- `git diff --check`: no output
- `pre-commit run --all-files`: passed
- Markdown relative links resolve
- `repomix --include-diffs --include "$(git diff --name-only | paste -sd, -)" -o .context/repomix/repomix-dotfiles-issue192.xml`: packed successfully

`mise run doctor` was not run because this PR is documentation-only and does not
change setup, toolchain, rendered config, task behavior, health-check behavior,
scripts, CI semantics, versions, dependencies, or lockfiles.

## Risk and rollback

**Risk:** Low. This PR adds reusable documentation guidance and updates routing
wording only. It does not change repository behavior, scripts, tasks, CI
semantics, versions, dependencies, or lockfiles.

**Rollback:** Revert this PR to restore the previous core skeleton and roadmap
wording.

## Review notes

The new core documents intentionally avoid dotfiles-specific, chezmoi-specific,
workstation-specific, operator-specific, and issue-specific assumptions.

Existing `docs/llm/**`, `docs/workflows/**`, and `docs/chezmoi/**` surfaces
remain in place as migration inputs. Local repository guidance, local surface
capsules, and local workflow migration remain out of scope for this PR.

## Out of scope

- Do not perform the full documentation migration.
- Do not migrate dotfiles-specific guidance into `docs/context/local/**`.
- Do not create or fill local surface capsules under
  `docs/context/local/surfaces/**`.
- Do not migrate workflow guidance into `docs/context/local/workflows/**`.
- Do not convert `AGENTS.md` into the final root context manifest.
- Do not thin `.github/copilot-instructions.md`.
- Do not delete `docs/llm/**`, `docs/workflows/**`, or `docs/chezmoi/**`.
- Do not archive obsolete docs merely to avoid deleting them.
- Do not change Repomix routing.
- Do not add `.github/instructions/**`.
- Do not introduce Copilot-specific architecture as the primary target.
- Do not change repository behavior, scripts, tasks, CI semantics, versions,
  dependencies, or lockfiles.

## Linked issue

Closes #192
Refs #187
