### PR TITLE
docs(context): distill local guidance

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -48,8 +48,10 @@ anchors:
 - `docs/chezmoi/**`
 
 Core reusable guidance now starts at
-[docs/context/core/README.md](./core/README.md). The Repomix instruction
-router lives at [docs/context/repomix/instructions.md](./repomix/instructions.md).
+[docs/context/core/README.md](./core/README.md). Dotfiles-specific guidance now
+starts at [docs/context/local/README.md](./local/README.md). The Repomix
+instruction router lives at
+[docs/context/repomix/instructions.md](./repomix/instructions.md).
 
 Future migration issues should distill durable requirements before moving,
 compressing, or deleting any old surface. Prefer preserving constraints,
@@ -66,9 +68,8 @@ without expanding the active patch.
 This contract excludes:
 
 - performing the full documentation migration
-- distilling full repository-specific local guidance
 - creating full local surface capsules
-- migrating workflow guidance
+- migrating detailed workflow procedures
 - converting `AGENTS.md` into the final root context manifest
 - adding `.github/instructions/**`
 - preserving obsolete documentation by archiving it
@@ -80,6 +81,6 @@ This contract excludes:
 After each child issue merges, compare the resulting repository state against
 this contract and the migration map before creating the next child issue.
 
-After reusable core guidance is distilled, the expected next step is a
-separately scoped issue for distilling repository-specific guidance into
-`docs/context/local/**`.
+After repository-specific local guidance is distilled, the expected next step is
+a separately scoped issue for compact surface capsules under
+`docs/context/local/surfaces/**`.

--- a/docs/context/local/README.md
+++ b/docs/context/local/README.md
@@ -1,20 +1,47 @@
-# Local context skeleton
+# Local context guidance
 
 ## Purpose
 
 This directory is the dotfiles repository-specific extension layer for the
 context architecture.
 
-Future child issues should place local repository identity, behavior boundaries,
-glossary, validation routing, surface registry, and local workflow routing here.
+Use it for repository identity, source-state rules, behavior boundaries, local
+terms, validation routing, surface routing, and relationships between root
+routers, adapters, and legacy documentation inputs.
 
-## Current status
+Use [Core context guidance](../core/README.md) for reusable assistant rules such
+as evidence discipline, output format selection, review classification,
+validation evidence, generated artifacts, drift control, and out-of-scope
+findings.
 
-This issue creates the routing skeleton only. Keep existing `docs/llm/**`,
-`docs/workflows/**`, and `docs/chezmoi/**` documents in place as migration
-inputs.
+## Local documents
 
-## Routing
+- [Local repository profile](./profile.md): repository identity, source-state
+  model, supported host posture, and current documentation entry points.
+- [Local behavior boundaries](./boundaries.md): behavior-sensitive repository
+  surfaces that must not change unless the active issue scopes them.
+- [Local glossary](./glossary.md): repository-specific terms used by context,
+  workflow, and surface guidance.
+- [Local validation map](./validation.md): validation routing by touched
+  repository surface.
+- [Local surface registry](./surface-registry.md): future capsule candidates,
+  migration evidence, and failure-prevention focus for local surfaces.
+- [Local context routing](./routing.md): relationships between core guidance,
+  local guidance, root routers, adapters, legacy inputs, and Repomix context.
 
-Use [Context migration map](../migration-map.md) before distilling local guidance.
-Move reusable guidance to `docs/context/core/**` instead of duplicating it here.
+## Deferred local areas
+
+- [Local surface routing](./surfaces/README.md) remains the future home for
+  compact surface capsules. This issue adds only a registry and routing pointer.
+- [Local workflow routing](./workflows/README.md) remains the future home for
+  issue, pull request, validation, merge, and closure procedures. This issue
+  adds only routing guidance.
+
+## Migration boundary
+
+Existing `docs/llm/**`, `docs/workflows/**`, and `docs/chezmoi/**` documents
+remain migration inputs until later scoped issues distill, replace, or remove
+their durable guidance.
+
+Do not copy reusable core rules into this local layer. Link to
+`docs/context/core/**` instead, and keep dotfiles-specific assumptions here.

