### PR TITLE
docs(context): distill local surface capsules

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -49,7 +49,9 @@ anchors:
 
 Core reusable guidance now starts at
 [docs/context/core/README.md](./core/README.md). Dotfiles-specific guidance now
-starts at [docs/context/local/README.md](./local/README.md). The Repomix
+starts at [docs/context/local/README.md](./local/README.md). Compact local
+surface capsules now start at
+[docs/context/local/surfaces/README.md](./local/surfaces/README.md). The Repomix
 instruction router lives at
 [docs/context/repomix/instructions.md](./repomix/instructions.md).
 
@@ -68,7 +70,6 @@ without expanding the active patch.
 This contract excludes:
 
 - performing the full documentation migration
-- creating full local surface capsules
 - migrating detailed workflow procedures
 - converting `AGENTS.md` into the final root context manifest
 - adding `.github/instructions/**`
@@ -81,6 +82,6 @@ This contract excludes:
 After each child issue merges, compare the resulting repository state against
 this contract and the migration map before creating the next child issue.
 
-After repository-specific local guidance is distilled, the expected next step is
-a separately scoped issue for compact surface capsules under
-`docs/context/local/surfaces/**`.
+After compact local surface capsules are distilled, the expected next step is a
+separately scoped issue for local workflow guidance under
+`docs/context/local/workflows/**`.

--- a/docs/context/local/README.md
+++ b/docs/context/local/README.md
@@ -24,18 +24,28 @@ findings.
   workflow, and surface guidance.
 - [Local validation map](./validation.md): validation routing by touched
   repository surface.
-- [Local surface registry](./surface-registry.md): future capsule candidates,
+- [Local surface registry](./surface-registry.md): current capsule routing,
   migration evidence, and failure-prevention focus for local surfaces.
 - [Local context routing](./routing.md): relationships between core guidance,
   local guidance, root routers, adapters, legacy inputs, and Repomix context.
 
+## Local surface capsules
+
+[Local surface capsules](./surfaces/README.md) provide compact
+failure-prevention routing for behavior-sensitive surfaces:
+
+- [Chezmoi](./surfaces/chezmoi.md)
+- [Mise](./surfaces/mise.md)
+- [WSL2](./surfaces/wsl2.md)
+- [Identity](./surfaces/identity.md)
+- [Neovim](./surfaces/neovim.md)
+- [GitHub Actions](./surfaces/github-actions.md)
+
 ## Deferred local areas
 
-- [Local surface routing](./surfaces/README.md) remains the future home for
-  compact surface capsules. This issue adds only a registry and routing pointer.
 - [Local workflow routing](./workflows/README.md) remains the future home for
-  issue, pull request, validation, merge, and closure procedures. This issue
-  adds only routing guidance.
+  issue, pull request, validation, merge, and closure procedures. Workflow
+  procedures remain out of scope for the surface capsule layer.
 
 ## Migration boundary
 

--- a/docs/context/local/surface-registry.md
+++ b/docs/context/local/surface-registry.md
@@ -2,27 +2,26 @@
 
 ## Purpose
 
-Use this registry to route future dotfiles surface capsule work without creating
-full capsules in this issue.
+Use this registry to route dotfiles surface capsule work.
 
-A future surface capsule should be compact. It should prevent predictable LLM
-mistakes, point to current local evidence, and avoid becoming a replacement
-manual for the detailed legacy documentation.
+Surface capsules are compact failure-prevention documents. They point to current
+local evidence and avoid becoming replacement manuals for detailed legacy
+documentation.
 
 ## Registry
 
-| Future capsule | Primary migration evidence | Failure-prevention focus |
+| Capsule | Primary migration evidence | Failure-prevention focus |
 | --- | --- | --- |
