### PR TITLE
docs(context): distill local workflow guidance

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -51,8 +51,10 @@ Core reusable guidance now starts at
 [docs/context/core/README.md](./core/README.md). Dotfiles-specific guidance now
 starts at [docs/context/local/README.md](./local/README.md). Compact local
 surface capsules now start at
-[docs/context/local/surfaces/README.md](./local/surfaces/README.md). The Repomix
-instruction router lives at
+[docs/context/local/surfaces/README.md](./local/surfaces/README.md). Local
+workflow guidance now starts at
+[docs/context/local/workflows/README.md](./local/workflows/README.md). The
+Repomix instruction router lives at
 [docs/context/repomix/instructions.md](./repomix/instructions.md).
 
 Future migration issues should distill durable requirements before moving,
@@ -70,7 +72,6 @@ without expanding the active patch.
 This contract excludes:
 
 - performing the full documentation migration
-- migrating detailed workflow procedures
 - converting `AGENTS.md` into the final root context manifest
 - adding `.github/instructions/**`
 - preserving obsolete documentation by archiving it
@@ -82,6 +83,8 @@ This contract excludes:
 After each child issue merges, compare the resulting repository state against
 this contract and the migration map before creating the next child issue.
 
-After compact local surface capsules are distilled, the expected next step is a
-separately scoped issue for local workflow guidance under
-`docs/context/local/workflows/**`.
+After local workflow guidance is distilled, the expected next step is a
+separately scoped issue for root router and obsolete surface cleanup. That later
+issue should compare current repository state against the parent issue and
+migration map before changing `AGENTS.md`, adapters, or legacy documentation
+surfaces.

--- a/docs/context/local/README.md
+++ b/docs/context/local/README.md
@@ -28,6 +28,8 @@ findings.
   migration evidence, and failure-prevention focus for local surfaces.
 - [Local context routing](./routing.md): relationships between core guidance,
   local guidance, root routers, adapters, legacy inputs, and Repomix context.
+- [Local workflow routing](./workflows/README.md): issue, PR, validation, merge,
+  closure, Commander, and Worker procedures.
 
 ## Local surface capsules
 
@@ -41,11 +43,15 @@ failure-prevention routing for behavior-sensitive surfaces:
 - [Neovim](./surfaces/neovim.md)
 - [GitHub Actions](./surfaces/github-actions.md)
 
-## Deferred local areas
+## Local workflow guidance
 
-- [Local workflow routing](./workflows/README.md) remains the future home for
-  issue, pull request, validation, merge, and closure procedures. Workflow
-  procedures remain out of scope for the surface capsule layer.
+[Local workflow guidance](./workflows/README.md) provides concise procedures for
+scoped issue handling, Commander and Worker coordination, pull requests,
+validation reporting, merge decisions, and issue closure.
+
+Workflow guidance should route reusable evidence, output, and review rules to
+`docs/context/core/**`, and route behavior-sensitive validation to the local
+validation map and surface capsules.
 
 ## Migration boundary
 

--- a/docs/context/local/routing.md
+++ b/docs/context/local/routing.md
@@ -15,7 +15,7 @@ For dotfiles repository work, route context in this order:
 2. Use [Context architecture](../README.md) to identify the target context layer.
 3. Use [Core context guidance](../core/README.md) for reusable assistant rules.
 4. Use this local layer for repository-specific identity, behavior boundaries,
-   local validation routing, and surface routing.
+   local validation routing, surface routing, and workflow procedures.
 5. Use legacy `docs/llm/**`, `docs/workflows/**`, and `docs/chezmoi/**`
    documents as migration evidence until later scoped issues replace or remove
    them.
@@ -41,7 +41,7 @@ migrated or intentionally discarded:
 | Legacy surface | Current relationship |
 | --- | --- |
 | `docs/llm/**` | Migration input for reusable core rules, local repository rules, and later workflow/root-adapter cleanup. |
-| `docs/workflows/**` | Migration input for future `docs/context/local/workflows/**` procedure migration. |
+| `docs/workflows/**` | Migration input for local workflow procedures now distilled under `docs/context/local/workflows/**`; keep as legacy input until later cleanup. |
 | `docs/chezmoi/**` | Migration evidence for future compact surface capsules and behavior-sensitive local constraints. |
 | `README.md` | Current first-run and operator-facing entry point. |
 | `ARCHITECTURE.md` | Legacy high-level architecture and teardown routing input. |