--- a/docs/context/local/boundaries.md
+++ b/docs/context/local/boundaries.md
@@ -1,0 +1,69 @@
+# Local behavior boundaries
+
+## Purpose
+
+Use these boundaries to keep dotfiles context changes behavior-preserving unless
+the active issue explicitly scopes a behavior change.
+
+This document records local repository constraints. It does not authorize
+changes to scripts, tasks, rendered configuration, CI, tool versions,
+dependencies, lockfiles, or generated artifacts.
+
+## Default rule
+
+Preserve existing repository behavior unless the active issue explicitly scopes a
+change and validation evidence matches the touched surface.
+
+Documentation-only changes must not imply changes to provisioning, rendered
+output, task execution, CI semantics, or tool resolution.
+
+## Behavior-sensitive surfaces
+
+Treat these surfaces as behavior-sensitive:
+
+- chezmoi source-state templates, attributes, scripts, hooks, externals, and
+  generated target paths
+- package provisioning for macOS, Linux, and Windows-side prerequisites
+- `.chezmoidata/**` data consumed by templates, scripts, mise, completions, or
+  package generation
+- `.chezmoitemplates/**` reusable template fragments
+- 1Password identity discovery, identity metadata, SSH signing, SSH agent
+  routing, and generated identity files
+- WSL2 bridge behavior, Windows interop, `npiperelay.exe`, `op.exe`, user
+  systemd services, and Windows-side sync paths
+- shell startup, zsh, WezTerm, Starship, Git, SSH, Homebrew, mise, Vale, and
+  Neovim rendered configuration
+- `dot_config/mise/tasks/**`, `.mise.toml`, tool declarations, runtime versions,
+  tool versions, dependencies, and lockfiles
+- GitHub Actions `compliance.yml` semantics and CI validation behavior
+- generated Repomix artifacts under `.context/repomix/**`
+
+## Local preservation rules
+
+Follow these local rules unless the active issue says otherwise:
+
+- Do not change chezmoi scripts, trigger comments, template whitespace trimming,
+  or rendered-output-sensitive comments as incidental cleanup.
+- Do not change mise task names, grouping, metadata, dependencies, executable
+  bits, or behavior as part of documentation routing.
+- Do not treat locally visible mise tasks as repository-owned source state
+  without comparing source-state, managed target, and local visibility evidence.
+- Do not treat CI as proof of local WSL2, 1Password, SSH agent, Windows interop,
+  user systemd, or workstation convergence.
+- Do not change runtime versions, tool versions, package lists, dependencies, or
+  lockfiles from a context-documentation issue.
+- Do not hand-edit generated Repomix output or rendered target files.
+- Do not delete, archive, or thin legacy guidance surfaces until a scoped issue
+  confirms their durable guidance has been migrated or intentionally discarded.
+
+## Scoped exceptions
+
+A later issue may change a behavior-sensitive surface only when it:
+
+1. names the exact behavior or surface being changed;
+2. identifies current source-state and rendered-target evidence where relevant;
+3. lists affected commands, scripts, tasks, CI paths, documentation, and operator
+   workflows;
+4. preserves behavior unless the issue explicitly scopes a behavior change;
+5. reports validation with command output, CI evidence, inspected state, or
+   explicit maintainer confirmation.