-| `surfaces/chezmoi.md` | [`docs/chezmoi/action-graph.md`](../../chezmoi/action-graph.md), [`docs/chezmoi/script-contract-inspection.md`](../../chezmoi/script-contract-inspection.md), [`docs/chezmoi/script-trigger-audit.md`](../../chezmoi/script-trigger-audit.md), [`docs/chezmoi/thin-phase-gate-rules.md`](../../chezmoi/thin-phase-gate-rules.md) | Preserve source-state versus rendered-target distinctions, script ordering, trigger-sensitive rendered content, template whitespace, and behavior-sensitive phase gates. |
-| `surfaces/mise.md` | [`docs/chezmoi/mise-task-boundary.md`](../../chezmoi/mise-task-boundary.md), [`docs/chezmoi/mise-task-taxonomy.md`](../../chezmoi/mise-task-taxonomy.md), [`docs/chezmoi/mise-task-source-drift-inspection.md`](../../chezmoi/mise-task-source-drift-inspection.md), [`docs/chezmoi/doctor-repair-task-boundary.md`](../../chezmoi/doctor-repair-task-boundary.md) | Avoid unscoped task renames, regrouping, metadata changes, dependency changes, and false ownership claims from local mise visibility alone. |
-| `surfaces/wsl2.md` | [`docs/chezmoi/wsl2-convergence-validation.md`](../../chezmoi/wsl2-convergence-validation.md), [`docs/chezmoi/bootstrap-identity-boundary.md`](../../chezmoi/bootstrap-identity-boundary.md), [`README.md`](../../../README.md) | Keep Windows interop, `op.exe`, `npiperelay.exe`, user systemd, SSH agent bridge, and CI-versus-local validation boundaries explicit. |
-| `surfaces/identity.md` | [`docs/chezmoi/bootstrap-identity-boundary.md`](../../chezmoi/bootstrap-identity-boundary.md), [`docs/chezmoi/data-contract-boundary.md`](../../chezmoi/data-contract-boundary.md), [`AGENTS.md`](../../../AGENTS.md) | Protect 1Password item metadata, generated identity files, SSH signing, scoped Git identity routing, and secret-adjacent output handling. |
-| `surfaces/neovim.md` | [`dot_config/nvim/`](../../../dot_config/nvim/), [`dot_config/mise/tasks/doctor/executable_nvim.tmpl`](../../../dot_config/mise/tasks/doctor/executable_nvim.tmpl), [`README.md`](../../../README.md), [`AGENTS.md`](../../../AGENTS.md) | Keep LazyVim, provider health, lockfile synchronization, headless integration, and rendered template behavior separate from generic editor advice. |
-| `surfaces/github-actions.md` | [`.github/workflows/compliance.yml`](../../../.github/workflows/compliance.yml), [`.github/pull_request_template.md`](../../../.github/pull_request_template.md), [`docs/workflows/validation-workflow.md`](../../workflows/validation-workflow.md) | Preserve CI semantics, branch-protection evidence boundaries, and the distinction between local validation and remote GitHub Actions status. |
+| [Chezmoi](./surfaces/chezmoi.md) | [`docs/chezmoi/action-graph.md`](../../chezmoi/action-graph.md), [`docs/chezmoi/script-contract-inspection.md`](../../chezmoi/script-contract-inspection.md), [`docs/chezmoi/script-trigger-audit.md`](../../chezmoi/script-trigger-audit.md), [`docs/chezmoi/thin-phase-gate-rules.md`](../../chezmoi/thin-phase-gate-rules.md) | Preserve source-state versus rendered-target distinctions, script ordering, trigger-sensitive rendered content, template whitespace, and behavior-sensitive phase gates. |
+| [Mise](./surfaces/mise.md) | [`docs/chezmoi/mise-task-boundary.md`](../../chezmoi/mise-task-boundary.md), [`docs/chezmoi/mise-task-taxonomy.md`](../../chezmoi/mise-task-taxonomy.md), [`docs/chezmoi/mise-task-source-drift-inspection.md`](../../chezmoi/mise-task-source-drift-inspection.md), [`docs/chezmoi/doctor-repair-task-boundary.md`](../../chezmoi/doctor-repair-task-boundary.md) | Avoid unscoped task renames, regrouping, metadata changes, dependency changes, and false ownership claims from local mise visibility alone. |
+| [WSL2](./surfaces/wsl2.md) | [`docs/chezmoi/wsl2-convergence-validation.md`](../../chezmoi/wsl2-convergence-validation.md), [`docs/chezmoi/bootstrap-identity-boundary.md`](../../chezmoi/bootstrap-identity-boundary.md), [`README.md`](../../../README.md) | Keep Windows interop, `op.exe`, `npiperelay.exe`, user systemd, SSH agent bridge, and CI-versus-local validation boundaries explicit. |
+| [Identity](./surfaces/identity.md) | [`docs/chezmoi/bootstrap-identity-boundary.md`](../../chezmoi/bootstrap-identity-boundary.md), [`docs/chezmoi/data-contract-boundary.md`](../../chezmoi/data-contract-boundary.md), [`AGENTS.md`](../../../AGENTS.md) | Protect 1Password item metadata, generated identity files, SSH signing, scoped Git identity routing, and secret-adjacent output handling. |
+| [Neovim](./surfaces/neovim.md) | [`dot_config/nvim/`](../../../dot_config/nvim/), [`dot_config/mise/tasks/doctor/executable_nvim.tmpl`](../../../dot_config/mise/tasks/doctor/executable_nvim.tmpl), [`README.md`](../../../README.md), [`AGENTS.md`](../../../AGENTS.md) | Keep LazyVim, provider health, lockfile synchronization, headless integration, and rendered template behavior separate from generic editor advice. |
+| [GitHub Actions](./surfaces/github-actions.md) | [`.github/workflows/compliance.yml`](../../../.github/workflows/compliance.yml), [`.github/pull_request_template.md`](../../../.github/pull_request_template.md), [`docs/workflows/validation-workflow.md`](../../workflows/validation-workflow.md) | Preserve CI semantics, branch-protection evidence boundaries, and the distinction between local validation and remote GitHub Actions status. |
 
-## Capsule rules for later issues
+## Capsule rules
 