--- a/docs/context/local/workflows/README.md
+++ b/docs/context/local/workflows/README.md
@@ -2,24 +2,36 @@
 
 ## Purpose
 
-This directory is the future home for local issue, pull request, validation,
-merge, and closure workflow guidance aligned with the context architecture.
+This directory contains dotfiles-local workflow procedures for issue handling,
+Commander and Worker coordination, pull requests, validation reporting, merge,
+and closure decisions.
 
-## Current status
+Use these documents for repository workflow procedure. Use
+[Core context guidance](../../core/README.md) for reusable evidence, output, and
+review discipline, and use the [Local validation map](../validation.md) plus
+[Local surface capsules](../surfaces/README.md) for touched-surface validation.
 
-No workflow procedures have been migrated into this directory yet.
+## Workflow documents
 
-Use the [Local validation map](../validation.md) for local validation routing and
-continue using existing [workflow documentation](../../../workflows/README.md) as
-the migration input until a later scoped issue distills it.
+- [Issue workflow guidance](./issues.md): scoped issue contracts,
+  parent-child sequencing, acceptance criteria, and out-of-scope findings.
+- [Commander and Worker workflow guidance](./threads.md): thread role separation,
+  handoff prompts, file-plan-first workflow, and child issue sequencing.
+- [Pull request workflow guidance](./pull-requests.md): PR body expectations,
+  linked issue wording, validation evidence, review notes, risk, and rollback.
+- [Workflow validation guidance](./validation.md): validation reporting,
+  documentation-only boundaries, surface routing, and CI versus local evidence.
+- [Merge and closure workflow guidance](./merge-and-close.md): merge decision
+  inputs, closure wording, checkbox discipline, and post-merge comparison.
 
-## Routing
+## Scope boundary
 
-Future workflow guidance should preserve validation-evidence discipline,
-Commander / Worker boundaries, scoped issue handling, and out-of-scope finding
-reporting while avoiding generic assistant guidance that belongs in
-`docs/context/core/**`.
+This directory should contain concise procedures, not reusable assistant rules or
+surface capsules.
 
-This directory should contain procedures, not surface capsules. Surface-specific
-failure-prevention rules should route through
-[Local surface routing](../surfaces/README.md).
+Do not duplicate rules already covered by `docs/context/core/**`, repository-wide
+local behavior boundaries, or surface-specific capsules. Link to those documents
+instead.
+
+Existing `docs/workflows/**` files remain migration inputs until a later scoped
+issue removes or redirects obsolete surfaces.

--- a/docs/context/local/workflows/issues.md
+++ b/docs/context/local/workflows/issues.md
@@ -1,0 +1,90 @@
+# Issue workflow guidance
+
+## Purpose
+
+Use this workflow when creating, reviewing, or implementing scoped dotfiles
+repository issues.
+
+Issues are scope contracts. They should make the desired end state, boundaries,
+acceptance evidence, and known risks clear before a Worker Thread changes the
+repository.
+
+## Scope contract
+
+A scoped issue should define:
+
+- the goal and background;
+- in-scope work;
+- out-of-scope work;
+- objective acceptance criteria;
+- validation requirements;
+- constraints, risks, references, and notes.
+
+Use the repository's
+[change request issue form](../../../../.github/ISSUE_TEMPLATE/change-request.yml)
+as evidence for the expected issue shape. Do not edit the template from a
+workflow guidance issue.
+
+## Parent and child sequencing
+
+Use parent issues for architecture or migration programs that need independently
+reviewable child issues.
+
+For parent issue programs:
+
+- create child issues one at a time;
+- compare the merged result of the previous child issue against the parent
+  ledger before creating the next child issue;
+- keep the parent issue as the directional ledger, not as a prewritten patch;
+- close a child issue only when its own acceptance criteria are complete;
+- close the parent only after parent-level acceptance criteria are complete.
+
+A child issue PR may use:
+
+```text
+Closes #<child-issue-number>
+Refs #<parent-issue-number>
+```
+
+Use `Refs #<issue-number>` for partial progress that should not close the issue.
+
+## Acceptance criteria
+
+Acceptance criteria should be objective, observable, and independent.
+
+Do not mark criteria complete because work is planned, likely correct, or a patch
+applied cleanly. Completion requires command output, CI evidence, inspected
+state, merged PR content, or explicit maintainer confirmation.
+
+## Scope boundaries
+
+For this dotfiles repository, issue boundaries commonly protect:
+
+- repository behavior;
+- chezmoi scripts, templates, rendered target state, and trigger-sensitive
+  comments;
+- mise tasks, tool declarations, versions, dependencies, and lockfiles;
+- GitHub Actions semantics;
+- GitHub issue and pull request templates;
+- generated Repomix output.
+
+Use [Local behavior boundaries](../boundaries.md),
+[Local validation map](../validation.md), and
+[Local surface capsules](../surfaces/README.md) when the issue touches a
+behavior-sensitive surface.
+
+## Out-of-scope findings
+
+A Worker should preserve useful out-of-scope findings without implementing them
+in the active issue.
+
+Record:
+
+- what was found;
+- why it is outside the current issue;
+- why it may matter;
+- what evidence a later issue would need;
+- whether it should become follow-up work.
+
+Do not create, split, close, or redesign issues from a Worker Thread unless the
+maintainer explicitly assigns that decision.