--- a/docs/context/local/glossary.md
+++ b/docs/context/local/glossary.md
@@ -1,0 +1,26 @@
+# Local glossary
+
+## Purpose
+
+Use this glossary for repository-specific terms that appear across local context,
+surface, and workflow guidance.
+
+## Terms
+
+| Term | Meaning in this repository |
+| --- | --- |
+| source state | Files tracked in this repository and consumed by chezmoi as the editable source of workstation configuration. |
+| rendered target state | Files, scripts, configuration, and local artifacts produced by chezmoi in the target home directory or host environment. |
+| source-state path | A repository path using chezmoi source-state naming, such as `dot_config/**`, `private_dot_ssh/**`, or `.chezmoiscripts/**`. |
+| target path | The rendered path managed or affected by chezmoi after source-state attributes and templates are evaluated. |
+| generated context artifact | A generated Repomix artifact under `.context/repomix/**`; it is read-only evidence, not tracked source documentation. |
+| local context layer | `docs/context/local/**`, the dotfiles-specific extension layer for repository identity, behavior boundaries, validation routing, and local routing. |
+| surface capsule | A future compact document under `docs/context/local/surfaces/**` that prevents predictable mistakes for one behavior-sensitive local surface. |
+| workflow guidance | Future local issue, pull request, validation, merge, closure, Commander, and Worker procedures under `docs/context/local/workflows/**`. |
+| legacy input | Current documentation under `docs/llm/**`, `docs/workflows/**`, `docs/chezmoi/**`, `AGENTS.md`, `.github/copilot-instructions.md`, `README.md`, or `ARCHITECTURE.md` that still provides migration evidence. |
+| root context manifest | The future concise `AGENTS.md` role described by the parent context architecture program. |
+| adapter | Vendor-specific assistant entry point such as `.github/copilot-instructions.md`; adapters should route to the LLM-agnostic context architecture. |
+| 1Password identity | Repository-discovered identity metadata from prepared 1Password SSH Key items used for Git authoring, SSH signing, and SSH routing. |
+| WSL2 bridge | The Windows-to-WSL2 identity and SSH agent path involving Windows 11, WSL2 Ubuntu, Windows 1Password Desktop, `op.exe`, `npiperelay.exe`, and user systemd. |
+| doctor task | A repository-local mise validation or readiness check under `dot_config/mise/tasks/doctor/**`. |
+| repair candidate | A current behavior that may be mutation-oriented and may need a future explicit `repair:*` decision; it is not authorization to change current tasks. |

--- a/docs/context/local/profile.md
+++ b/docs/context/local/profile.md
@@ -1,0 +1,73 @@
+# Local repository profile
+
+## Purpose
+
+Use this profile to identify what kind of repository this is, which state is
+editable source, and which documentation entry point should be used for local
+context.
+
+## Repository identity
+
+This repository is a chezmoi-managed dotfiles source-state repository for
+personal workstation configuration.
+
+It is an infrastructure repository for provisioning and maintaining workstation
+state. It is not a normal application repository, package workspace, deployment
+monorepo, Terraform/OpenTofu repository, or service runtime.
+
+Do not import architecture assumptions from reference repositories unless local
+repository evidence and the active issue explicitly require them.
+
+## Source-state model
+
+Edit repository source state, not rendered target state.
+
+Repository source state includes paths such as:
+
+- `.chezmoidata/**`
+- `.chezmoiscripts/**`
+- `.chezmoitemplates/**`
+- `dot_*` and `private_dot_*` source-state paths
+- `docs/**`
+- `AGENTS.md`
+- `.github/**`
+
+Rendered target state is produced by chezmoi from source-state files,
+templates, attributes, and host data. A valid source-state edit can still render
+invalid target shell, Lua, TOML, JSON, INI, service, or SSH configuration if the
+rendered output is not reviewed when behavior-sensitive templates change.
+
+Generated Repomix output under `.context/repomix/**` is read-only evidence, not
+source documentation.
+
+## Supported host posture
+
+The README documents the supported first-run path for macOS and Windows 11 with
+WSL2 Ubuntu 24.04 or later.
+
+Other Linux distributions may appear in source-state logic, package data, or
+legacy documentation, but they are not currently documented as supported
+first-run targets.
+
+Do not treat GitHub Actions CI as proof of local WSL2, Windows interop,
+1Password Desktop, SSH agent bridge, user systemd, or workstation runtime
+convergence.
+
+## Current documentation entry points
+
+Use the current entry point that matches the task:
+
+| Entry point | Current role |
+| --- | --- |
+| [`README.md`](../../../README.md) | First-run and operator-facing bootstrap entry point. |
+| [`AGENTS.md`](../../../AGENTS.md) | Current repository-wide assistant guidance and future root manifest input. |
+| [`.github/copilot-instructions.md`](../../../.github/copilot-instructions.md) | Current GitHub Copilot adapter input. |
+| [`ARCHITECTURE.md`](../../../ARCHITECTURE.md) | Legacy high-level architecture and teardown routing input. |
+| [`docs/context/README.md`](../README.md) | Context architecture entry point. |
+| [`docs/context/core/README.md`](../core/README.md) | Reusable context guidance. |
+| [`docs/context/local/README.md`](./README.md) | Dotfiles-specific context extension layer. |
+| [`docs/context/repomix/README.md`](../repomix/README.md) | Tracked Repomix context routing. |
+
+Focused legacy documents under `docs/llm/**`, `docs/workflows/**`, and
+`docs/chezmoi/**` remain migration inputs until later issues replace or remove
+them.