-A later capsule issue should:
+A surface capsule should:
 
 - start from the migration evidence listed above;
 - distill only durable failure-prevention rules;
@@ -31,9 +30,10 @@ A later capsule issue should:
   rendered behavior;
 - keep workflow procedures under `docs/context/local/workflows/**`, not in a
   surface capsule;
-- update this registry when capsule names or routing change.
+- stay compact enough to act as routing context, not a domain manual.
 
 ## Current issue boundary
 
-This registry is routing only. It does not create the capsules and does not move
-or delete `docs/chezmoi/**` documentation.
+This registry records the current capsule routing. It does not move, delete, or
+replace `docs/chezmoi/**`, `docs/llm/**`, or `docs/workflows/**` migration
+inputs.

--- a/docs/context/local/surfaces/README.md
+++ b/docs/context/local/surfaces/README.md
@@ -1,25 +1,31 @@
-# Local surface routing
+# Local surface capsules
 
 ## Purpose
 
-This directory is the future home for compact dotfiles surface capsules.
+This directory contains compact dotfiles surface capsules.
 
-Surface capsules should prevent predictable LLM mistakes and route reviewers to
-the correct local evidence. They should not become full domain manuals.
+Surface capsules prevent predictable LLM mistakes on behavior-sensitive local
+surfaces and route reviewers to the right evidence. They are not full domain
+manuals and do not replace detailed migration evidence.
 
-## Current status
+## Capsule index
 
-No full surface capsules exist yet.
+| Surface | Use when the work touches or cites |
+| --- | --- |
+| [Chezmoi](./chezmoi.md) | source-state files, rendered target state, templates, scripts, script ordering, trigger-sensitive rendered content, or phase gates. |
+| [Mise](./mise.md) | mise tasks, task grouping, task metadata, source-state versus local task visibility, doctor checks, or repair-adjacent behavior. |
+| [WSL2](./wsl2.md) | Windows interop, Windows-side tools, `op.exe`, `npiperelay.exe`, user systemd, SSH agent bridge, or local WSL2 validation. |
+| [Identity](./identity.md) | 1Password identity metadata, generated identity files, SSH signing, scoped Git identity routing, or secret-adjacent evidence. |
+| [Neovim](./neovim.md) | LazyVim configuration, providers, `lazy-lock.json`, headless integration, or rendered Neovim templates. |
+| [GitHub Actions](./github-actions.md) | `.github/workflows/**`, compliance workflow semantics, remote CI evidence, or branch-protection status. |
 
-Use the [Local surface registry](../surface-registry.md) to identify future
-capsule candidates, migration evidence, and failure-prevention focus. Existing
-[chezmoi documentation](../../../chezmoi/) remains migration evidence until a
-later scoped issue distills it.
+## Routing rule
 
-## Future capsule candidates
+Start with the active issue and current repository evidence. Use
+[Local behavior boundaries](../boundaries.md) for repository-wide constraints and
+[Local validation map](../validation.md) for validation routing. Use these
+capsules only for surface-specific failure prevention.
 
-Future child issues may add concise capsules for surfaces such as chezmoi, mise,
-WSL2, Neovim, identity, and GitHub Actions.
-
-A future capsule should link to detailed evidence instead of copying long legacy
-documents into this directory.
+Legacy `docs/chezmoi/**`, `docs/llm/**`, and `docs/workflows/**` files remain
+migration inputs until later scoped issues replace or remove their durable
+content.