--- a/docs/context/local/workflows/merge-and-close.md
+++ b/docs/context/local/workflows/merge-and-close.md
@@ -1,0 +1,111 @@
+# Merge and closure workflow guidance
+
+## Purpose
+
+Use this workflow when deciding whether a PR is ready to merge and whether an
+issue should close.
+
+Merge and closure decisions should preserve traceability between the issue
+contract, PR evidence, validation, and parent roadmap.
+
+## Merge decision inputs
+
+Before recommending merge, confirm that:
+
+- the PR scope matches the linked issue or PR slice;
+- required review is complete or explicitly waived by the maintainer;
+- required local validation has evidence;
+- required GitHub Actions checks have passed when CI is required;
+- linked issue wording is correct;
+- generated artifacts were not hand-edited;
+- out-of-scope findings are captured separately;
+- acceptance criteria are not marked complete without evidence.
+
+Do not recommend merge only because a patch applies cleanly.
+
+## Merge method
+
+Use the merge method that matches repository policy and the PR shape.
+
+For a small, reviewable documentation PR with a clean final message, squash merge
+is usually appropriate:
+
+```sh
+gh pr merge <pr-number> --squash --delete-branch
+```
+
+Do not merge from a Worker Thread when the Commander Thread owns PR sequencing,
+issue closure, or cross-PR synthesis unless that decision is explicitly
+delegated.
+
+## Closure wording
+
+Use closure wording only when it matches the intended issue state.
+
+Use `Refs #<issue-number>` for partial progress. Use `Closes #<issue-number>`
+only when merge should close the issue.
+
+For a child issue under a parent program, the completing PR should normally use:
+
+```text
+Closes #<child-issue-number>
+Refs #<parent-issue-number>
+```
+
+For intermediate PRs in a larger issue, leave the issue open and document the
+remaining work.
+
+## Checkbox discipline
+
+Update issue checkboxes only with evidence.
+
+Acceptable evidence includes:
+
+- merged PR content;
+- command output;
+- CI results;
+- directly inspected repository state;
+- explicit maintainer confirmation.
+
+Do not check an item because it is planned, likely correct, suggested by an LLM,
+or implied by unrelated checks.
+
+## Manual closure
+
+Manual issue closure is appropriate only when all completion evidence exists but
+the issue did not close automatically.
+
+A useful closure comment should state:
+
+- which PRs completed the issue;
+- which validation evidence supports closure;
+- which work was intentionally excluded;
+- which follow-up findings remain outside the closed issue.
+
+Keep closure comments factual and avoid unsupported readiness claims.
+
+## Post-merge comparison
+
+After a child issue merges, compare the resulting repository state against:
+
+- the parent issue ledger;
+- [Context migration map](../../migration-map.md);
+- the child issue acceptance criteria;
+- the merged PR body and validation evidence;
+- current repository evidence.
+
+Use that comparison to decide the next child issue. Do not pre-create later child
+issues from stale roadmap wording.
+
+## Rollback after merge
+
+If a merged PR must be reverted, the revert PR should explain:
+
+- which PR is being reverted;
+- what behavior or documentation is restored;
+- whether the original issue should reopen or a new issue should be created;
+- what validation was run for the revert.
+
+For documentation-only changes, rollback is usually a normal revert. For
+behavior changes, confirm whether rendered target state or manual cleanup is
+involved.