--- a/docs/context/local/routing.md
+++ b/docs/context/local/routing.md
@@ -1,0 +1,60 @@
+# Local context routing
+
+## Purpose
+
+Use this routing map to choose the correct local context entry point without
+turning root routers, adapters, or legacy documentation into permanent
+architecture anchors.
+
+## Routing order
+
+For dotfiles repository work, route context in this order:
+
+1. Start with the active user request, issue, pull request, review, or validation
+   evidence.
+2. Use [Context architecture](../README.md) to identify the target context layer.
+3. Use [Core context guidance](../core/README.md) for reusable assistant rules.
+4. Use this local layer for repository-specific identity, behavior boundaries,
+   local validation routing, and surface routing.
+5. Use legacy `docs/llm/**`, `docs/workflows/**`, and `docs/chezmoi/**`
+   documents as migration evidence until later scoped issues replace or remove
+   them.
+
+## Root and adapter relationship
+
+`AGENTS.md` is the current repository-wide assistant guidance and future root
+context manifest input. Do not convert it into the final root context manifest
+unless a later issue explicitly scopes that work.
+
+`.github/copilot-instructions.md` is the current GitHub Copilot adapter input.
+Do not thin it or add `.github/instructions/**` unless a later issue explicitly
+scopes adapter work.
+
+Adapters should remain secondary to the language-model-agnostic context
+architecture. Do not make Copilot-specific structure the primary architecture.
+
+## Legacy documentation relationship
+
+Legacy documentation surfaces remain useful until their durable guidance is
+migrated or intentionally discarded:
+
+| Legacy surface | Current relationship |
+| --- | --- |
+| `docs/llm/**` | Migration input for reusable core rules, local repository rules, and later workflow/root-adapter cleanup. |
+| `docs/workflows/**` | Migration input for future `docs/context/local/workflows/**` procedure migration. |
+| `docs/chezmoi/**` | Migration evidence for future compact surface capsules and behavior-sensitive local constraints. |
+| `README.md` | Current first-run and operator-facing entry point. |
+| `ARCHITECTURE.md` | Legacy high-level architecture and teardown routing input. |
+
+Do not delete, archive, or rewrite these surfaces merely because a local context
+summary exists. Later issues should remove obsolete surfaces only after durable
+requirements have been migrated or intentionally discarded.
+
+## Repomix relationship
+
+Tracked Repomix guidance lives under [`docs/context/repomix/**`](../repomix/README.md).
+Generated Repomix output lives under `.context/repomix/**` and remains read-only
+evidence.
+
+Use fresh local command output, diffs, or maintainer-provided evidence over a
+stale generated snapshot when they conflict.