--- a/docs/context/local/surfaces/chezmoi.md
+++ b/docs/context/local/surfaces/chezmoi.md
@@ -1,0 +1,72 @@
+# Chezmoi surface capsule
+
+## Purpose
+
+Use this capsule when work touches or cites chezmoi source state, templates,
+scripts, rendered target state, or phase-sensitive provisioning behavior.
+
+Keep the capsule focused on failure prevention. Use detailed legacy evidence
+instead of copying domain manuals into this file.
+
+## Predictable LLM failure modes
+
+- Editing rendered target-state assumptions instead of repository source state.
+- Treating source-state paths such as `dot_config/**`, `private_dot_ssh/**`, or
+  `.chezmoiscripts/**` as literal target paths.
+- Reformatting Go Template whitespace trimming as harmless Markdown or shell
+  cleanup.
+- Adding, removing, relabeling, or normalizing trigger comments without scoping
+  the rendered-content rerun impact.
+- Treating CI convergence as proof of local workstation, WSL2, 1Password, SSH
+  agent, or user service convergence.
+- Moving logic out of `.chezmoiscripts/**` without proving that phase ordering,
+  preconditions, rendered branches, and trigger behavior are preserved.
+
+## Behavior-sensitive boundaries
+
+Preserve source-state versus rendered-target distinctions. A source edit can
+change rendered shell, Lua, TOML, JSON, INI, systemd, SSH, or Git behavior even
+when the source diff looks documentation-like.
+
+Treat these as behavior-sensitive unless the active issue explicitly scopes the
+change:
+
+- `.chezmoiscripts/**` ordering, `before_` and `after_` placement, and
+  `run_`, `run_once_`, or `run_onchange_` semantics;
+- template whitespace around shebangs, comments, heredocs, and conditional
+  branches;
+- trigger comments and implicit rendered inputs that control reruns;
+- `.chezmoidata/**` and `.chezmoitemplates/**` consumers;
+- `.chezmoiignore.tmpl`, `.chezmoi.toml.tmpl`, externals, hooks, and generated
+  target paths.
+
+## Evidence and routing links
+
+- [Local repository profile](../profile.md)
+- [Local behavior boundaries](../boundaries.md)
+- [Local validation map](../validation.md)
+- [Chezmoi action graph](../../../chezmoi/action-graph.md)
+- [Chezmoi script contract inspection](../../../chezmoi/script-contract-inspection.md)
+- [Chezmoi script trigger audit](../../../chezmoi/script-trigger-audit.md)
+- [Thin chezmoi phase gate rules](../../../chezmoi/thin-phase-gate-rules.md)
+- [Chezmoi data contract boundary](../../../chezmoi/data-contract-boundary.md)
+
+## Validation routing
+
+For documentation-only capsule or routing edits, use baseline documentation
+validation from [Local validation map](../validation.md).
+
+If the change touches source-state templates, scripts, data, or rendered-output
+claims, add rendered-output evidence appropriate to the touched surface, such as
+`chezmoi execute-template`, `chezmoi diff`, source-state inspection, trigger
+audit review, or host-specific rendered branch inspection.
+
+Run `mise run doctor` only when setup, toolchain, rendered config, task behavior,
+health-check behavior, scripts, CI semantics, versions, dependencies, or
+lockfiles change.
+
+## Out of scope
+
+This capsule does not authorize script rewrites, trigger normalization, template
+whitespace cleanup, behavior changes, task delegation, generated output edits, or
+legacy documentation deletion.

--- a/docs/context/local/surfaces/github-actions.md
+++ b/docs/context/local/surfaces/github-actions.md
@@ -1,0 +1,64 @@
+# GitHub Actions surface capsule
+
+## Purpose
+
+Use this capsule when work touches or cites GitHub Actions workflows, compliance
+CI semantics, branch-protection evidence, or remote CI status.
+
+Keep CI guidance focused on behavior boundaries. Workflow procedure migration
+belongs under `docs/context/local/workflows/**`, not in this capsule.
+
+## Predictable LLM failure modes
+
+- Treating local validation as proof that GitHub Actions CI passed.
+- Treating a clean GitHub Actions run as proof of local WSL2, 1Password, SSH
+  agent, user systemd, or Windows interop convergence.
+- Changing workflow triggers, permissions, matrix entries, action pins, or phase
+  commands as documentation cleanup.
+- Reordering `chezmoi`, `mise run integrate:nvim`, and `mise run doctor` phases
+  without explicit behavior scope.
+- Adding secrets, environments, or branch-protection claims without current
+  repository or GitHub evidence.
+- Moving PR, merge, or closure procedures into this surface capsule.
+
+## Behavior-sensitive boundaries
+
+The compliance workflow is behavior-sensitive because it applies source state,
+proves idempotency, restores Neovim integration, and runs the repository doctor
+path in automation.
+
+Treat these as behavior-sensitive unless explicitly scoped:
+
+- `.github/workflows/**` triggers, permissions, matrix, environment, and
+  concurrency semantics;
+- pinned action references and Renovate-managed workflow comments;
+- `chezmoi init --source="$GITHUB_WORKSPACE" --apply` automation behavior;
+- `chezmoi verify` idempotency proof;
+- `mise run integrate:nvim` and `mise run doctor` CI phases;
+- PR template validation wording when it changes required evidence.
+
+## Evidence and routing links
+
+- [Local validation map](../validation.md)
+- [Local behavior boundaries](../boundaries.md)
+- [Local workflow routing](../workflows/README.md)
+- [Compliance workflow](../../../../.github/workflows/compliance.yml)
+- [Pull request template](../../../../.github/pull_request_template.md)
+- [Validation workflow migration input](../../../workflows/validation-workflow.md)
+
+## Validation routing
+
+For documentation-only capsule or routing edits, use baseline documentation
+validation from [Local validation map](../validation.md).
+
+If a change touches workflow YAML, workflow commands, action pins, permissions,
+triggers, matrix behavior, CI phase order, or branch-protection claims, remote
+GitHub Actions evidence is required after PR creation when that status is claimed
+or required. Local checks do not prove remote CI status.
+
+## Out of scope
+
+This capsule does not authorize workflow behavior changes, action updates,
+branch-protection edits, secret or environment changes, PR procedure migration,
+merge procedure migration, or treating CI as local workstation convergence
+proof.