--- a/docs/context/local/workflows/pull-requests.md
+++ b/docs/context/local/workflows/pull-requests.md
@@ -1,0 +1,105 @@
+# Pull request workflow guidance
+
+## Purpose
+
+Use this workflow when preparing or reviewing pull request content for this
+dotfiles repository.
+
+A PR should be a reviewable unit of change that explains what changed, why it
+changed, how it was validated, what risks remain, and which issue it advances.
+
+## PR body expectations
+
+Use the repository
+[pull request template](../../../../.github/pull_request_template.md) as evidence
+for the current PR body structure. Do not edit the template from this workflow
+area.
+
+A PR body should cover:
+
+- Summary;
+- Why;
+- Changes;
+- Validation;
+- Risk and rollback;
+- Review notes;
+- Out of scope;
+- Linked issue.
+
+Remove template comments from the final body. Keep validation checkboxes tied to
+actual evidence, not expected success.
+
+## Linked issue wording
+
+Use linked issue wording deliberately.
+
+Use:
+
+```text
+Refs #<issue-number>
+```
+
+when a PR contributes to an issue but should not close it.
+
+Use:
+
+```text
+Closes #<issue-number>
+```
+
+only when merging the PR should close the issue because the remaining acceptance
+criteria are complete.
+
+For child issues under a parent ledger, a completing PR should normally close the
+child issue and reference the parent:
+
+```text
+Closes #<child-issue-number>
+Refs #<parent-issue-number>
+```
+
+## Validation section
+
+Report validation as evidence.
+
+Each completed validation item should have command output, exit status, CI
+evidence, inspected state, or explicit maintainer confirmation behind it. Local
+checks do not prove GitHub Actions CI passed, and a clean patch application does
+not prove semantic correctness.
+
+Use [Local workflow validation](./validation.md) and the
+[Local validation map](../validation.md) to choose checks for the touched surface.
+
+## Review notes
+
+Use Review notes to preserve context that would help a reviewer focus.
+
+Good review notes include:
+
+- files or sections that deserve careful review;
+- accepted trade-offs;
+- known non-blocking follow-ups;
+- validation that is intentionally not required and why;
+- documentation-only boundaries, when relevant.
+
+Do not hide new requirements in Review notes. Requirements belong in the issue,
+PR scope, or validation section.
+
+## Risk and rollback
+
+Every PR should include a realistic rollback path.
+
+For documentation-only context changes, rollback is usually reverting the PR.
+For behavior changes, state what reverting restores and whether rendered target
+state, generated artifacts, or manual cleanup are involved.
+
+Do not claim rollback is risk-free unless evidence supports that claim.
+
+## Merge readiness claims
+
+Do not declare merge readiness unless required validation, review, and CI
+evidence are available.
+
+A Worker may draft PR text or recommend how to report provided validation, but it
+must not claim command output, CI status, issue closure, or reviewer approval
+that has not been provided or inspected.