--- a/docs/context/local/surface-registry.md
+++ b/docs/context/local/surface-registry.md
@@ -1,0 +1,39 @@
+# Local surface registry
+
+## Purpose
+
+Use this registry to route future dotfiles surface capsule work without creating
+full capsules in this issue.
+
+A future surface capsule should be compact. It should prevent predictable LLM
+mistakes, point to current local evidence, and avoid becoming a replacement
+manual for the detailed legacy documentation.
+
+## Registry
+
+| Future capsule | Primary migration evidence | Failure-prevention focus |
+| --- | --- | --- |
+| `surfaces/chezmoi.md` | [`docs/chezmoi/action-graph.md`](../../chezmoi/action-graph.md), [`docs/chezmoi/script-contract-inspection.md`](../../chezmoi/script-contract-inspection.md), [`docs/chezmoi/script-trigger-audit.md`](../../chezmoi/script-trigger-audit.md), [`docs/chezmoi/thin-phase-gate-rules.md`](../../chezmoi/thin-phase-gate-rules.md) | Preserve source-state versus rendered-target distinctions, script ordering, trigger-sensitive rendered content, template whitespace, and behavior-sensitive phase gates. |
+| `surfaces/mise.md` | [`docs/chezmoi/mise-task-boundary.md`](../../chezmoi/mise-task-boundary.md), [`docs/chezmoi/mise-task-taxonomy.md`](../../chezmoi/mise-task-taxonomy.md), [`docs/chezmoi/mise-task-source-drift-inspection.md`](../../chezmoi/mise-task-source-drift-inspection.md), [`docs/chezmoi/doctor-repair-task-boundary.md`](../../chezmoi/doctor-repair-task-boundary.md) | Avoid unscoped task renames, regrouping, metadata changes, dependency changes, and false ownership claims from local mise visibility alone. |
+| `surfaces/wsl2.md` | [`docs/chezmoi/wsl2-convergence-validation.md`](../../chezmoi/wsl2-convergence-validation.md), [`docs/chezmoi/bootstrap-identity-boundary.md`](../../chezmoi/bootstrap-identity-boundary.md), [`README.md`](../../../README.md) | Keep Windows interop, `op.exe`, `npiperelay.exe`, user systemd, SSH agent bridge, and CI-versus-local validation boundaries explicit. |
+| `surfaces/identity.md` | [`docs/chezmoi/bootstrap-identity-boundary.md`](../../chezmoi/bootstrap-identity-boundary.md), [`docs/chezmoi/data-contract-boundary.md`](../../chezmoi/data-contract-boundary.md), [`AGENTS.md`](../../../AGENTS.md) | Protect 1Password item metadata, generated identity files, SSH signing, scoped Git identity routing, and secret-adjacent output handling. |
+| `surfaces/neovim.md` | [`dot_config/nvim/`](../../../dot_config/nvim/), [`dot_config/mise/tasks/doctor/executable_nvim.tmpl`](../../../dot_config/mise/tasks/doctor/executable_nvim.tmpl), [`README.md`](../../../README.md), [`AGENTS.md`](../../../AGENTS.md) | Keep LazyVim, provider health, lockfile synchronization, headless integration, and rendered template behavior separate from generic editor advice. |
+| `surfaces/github-actions.md` | [`.github/workflows/compliance.yml`](../../../.github/workflows/compliance.yml), [`.github/pull_request_template.md`](../../../.github/pull_request_template.md), [`docs/workflows/validation-workflow.md`](../../workflows/validation-workflow.md) | Preserve CI semantics, branch-protection evidence boundaries, and the distinction between local validation and remote GitHub Actions status. |
+
+## Capsule rules for later issues
+
+A later capsule issue should:
+
+- start from the migration evidence listed above;
+- distill only durable failure-prevention rules;
+- link to detailed legacy evidence instead of copying long manuals;
+- avoid changing scripts, tasks, CI, versions, dependencies, lockfiles, or
+  rendered behavior;
+- keep workflow procedures under `docs/context/local/workflows/**`, not in a
+  surface capsule;
+- update this registry when capsule names or routing change.
+
+## Current issue boundary
+
+This registry is routing only. It does not create the capsules and does not move
+or delete `docs/chezmoi/**` documentation.

--- a/docs/context/local/surfaces/README.md
+++ b/docs/context/local/surfaces/README.md
@@ -1,4 +1,4 @@
-# Local surface skeleton
+# Local surface routing
 
 ## Purpose
 
@@ -9,7 +9,10 @@ the correct local evidence. They should not become full domain manuals.
 
 ## Current status
 