--- a/docs/context/local/surfaces/identity.md
+++ b/docs/context/local/surfaces/identity.md
@@ -1,0 +1,67 @@
+# Identity surface capsule
+
+## Purpose
+
+Use this capsule when work touches or cites 1Password identity metadata,
+generated Git identity files, SSH signing, scoped Git identity routing, SSH agent
+behavior, or secret-adjacent local evidence.
+
+Keep identity guidance strict and redaction-aware. Generated identity outputs are
+behavior-sensitive evidence, not safe material to copy into docs.
+
+## Predictable LLM failure modes
+
+- Treating 1Password item metadata as interchangeable labels instead of routing
+  keys for generated identity behavior.
+- Reading generated identity files as source of truth instead of repository data
+  and templates.
+- Printing account IDs, item IDs, key material, local profile paths, or SSH agent
+  output when structural evidence would be enough.
+- Changing SSH signing, `allowed_signers`, or scoped Git identity includes as
+  incidental cleanup.
+- Assuming locked or missing 1Password state in CI proves local workstation
+  behavior.
+- Collapsing WSL2 bridge behavior into generic identity validation.
+
+## Behavior-sensitive boundaries
+
+Identity convergence combines 1Password SSH Key item metadata, chezmoi template
+data, generated public key files, generated Git identity includes,
+`allowed_signers`, SSH config routing, and SSH agent availability.
+
+Treat these as behavior-sensitive unless explicitly scoped:
+
+- `.chezmoidata/**` identity fields and schema assumptions;
+- `.chezmoitemplates/git_identity_config.tmpl`;
+- `.chezmoiscripts/run_onchange_after_50-converge-identities.sh.tmpl`;
+- `dot_config/1Password/ssh/private_agent.toml.tmpl`;
+- `dot_config/ssh/**` routing and `core.sshCommand` assumptions;
+- generated Git identity includes, generated public keys, and
+  `allowed_signers` content.
+
+## Evidence and routing links
+
+- [Local behavior boundaries](../boundaries.md)
+- [Local validation map](../validation.md)
+- [Bootstrap and identity boundary](../../../chezmoi/bootstrap-identity-boundary.md)
+- [Chezmoi data contract boundary](../../../chezmoi/data-contract-boundary.md)
+- [WSL2 surface capsule](./wsl2.md)
+- [`dot_config/mise/tasks/doctor/executable_identity.tmpl`](../../../../dot_config/mise/tasks/doctor/executable_identity.tmpl)
+- [`.chezmoitemplates/git_identity_config.tmpl`](../../../../.chezmoitemplates/git_identity_config.tmpl)
+
+## Validation routing
+
+For documentation-only capsule or routing edits, use baseline documentation
+validation from [Local validation map](../validation.md).
+
+If a change touches identity data, templates, generated identity routing, SSH
+signing, SSH config, or agent behavior, validation must use redacted structural
+evidence. Prefer rendered-output inspection, scoped Git config inspection,
+`doctor:identity`, and host-specific checks that match the changed surface.
+
+## Out of scope
+
+This capsule does not authorize exposing secrets, changing 1Password metadata
+contracts, changing generated identity file names, changing SSH signing, changing
+Git identity routing, changing SSH agent bridge behavior, or editing generated
+identity outputs directly.

--- a/docs/context/local/surfaces/mise.md
+++ b/docs/context/local/surfaces/mise.md
@@ -1,0 +1,68 @@
+# Mise surface capsule
+
+## Purpose
+
+Use this capsule when work touches or cites mise configuration, file tasks, task
+metadata, task grouping, doctor checks, or repair-adjacent behavior.
+
+Keep task guidance compact and behavior-preserving. Detailed task taxonomy and
+audit documents remain migration evidence.
+
+## Predictable LLM failure modes
+
+- Treating `mise tasks ls` output as proof that a task is repository-owned
+  source state.
+- Renaming, regrouping, splitting, or deleting tasks as incidental documentation
+  cleanup.
+- Changing `# [MISE]` metadata, aliases, dependencies, executable bits, or task
+  descriptions without explicit issue scope.
+- Hiding persistent local mutation behind validation-only `doctor:*` wording.
+- Creating `converge:*` or `repair:*` tasks because legacy docs discuss them as
+  future taxonomy candidates.
+- Running or recommending broad repair commands when the active issue is
+  documentation-only.
+
+## Behavior-sensitive boundaries
+
+Repository-owned mise task source state lives under `dot_config/mise/tasks/**`
+and renders into local task visibility through chezmoi attributes and templates.
+Local task visibility can also include unmanaged target-state drift, so source
+state, managed target paths, and local visibility must be separated before
+ownership claims.
+
+Treat these as behavior-sensitive unless explicitly scoped:
+
+- `.mise.toml`, tool declarations, runtime versions, tool versions, and
+  lockfiles;
+- `dot_config/mise/tasks/**` names, grouping, metadata, dependencies, aliases,
+  executable bits, and command bodies;
+- `doctor:*` validation and recovery behavior;
+- setup, integration, sync, update, and future repair taxonomy boundaries;
+- script delegation from `.chezmoiscripts/**` into `mise run <task>`.
+
+## Evidence and routing links
+
+- [Local behavior boundaries](../boundaries.md)
+- [Local validation map](../validation.md)
+- [Mise task boundary](../../../chezmoi/mise-task-boundary.md)
+- [Mise task taxonomy](../../../chezmoi/mise-task-taxonomy.md)
+- [Mise task source drift inspection](../../../chezmoi/mise-task-source-drift-inspection.md)
+- [Doctor and repair task boundary](../../../chezmoi/doctor-repair-task-boundary.md)
+- [`dot_config/mise/tasks/`](../../../../dot_config/mise/tasks/)
+
+## Validation routing
+
+For documentation-only capsule or routing edits, use baseline documentation
+validation from [Local validation map](../validation.md).
+
+If a change touches task source state, task metadata, task behavior, tool
+resolution, health-check behavior, versions, dependencies, or lockfiles, route to
+mise-specific validation. Consider `mise tasks info`, `mise tasks deps`,
+`mise run <task>`, `mise run doctor`, rendered-output inspection, and CI evidence
+according to the changed surface.
+
+## Out of scope
+
+This capsule does not authorize task renames, regrouping, metadata changes,
+`doctor:*` behavior changes, `repair:*` creation, dependency changes, lockfile
+changes, or adoption of unmanaged local target-state tasks.