--- a/docs/context/local/workflows/threads.md
+++ b/docs/context/local/workflows/threads.md
@@ -1,0 +1,85 @@
+# Commander and Worker workflow guidance
+
+## Purpose
+
+Use this workflow when repository work is split across planning, Commander, and
+Worker conversations.
+
+The goal is to keep issue topology, implementation, validation interpretation,
+and closure decisions separated enough that each PR remains reviewable.
+
+## Thread roles
+
+Planning Threads may shape the roadmap, compare alternatives, and draft issue
+bodies. They should not be treated as implementation evidence unless their
+output is copied into an issue, PR, command output, or current repository file.
+
+Commander Threads own:
+
+- parent and child issue sequencing;
+- Worker Thread handoff prompts;
+- PR slicing;
+- cross-PR synthesis;
+- post-merge comparison against the parent issue and migration map;
+- final closure recommendations.
+
+Worker Threads own:
+
+- the one assigned issue, PR, or bounded task;
+- current evidence inspection for that scope;
+- the smallest safe file plan;
+- patch generation only after the file plan is accepted or explicitly requested;
+- validation interpretation after evidence is provided;
+- out-of-scope finding reporting.
+
+## Handoff prompt expectations
+
+A Worker handoff should name:
+
+- the active issue and parent issue, when relevant;
+- authoritative issue, PR, and repository evidence files;
+- in-scope and out-of-scope surfaces;
+- hard constraints;
+- expected implementation direction;
+- validation expectations;
+- the recommended branch name.
+
+Use current repository evidence over stale summaries when they conflict.
+Generated Repomix snapshots are read-only evidence, not editable source.
+
+## File-plan-first workflow
+
+Before producing a patch for a documentation migration issue, a Worker should:
+
+1. classify candidate guidance by target responsibility;
+2. identify the smallest target file list;
+3. link reusable core rules instead of duplicating them;
+4. link local and surface guidance for repository-specific behavior boundaries;
+5. call out ambiguity, stale material, and out-of-scope findings;
+6. produce a strict patch only after the plan is accepted or explicitly
+   requested.
+
+Use [Core output discipline](../../core/output.md) for patch format and
+non-patch deliverable boundaries.
+
+## Child issue sequencing
+
+For parent issue programs, later child issues should not be created before the
+previous child issue is complete and reviewed.
+
+After each child issue merges, the Commander Thread should compare the result
+against:
+
+- the parent issue ledger;
+- [Context migration map](../../migration-map.md);
+- the merged PR body and validation evidence;
+- the current repository state.
+
+The comparison should decide the next child issue from current evidence instead
+of assuming an earlier provisional sequence is still exact.
+
+## Out of scope
+
+A Worker Thread must not change issue topology, create follow-up issues, close
+tracking issues, rewrite root routers, or implement adjacent cleanup unless the
+active issue or maintainer explicitly scopes that work.

--- a/docs/context/local/workflows/validation.md
+++ b/docs/context/local/workflows/validation.md
@@ -1,0 +1,99 @@
+# Workflow validation guidance
+
+## Purpose
+
+Use this workflow when reporting validation for issues, PRs, and review
+summaries in this dotfiles repository.
+
+This document focuses on workflow reporting. Use the
+[Local validation map](../validation.md) to choose checks by touched surface, and
+use [Core evidence discipline](../../core/evidence.md) for reusable validation
+evidence rules.
+
+## Requirements versus evidence
+
+Keep these states separate:
+
+- required validation: checks that should be run before completion;
+- completed validation: checks with command output, exit status, CI evidence,
+  inspected state, or explicit maintainer confirmation;
+- skipped validation: checks not run, with the reason;
+- failed validation: checks that failed, including any retry evidence.
+
+Do not check a validation item because it is expected to pass.
+
+## Documentation-only boundary
+
+For documentation-only context or workflow changes, baseline validation usually
+comes from:
+
+- `git status --short`;
+- `git diff --stat`;
+- `git diff --check`;
+- `pre-commit run --all-files`;
+- Markdown relative link validation when repository-relative links change;
+- `repomix` when context routing, LLM guidance, workflow guidance, Repomix
+  guidance, or generated snapshot routing changes.
+
+Do not require `mise run doctor` when the PR changes only Markdown context or
+routing and does not change setup, toolchain, rendered config, task behavior,
+health-check behavior, scripts, CI semantics, versions, dependencies, or
+lockfiles.
+
+If `mise run doctor` is not run for a documentation-only PR, report that reason
+instead of marking the check complete.
+
+## Surface-specific routing
+
+Route behavior-sensitive validation through the local surface guidance:
+
+- [Chezmoi](../surfaces/chezmoi.md) for source-state, templates, scripts,
+  rendered output, and trigger-sensitive behavior;
+- [Mise](../surfaces/mise.md) for task source state, metadata, tool resolution,
+  and health-check behavior;
+- [WSL2](../surfaces/wsl2.md) for Windows interop, user systemd, and bridge
+  behavior;
+- [Identity](../surfaces/identity.md) for 1Password, SSH signing, scoped Git
+  identity, and secret-adjacent evidence;
+- [Neovim](../surfaces/neovim.md) for plugin state, providers, and headless
+  integration;
+- [GitHub Actions](../surfaces/github-actions.md) for workflow semantics and
+  remote CI evidence.
+
+Do not duplicate those surface rules in workflow reports. Link to them and state
+which evidence was actually collected.
+
+## CI versus local evidence
+
+Local validation and remote CI answer different questions.
+
+Do not infer GitHub Actions success from local checks. Do not infer local WSL2,
+1Password, SSH agent, Windows interop, user systemd, or workstation convergence
+from GitHub Actions CI.
+
+When CI is required, report it only after CI evidence is available.
+
+## Validation reporting format
+
+A useful PR or review validation report should state:
+
+- the command or evidence source;
+- the observed result;
+- whether the item is complete, skipped, failed, or pending;
+- why skipped checks were not required for the touched surface.
+
+For example:
+
+```text
+- `git diff --check`: no output
+- `pre-commit run --all-files`: passed
+- `mise run doctor`: not run because this PR is documentation-only and does not
+  change setup, toolchain, rendered config, task behavior, health-check behavior,
+  scripts, CI semantics, versions, dependencies, or lockfiles
+```
+
+## Out of scope
+
+This document does not add validation automation, change CI requirements, change
+mise tasks, or require heavyweight local convergence checks for pure
+Markdown-only changes.