-This issue creates the routing skeleton only. Existing
+No full surface capsules exist yet.
+
+Use the [Local surface registry](../surface-registry.md) to identify future
+capsule candidates, migration evidence, and failure-prevention focus. Existing
 [chezmoi documentation](../../../chezmoi/) remains migration evidence until a
 later scoped issue distills it.
 
@@ -17,3 +20,6 @@ later scoped issue distills it.
 
 Future child issues may add concise capsules for surfaces such as chezmoi, mise,
 WSL2, Neovim, identity, and GitHub Actions.
+
+A future capsule should link to detailed evidence instead of copying long legacy
+documents into this directory.

--- a/docs/context/local/validation.md
+++ b/docs/context/local/validation.md
@@ -1,0 +1,53 @@
+# Local validation map
+
+## Purpose
+
+Use this map to choose validation that matches the dotfiles repository surface
+touched by a change.
+
+This file routes local validation decisions. It does not replace the detailed
+legacy [Validation workflow](../../workflows/validation-workflow.md), and it does
+not make validation claims without evidence.
+
+## Baseline documentation validation
+
+For documentation-only context changes, use evidence from:
+
+- `git status --short`
+- `git diff --stat`
+- `git diff --check`
+- `pre-commit run --all-files`
+- Markdown relative link validation, when repository-relative Markdown links are
+  added, removed, or changed
+- `repomix`, when context routing, LLM guidance, workflow guidance, Repomix
+  guidance, or generated snapshot routing changes
+- GitHub Actions CI after PR creation, when required by branch protection or
+  reviewer request
+
+Do not mark any check complete without command output, CI evidence, inspected
+state, or explicit maintainer confirmation.
+
+## Surface map
+
+| Touched surface | Validation routing |
+| --- | --- |
+| `docs/context/**` | Use baseline documentation validation. Run Markdown link validation when links change. Run `repomix` because context routing affects generated LLM evidence. |
+| `AGENTS.md` or `.github/copilot-instructions.md` | Use baseline documentation validation, Markdown link validation, and `repomix`; these files affect assistant routing. |
+| `docs/llm/**` or `docs/workflows/**` | Use baseline documentation validation, Markdown link validation when links change, and `repomix`; these remain migration inputs until later issues replace them. |
+| `README.md` or `ARCHITECTURE.md` | Use baseline documentation validation, Markdown link validation when links change, and `repomix` when assistant or context routing changes. Add behavior validation only if the edit changes documented operator commands or behavior claims. |
+| `docs/chezmoi/**` only | Use baseline documentation validation and Markdown link validation when links change. Add rendered-output or task validation only if the active issue changes source-state behavior or current behavior claims. |
+| `.chezmoiignore.tmpl`, `.chezmoi.toml.tmpl`, `.chezmoiscripts/**`, `.chezmoitemplates/**`, or rendered configuration templates | Use rendered-output inspection such as `chezmoi diff` or `chezmoi execute-template` in addition to baseline checks. Consider `mise run doctor` only when setup, toolchain, rendered config, task behavior, or health-check behavior changes. |
+| `.chezmoidata/**` | Review every template, script, package, completion, or tool consumer affected by the data. Add rendered-output and task validation that matches the changed consumer. |
+| `dot_config/mise/tasks/**`, `.mise.toml`, tool declarations, versions, dependencies, or lockfiles | Validate mise task visibility, task behavior, tool resolution, and health checks appropriate to the change. `mise run doctor` is usually relevant when health-check behavior or setup/toolchain behavior changes. |
+| `.github/workflows/**` | Use workflow-focused review plus GitHub Actions CI evidence after PR creation. Local checks do not prove remote CI status. |
+| `.context/repomix/**` generated XML | Do not edit generated output directly. Regenerate with `repomix` when validation requires fresh evidence. |
+
+## Documentation-only doctor boundary
+
+Do not require `mise run doctor` for a PR that changes only Markdown context or
+routing and does not change setup, toolchain, rendered config, task behavior,
+health-check behavior, scripts, CI semantics, versions, dependencies, or
+lockfiles.
+
+If `mise run doctor` is not run for such a PR, report that it was not run for
+that reason rather than marking it complete.