--- a/docs/context/local/surfaces/neovim.md
+++ b/docs/context/local/surfaces/neovim.md
@@ -1,0 +1,66 @@
+# Neovim surface capsule
+
+## Purpose
+
+Use this capsule when work touches or cites Neovim source state, LazyVim
+configuration, provider health, plugin lockfile synchronization, or headless
+integration behavior.
+
+Keep Neovim guidance local to this dotfiles repository. Do not import generic
+editor advice unless current repository evidence and the active issue require it.
+
+## Predictable LLM failure modes
+
+- Treating this repository as a general Neovim distribution instead of a
+  chezmoi-rendered LazyVim-based configuration.
+- Editing rendered Neovim target files instead of `dot_config/nvim/**` source
+  state.
+- Changing plugin selections, provider paths, or `lazy-lock.json` as incidental
+  cleanup.
+- Hand-editing lockfile state instead of using the repository's update and
+  integration paths.
+- Assuming provider health without `doctor:nvim` or equivalent evidence when
+  Neovim behavior changes.
+- Applying generic keymap, LSP, or plugin recommendations without local scope.
+
+## Behavior-sensitive boundaries
+
+Neovim behavior is produced from chezmoi source-state templates, LazyVim plugin
+configuration, mise-managed tools, provider resolution, and lockfile state.
+
+Treat these as behavior-sensitive unless explicitly scoped:
+
+- `dot_config/nvim/**`, especially `.tmpl` files and `lazy-lock.json`;
+- `dot_config/mise/tasks/integrate/executable_nvim.tmpl`;
+- `dot_config/mise/tasks/doctor/executable_nvim.tmpl`;
+- `dot_config/mise/tasks/update/executable_lazy-lock.tmpl`;
+- Node, Python, and Neovim provider assumptions resolved through mise;
+- headless integration commands and plugin restoration behavior.
+
+## Evidence and routing links
+
+- [Local behavior boundaries](../boundaries.md)
+- [Local validation map](../validation.md)
+- [`dot_config/nvim/`](../../../../dot_config/nvim/)
+- [`dot_config/nvim/lazy-lock.json`](../../../../dot_config/nvim/lazy-lock.json)
+- [`dot_config/mise/tasks/integrate/executable_nvim.tmpl`](../../../../dot_config/mise/tasks/integrate/executable_nvim.tmpl)
+- [`dot_config/mise/tasks/doctor/executable_nvim.tmpl`](../../../../dot_config/mise/tasks/doctor/executable_nvim.tmpl)
+- [`dot_config/mise/tasks/update/executable_lazy-lock.tmpl`](../../../../dot_config/mise/tasks/update/executable_lazy-lock.tmpl)
+- [README](../../../../README.md)
+
+## Validation routing
+
+For documentation-only capsule or routing edits, use baseline documentation
+validation from [Local validation map](../validation.md).
+
+If a change touches Neovim source state, rendered templates, providers, plugin
+configuration, lockfile state, or integration behavior, route validation to the
+relevant Neovim checks. Consider `mise run integrate:nvim`, `mise run doctor` or
+`doctor:nvim`, headless Neovim startup, and rendered-output inspection according
+to the actual touched files.
+
+## Out of scope
+
+This capsule does not authorize plugin changes, keymap changes, lockfile edits,
+provider changes, generic editor recommendations, runtime version changes, or
+Neovim behavior changes.