--- a/docs/context/migration-map.md
+++ b/docs/context/migration-map.md
@@ -13,11 +13,11 @@ routing changes, or behavior changes beyond the active child issue scope.
 
 | Source or legacy surface | Classification | Target treatment | Current status |
 | --- | --- | --- | --- |
-| `AGENTS.md` | Root guidance input. | Distill later into a concise root context manifest that points to `docs/context/README.md`. | Remains unchanged through issue #196. |
+| `AGENTS.md` | Root guidance input. | Distill later into a concise root context manifest that points to `docs/context/README.md`. | Remains unchanged through issue #198. |
 | `repomix-instruction.md` | Former root Repomix instruction input. | Relocated under `docs/context/repomix/**`; keep generated output under `.context/repomix/**`. | Moved to `docs/context/repomix/instructions.md` in issue #190. |
-| `.github/copilot-instructions.md` | Vendor-specific adapter input. | Thin later into an adapter that points to the language-model-agnostic context architecture. Keep Copilot-specific guidance out of the primary architecture. | Remains unchanged through issue #196. |
-| `docs/llm/**` | Reusable assistant guidance and local failure-prevention input. | Distill repository-agnostic rules into `docs/context/core/**`, dotfiles-specific rules into `docs/context/local/**`, and surface-specific rules into `docs/context/local/surfaces/**`. | Reusable core rules were distilled in issue #192, local repository guidance was distilled in issue #194, and local surface capsules were distilled in issue #196. The legacy surface remains a migration input until later workflow and root-router work completes. |
-| `docs/workflows/**` | Local workflow guidance input. | Distill issue, PR, validation, merge, and closure rules into `docs/context/local/workflows/**`. | Local routing exists after issue #194, but workflow procedures remain a later migration input after issue #196. |
+| `.github/copilot-instructions.md` | Vendor-specific adapter input. | Thin later into an adapter that points to the language-model-agnostic context architecture. Keep Copilot-specific guidance out of the primary architecture. | Remains unchanged through issue #198. |
+| `docs/llm/**` | Reusable assistant guidance and local failure-prevention input. | Distill repository-agnostic rules into `docs/context/core/**`, dotfiles-specific rules into `docs/context/local/**`, surface-specific rules into `docs/context/local/surfaces/**`, and workflow-adjacent rules into `docs/context/local/workflows/**`. | Reusable core rules were distilled in issue #192, local repository guidance was distilled in issue #194, local surface capsules were distilled in issue #196, and workflow-adjacent procedure rules were distilled in issue #198. The legacy surface remains a migration input until later root-router and cleanup work completes. |
+| `docs/workflows/**` | Local workflow guidance input. | Distill issue, PR, validation, merge, closure, Commander, and Worker rules into `docs/context/local/workflows/**`. | Local workflow procedures were distilled in issue #198. The legacy surface remains a migration input until later cleanup confirms its durable guidance has been migrated or intentionally discarded. |
 | `docs/chezmoi/**` | Local surface evidence input. | Compress durable chezmoi, mise, WSL2, Neovim, identity, and GitHub Actions constraints into `docs/context/local/surfaces/**`. | Compact surface capsules were created in issue #196. The legacy surface remains migration evidence until later cleanup confirms its durable guidance has been migrated or intentionally discarded. |
 
 ## Target area map
@@ -85,7 +85,8 @@ After each child issue merges, compare the repository against this map:
 
 ## Next handoff
 