--- a/docs/context/local/workflows/README.md
+++ b/docs/context/local/workflows/README.md
@@ -1,4 +1,4 @@
-# Local workflow skeleton
+# Local workflow routing
 
 ## Purpose
 
@@ -7,9 +7,11 @@ merge, and closure workflow guidance aligned with the context architecture.
 
 ## Current status
 
-This issue creates the routing skeleton only. Existing
-[workflow documentation](../../../workflows/README.md) remains the migration input
-until a later scoped issue distills it.
+No workflow procedures have been migrated into this directory yet.
+
+Use the [Local validation map](../validation.md) for local validation routing and
+continue using existing [workflow documentation](../../../workflows/README.md) as
+the migration input until a later scoped issue distills it.
 
 ## Routing
 
@@ -17,3 +19,7 @@ Future workflow guidance should preserve validation-evidence discipline,
 Commander / Worker boundaries, scoped issue handling, and out-of-scope finding
 reporting while avoiding generic assistant guidance that belongs in
 `docs/context/core/**`.
+
+This directory should contain procedures, not surface capsules. Surface-specific
+failure-prevention rules should route through
+[Local surface routing](../surfaces/README.md).

--- a/docs/context/migration-map.md
+++ b/docs/context/migration-map.md
@@ -13,12 +13,12 @@ routing changes, or behavior changes beyond the active child issue scope.
 
 | Source or legacy surface | Classification | Target treatment | Current status |
 | --- | --- | --- | --- |
-| `AGENTS.md` | Root guidance input. | Distill later into a concise root context manifest that points to `docs/context/README.md`. | No change in issue #190. |
+| `AGENTS.md` | Root guidance input. | Distill later into a concise root context manifest that points to `docs/context/README.md`. | Remains unchanged through issue #194. |
 | `repomix-instruction.md` | Former root Repomix instruction input. | Relocated under `docs/context/repomix/**`; keep generated output under `.context/repomix/**`. | Moved to `docs/context/repomix/instructions.md` in issue #190. |
-| `.github/copilot-instructions.md` | Vendor-specific adapter input. | Thin later into an adapter that points to the language-model-agnostic context architecture. Keep Copilot-specific guidance out of the primary architecture. | No change in issue #190. |
-| `docs/llm/**` | Reusable assistant guidance and local failure-prevention input. | Distill repository-agnostic rules into `docs/context/core/**` and dotfiles-specific rules into `docs/context/local/**`. | Reusable core rules are distilled in issue #192; the legacy surface remains a migration input until later issues finish local and workflow migration. |
-| `docs/workflows/**` | Local workflow guidance input. | Distill issue, PR, validation, merge, and closure rules into `docs/context/local/workflows/**`. | No move or deletion in issue #190. |
-| `docs/chezmoi/**` | Local surface evidence input. | Compress durable chezmoi, mise, WSL2, Neovim, identity, and GitHub Actions constraints into `docs/context/local/surfaces/**`. | No move or deletion in issue #190. |
+| `.github/copilot-instructions.md` | Vendor-specific adapter input. | Thin later into an adapter that points to the language-model-agnostic context architecture. Keep Copilot-specific guidance out of the primary architecture. | Remains unchanged through issue #194. |
+| `docs/llm/**` | Reusable assistant guidance and local failure-prevention input. | Distill repository-agnostic rules into `docs/context/core/**` and dotfiles-specific rules into `docs/context/local/**`. | Reusable core rules were distilled in issue #192, and local repository guidance is distilled in issue #194. The legacy surface remains a migration input until later workflow and root-router work completes. |
+| `docs/workflows/**` | Local workflow guidance input. | Distill issue, PR, validation, merge, and closure rules into `docs/context/local/workflows/**`. | Local routing exists after issue #194, but workflow procedures remain a later migration input. |
+| `docs/chezmoi/**` | Local surface evidence input. | Compress durable chezmoi, mise, WSL2, Neovim, identity, and GitHub Actions constraints into `docs/context/local/surfaces/**`. | Surface registry exists after issue #194, but full surface capsules remain later work. |
 
 ## Target area map
 