--- a/docs/context/local/surfaces/wsl2.md
+++ b/docs/context/local/surfaces/wsl2.md
@@ -1,0 +1,63 @@
+# WSL2 surface capsule
+
+## Purpose
+
+Use this capsule when work touches or cites Windows 11 plus WSL2 Ubuntu behavior,
+Windows interop, the 1Password SSH agent bridge, user systemd, or Windows-side
+sync paths.
+
+Keep WSL2 guidance separate from generic Linux guidance. CI is not local WSL2
+validation.
+
+## Predictable LLM failure modes
+
+- Treating WSL2 as ordinary Linux and ignoring Windows-side dependencies.
+- Treating GitHub Actions Ubuntu results as proof that local WSL2 interop works.
+- Replacing `op.exe` or `npiperelay.exe` bridge assumptions with generic Unix
+  SSH agent assumptions.
+- Changing user systemd service behavior without local service evidence.
+- Moving or normalizing Windows-side sync paths as path cleanup.
+- Printing unredacted local Windows profile paths, account identifiers, or
+  secret-adjacent bridge output unnecessarily.
+
+## Behavior-sensitive boundaries
+
+WSL2 convergence spans Linux source state, rendered Linux target state, Windows
+host tools, Windows 1Password Desktop, named pipes, user systemd, SSH agent
+routing, and Windows-side copied configuration.
+
+Treat these as behavior-sensitive unless explicitly scoped:
+
+- `op.exe` discovery and Windows 1Password Desktop assumptions;
+- `npiperelay.exe` bridge path and named-pipe invocation;
+- `dot_config/systemd/user/1password-bridge.service.tmpl` rendering;
+- `run_onchange_after_51-sync-windows-agent.sh.tmpl` Windows-side sync behavior;
+- WSL-specific conditional branches in templates and scripts;
+- local SSH agent socket routing used by Git and SSH.
+
+## Evidence and routing links
+
+- [Local repository profile](../profile.md)
+- [Local behavior boundaries](../boundaries.md)
+- [Local validation map](../validation.md)
+- [WSL2 convergence validation](../../../chezmoi/wsl2-convergence-validation.md)
+- [Bootstrap and identity boundary](../../../chezmoi/bootstrap-identity-boundary.md)
+- [README](../../../../README.md)
+- [`dot_config/systemd/user/1password-bridge.service.tmpl`](../../../../dot_config/systemd/user/1password-bridge.service.tmpl)
+- [`.chezmoiscripts/run_onchange_after_51-sync-windows-agent.sh.tmpl`](../../../../.chezmoiscripts/run_onchange_after_51-sync-windows-agent.sh.tmpl)
+
+## Validation routing
+
+For documentation-only capsule or routing edits, use baseline documentation
+validation from [Local validation map](../validation.md).
+
+If the change touches WSL2 bridge behavior, Windows interop, user systemd,
+Windows-side sync paths, SSH agent routing, or WSL-specific rendered branches,
+local WSL2 evidence is required. Do not substitute GitHub Actions CI for local
+WSL2 convergence evidence.
+
+## Out of scope
+
+This capsule does not authorize bridge rewrites, service changes, Windows path
+changes, package provisioning changes, identity behavior changes, or use of CI as
+proof of local WSL2 convergence.

--- a/docs/context/migration-map.md
+++ b/docs/context/migration-map.md
@@ -13,12 +13,12 @@ routing changes, or behavior changes beyond the active child issue scope.
 
 | Source or legacy surface | Classification | Target treatment | Current status |
 | --- | --- | --- | --- |
-| `AGENTS.md` | Root guidance input. | Distill later into a concise root context manifest that points to `docs/context/README.md`. | Remains unchanged through issue #194. |
+| `AGENTS.md` | Root guidance input. | Distill later into a concise root context manifest that points to `docs/context/README.md`. | Remains unchanged through issue #196. |
 | `repomix-instruction.md` | Former root Repomix instruction input. | Relocated under `docs/context/repomix/**`; keep generated output under `.context/repomix/**`. | Moved to `docs/context/repomix/instructions.md` in issue #190. |
-| `.github/copilot-instructions.md` | Vendor-specific adapter input. | Thin later into an adapter that points to the language-model-agnostic context architecture. Keep Copilot-specific guidance out of the primary architecture. | Remains unchanged through issue #194. |
-| `docs/llm/**` | Reusable assistant guidance and local failure-prevention input. | Distill repository-agnostic rules into `docs/context/core/**` and dotfiles-specific rules into `docs/context/local/**`. | Reusable core rules were distilled in issue #192, and local repository guidance is distilled in issue #194. The legacy surface remains a migration input until later workflow and root-router work completes. |
-| `docs/workflows/**` | Local workflow guidance input. | Distill issue, PR, validation, merge, and closure rules into `docs/context/local/workflows/**`. | Local routing exists after issue #194, but workflow procedures remain a later migration input. |
-| `docs/chezmoi/**` | Local surface evidence input. | Compress durable chezmoi, mise, WSL2, Neovim, identity, and GitHub Actions constraints into `docs/context/local/surfaces/**`. | Surface registry exists after issue #194, but full surface capsules remain later work. |
+| `.github/copilot-instructions.md` | Vendor-specific adapter input. | Thin later into an adapter that points to the language-model-agnostic context architecture. Keep Copilot-specific guidance out of the primary architecture. | Remains unchanged through issue #196. |
+| `docs/llm/**` | Reusable assistant guidance and local failure-prevention input. | Distill repository-agnostic rules into `docs/context/core/**`, dotfiles-specific rules into `docs/context/local/**`, and surface-specific rules into `docs/context/local/surfaces/**`. | Reusable core rules were distilled in issue #192, local repository guidance was distilled in issue #194, and local surface capsules were distilled in issue #196. The legacy surface remains a migration input until later workflow and root-router work completes. |
+| `docs/workflows/**` | Local workflow guidance input. | Distill issue, PR, validation, merge, and closure rules into `docs/context/local/workflows/**`. | Local routing exists after issue #194, but workflow procedures remain a later migration input after issue #196. |
+| `docs/chezmoi/**` | Local surface evidence input. | Compress durable chezmoi, mise, WSL2, Neovim, identity, and GitHub Actions constraints into `docs/context/local/surfaces/**`. | Compact surface capsules were created in issue #196. The legacy surface remains migration evidence until later cleanup confirms its durable guidance has been migrated or intentionally discarded. |
 
 ## Target area map
 