-After compact surface capsules are distilled, the next child issue can use this
-map to scope local workflow guidance under `docs/context/local/workflows/**`.
-That later issue should decide the exact file list from the post-merge
-repository state rather than treating this map as a prewritten patch.
+After local workflow guidance is distilled, the next child issue can use this
+map to scope root router and obsolete surface cleanup. That later issue should
+compare the post-merge repository state against the parent issue before changing
+`AGENTS.md`, `.github/copilot-instructions.md`, `docs/llm/**`,
+`docs/workflows/**`, or `docs/chezmoi/**`.


### PR DESCRIPTION
## Summary

Distill local workflow guidance into `docs/context/local/workflows/**`.

## Why

Issue #198 needs the local workflow layer to move beyond routing while keeping
reusable core guidance, repository-wide local guidance, and surface-specific
validation separate.

This completes the workflow-guidance child step under parent issue #187 without
rewriting root routers, GitHub templates, workflow YAML, or legacy documentation
surfaces.

## Changes

- Add `docs/context/local/workflows/issues.md` for scoped issue contracts,
  parent-child sequencing, acceptance criteria, and out-of-scope findings.
- Add `docs/context/local/workflows/threads.md` for Commander and Worker role
  boundaries, handoff prompts, file-plan-first work, and child issue sequencing.
- Add `docs/context/local/workflows/pull-requests.md` for PR body expectations,
  linked issue wording, validation evidence, review notes, risk, and rollback.
- Add `docs/context/local/workflows/validation.md` for validation reporting,
  documentation-only boundaries, surface routing, and CI versus local evidence.
- Add `docs/context/local/workflows/merge-and-close.md` for merge decision
  inputs, closure wording, checkbox discipline, and post-merge comparison.
- Update local, context, routing, workflow, and migration-map routers for the
  current migration phase and the expected next cleanup step.

## Validation

- [x] `git diff --check`
- [x] `pre-commit run --all-files`
- [x] Markdown relative links resolve
- [x] `repomix`
- [x] GitHub Actions CI passes

Validation evidence:

- `git diff --check`: no output
- `pre-commit run --all-files`: passed
- Markdown relative links resolve
- `repomix --include-diffs --include "$(git diff --name-only | paste -sd, -)" -o .context/repomix/repomix-dotfiles-issue198.xml`: focused diff artifact generated and reviewed

`mise run doctor` was not run because this PR is documentation-only and does not
change setup, toolchain, rendered config, task behavior, health-check behavior,
scripts, CI semantics, versions, dependencies, or lockfiles.

## Risk and rollback

**Risk:** Low. This PR adds documentation-only workflow guidance and routing
wording. It does not change repository behavior, scripts, tasks, CI semantics,
versions, dependencies, lockfiles, issue templates, PR templates, or workflows.

**Rollback:** Revert this PR to restore the previous local workflow router and
migration-phase wording.

## Review notes

This PR intentionally keeps existing `docs/llm/**`, `docs/workflows/**`, and
`docs/chezmoi/**` surfaces in place as migration inputs.

It also treats `.github/pull_request_template.md`,
`.github/ISSUE_TEMPLATE/**`, and `.github/workflows/**` as evidence only. Those
files are not changed.

The expected next child issue is root router and obsolete surface cleanup, but it
should be scoped only after comparing the merged result against parent issue
#187 and `docs/context/migration-map.md`.

## Out of scope

- Do not perform the full documentation migration.
- Do not convert `AGENTS.md` into the final root context manifest.
- Do not thin `.github/copilot-instructions.md`.
- Do not change `.github/pull_request_template.md`.
- Do not change `.github/ISSUE_TEMPLATE/**`.
- Do not change `.github/workflows/**`.
- Do not delete `docs/llm/**`, `docs/workflows/**`, or `docs/chezmoi/**`.
- Do not archive obsolete docs merely to avoid deleting them.
- Do not change Repomix routing.
- Do not add `.github/instructions/**`.
- Do not introduce Copilot-specific architecture as the primary target.
- Do not change repository behavior, scripts, tasks, CI semantics, versions,
  dependencies, or lockfiles.
- Do not hand-edit generated Repomix output.

## Linked issue

Closes #198
Refs #187
Refs #188
Refs #190
Refs #192
Refs #194
Refs #196