@@ -85,7 +85,8 @@ After each child issue merges, compare the repository against this map:
 
 ## Next handoff
 
-After reusable core guidance is distilled, the next child issue can use this map
-to scope repository-specific guidance distillation into `docs/context/local/**`.
-That later issue should decide the exact file list from the post-merge repository
-state rather than treating this map as a prewritten patch.
+After repository-specific local guidance is distilled, the next child issue can
+use this map to scope compact surface capsules under
+`docs/context/local/surfaces/**`. That later issue should decide the exact file
+list from the post-merge repository state rather than treating this map as a
+prewritten patch.


### PR DESCRIPTION
## Summary

Distill dotfiles-specific context guidance into `docs/context/local/**`.

## Why

Issue #194 needs the local context layer to move beyond a skeleton while keeping
reusable core guidance, surface capsules, and workflow procedures separate.

This keeps repository-specific assumptions replaceable for other repositories
without duplicating the reusable guidance already distilled into
`docs/context/core/**`.

## Changes

- Add `docs/context/local/profile.md` for repository identity and source-state
  model.
- Add `docs/context/local/boundaries.md` for local behavior boundaries.
- Add `docs/context/local/glossary.md` for compact local terminology.
- Add `docs/context/local/validation.md` for repository validation routing.
- Add `docs/context/local/surface-registry.md` for future surface capsule
  routing.
- Add `docs/context/local/routing.md` for root, adapter, legacy, core, local,
  surface, workflow, and Repomix relationships.
- Update local, surface, workflow, context, and migration-map routers to reflect
  the current migration step.

## Validation

- [x] `git diff --check`
- [x] `pre-commit run --all-files`
- [x] Markdown relative links resolve, when Markdown links change
- [x] `repomix`, when LLM guidance or snapshot routing changes
- [ ] `mise run doctor`, when setup, toolchain, rendered config, or task behavior changes
- [x] GitHub Actions CI passes

Validation evidence:

- `git diff --check`: no output
- `pre-commit run --all-files`: passed
- Markdown relative links resolve
- `repomix --include-diffs --include "$(git diff --name-only | paste -sd, -)" -o .context/repomix/repomix-dotfiles-issue194.xml`: focused diff artifact generated and reviewed

`mise run doctor` was not run because this PR is documentation-only and does not
change setup, toolchain, rendered config, task behavior, health-check behavior,
scripts, CI semantics, versions, dependencies, or lockfiles.

## Risk and rollback

**Risk:** Low. This PR adds local context documentation and router wording only.
It does not change repository behavior, scripts, tasks, CI semantics, versions,
dependencies, or lockfiles.

**Rollback:** Revert this PR to restore the previous local context skeleton and
roadmap wording.

## Review notes

This PR intentionally keeps `docs/context/local/surfaces/**` and
`docs/context/local/workflows/**` as future routing areas. It adds only a
surface registry and workflow routing pointers, not full capsules or workflow
procedures.

Existing `docs/llm/**`, `docs/workflows/**`, and `docs/chezmoi/**` surfaces
remain in place as migration inputs.

## Out of scope

- Do not perform the full documentation migration.
- Do not create full local surface capsules under
  `docs/context/local/surfaces/**`.
- Do not migrate workflow procedures into `docs/context/local/workflows/**`.
- Do not convert `AGENTS.md` into the final root context manifest.
- Do not thin `.github/copilot-instructions.md`.
- Do not delete `docs/llm/**`, `docs/workflows/**`, or `docs/chezmoi/**`.
- Do not archive obsolete docs merely to avoid deleting them.
- Do not change Repomix routing.
- Do not add `.github/instructions/**`.
- Do not introduce Copilot-specific architecture as the primary target.
- Do not change repository behavior, scripts, tasks, CI semantics, versions,
  dependencies, or lockfiles.
- Do not hand-edit generated Repomix output.

## Linked issue

Closes #194
Refs #187
Refs #188
Refs #190
Refs #192