@@ -85,8 +85,7 @@ After each child issue merges, compare the repository against this map:
 
 ## Next handoff
 
-After repository-specific local guidance is distilled, the next child issue can
-use this map to scope compact surface capsules under
-`docs/context/local/surfaces/**`. That later issue should decide the exact file
-list from the post-merge repository state rather than treating this map as a
-prewritten patch.
+After compact surface capsules are distilled, the next child issue can use this
+map to scope local workflow guidance under `docs/context/local/workflows/**`.
+That later issue should decide the exact file list from the post-merge
+repository state rather than treating this map as a prewritten patch.


### PR DESCRIPTION
## Summary

Distill compact local surface capsules under
`docs/context/local/surfaces/**`.

## Why

Issue #196 needs the local surface layer to move beyond routing and preserve
behavior-sensitive failure-prevention guidance without copying long legacy
manuals.

This keeps surface-specific constraints separate from reusable core guidance,
repository-wide local guidance, and future workflow procedures.

## Changes

- Add compact capsules for:
  - `docs/context/local/surfaces/chezmoi.md`
  - `docs/context/local/surfaces/mise.md`
  - `docs/context/local/surfaces/wsl2.md`
  - `docs/context/local/surfaces/identity.md`
  - `docs/context/local/surfaces/neovim.md`
  - `docs/context/local/surfaces/github-actions.md`
- Update `docs/context/local/surfaces/README.md` to route to the new capsules.
- Update `docs/context/local/surface-registry.md` to reflect current capsule
  routing.
- Refresh `docs/context/local/README.md`, `docs/context/README.md`, and
  `docs/context/migration-map.md` for the current migration phase.

## Validation

- [x] `git diff --check`
- [x] `pre-commit run --all-files`
- [x] Markdown relative links resolve, when Markdown links change
- [x] `repomix`, when LLM guidance or snapshot routing changes
- [ ] `mise run doctor`, when setup, toolchain, rendered config, or task behavior changes
- [x] GitHub Actions CI passes

Validation evidence:

- `git diff --check`: no output
- `pre-commit run --all-files`: passed
- Markdown relative links resolve
- `repomix --include-diffs --include "$(git diff --name-only | paste -sd, -)" -o .context/repomix/repomix-dotfiles-issue196.xml`: focused diff artifact generated

`mise run doctor` was not run because this PR is documentation-only and does not
change setup, toolchain, rendered config, task behavior, health-check behavior,
scripts, CI semantics, versions, dependencies, or lockfiles.

## Risk and rollback

**Risk:** Low. This PR adds documentation-only surface capsules and routing
wording. It does not change repository behavior, scripts, tasks, CI semantics,
versions, dependencies, or lockfiles.

**Rollback:** Revert this PR to restore the previous local surface router,
surface registry, and migration-phase wording.

## Review notes

The capsules intentionally stay compact and focus on predictable LLM failure
prevention. They link to existing evidence instead of copying long legacy
manuals.

Existing `docs/llm/**`, `docs/workflows/**`, and `docs/chezmoi/**` surfaces
remain in place as migration inputs.

Workflow procedure migration remains deferred to
`docs/context/local/workflows/**`.

## Out of scope

- Do not perform the full documentation migration.
- Do not migrate workflow procedures into `docs/context/local/workflows/**`.
- Do not convert `AGENTS.md` into the final root context manifest.
- Do not thin `.github/copilot-instructions.md`.
- Do not delete `docs/llm/**`, `docs/workflows/**`, or `docs/chezmoi/**`.
- Do not archive obsolete docs merely to avoid deleting them.
- Do not change Repomix routing.
- Do not add `.github/instructions/**`.
- Do not introduce Copilot-specific architecture as the primary target.
- Do not change repository behavior, scripts, tasks, CI semantics, versions,
  dependencies, or lockfiles.
- Do not hand-edit generated Repomix output.

## Linked issue

Closes #196
Refs #187
Refs #188
Refs #190
Refs #192
Refs #194
