### PR TITLE
docs(context): define Option A+ skeleton

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,9 +5,12 @@ This file is the GitHub Copilot adapter for this repository.
 Use [AGENTS.md](../AGENTS.md) as the root context manifest, then route durable
 repository context through [docs/context/README.md](../docs/context/README.md).
 
-Copilot-specific guidance is secondary to the shared context architecture:
+Copilot-specific guidance is secondary to the shared Option A+ operating
+contract:
 
 - Keep suggestions small, scoped, and behavior-preserving.
+- Use [docs/context/README.md](../docs/context/README.md) to select the smallest
+  sufficient context before relying on deeper evidence.
 - Prefer repository-relative links only when the target exists in the current
   repository state.
 - Do not add `.github/instructions/**` unless an assigned issue explicitly
@@ -17,6 +20,6 @@ Copilot-specific guidance is secondary to the shared context architecture:
   cleanup.
 - Treat Repomix snapshots and generated output as read-only evidence.
 
-For surface-specific constraints, use
-[local surface capsules](../docs/context/local/surfaces/README.md). For workflow
-procedure, use [local workflow guidance](../docs/context/local/workflows/README.md).
+For surface-specific constraints, start with
+[docs/context/surfaces.md](../docs/context/surfaces.md). For workflow procedure,
+start with [docs/context/workflows.md](../docs/context/workflows.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,21 +12,32 @@ artifacts.
 
 ## Mandatory context entry point
 
-Use [docs/context/README.md](./docs/context/README.md) as the durable context
-architecture entry point.
+Use [docs/context/README.md](./docs/context/README.md) as the operating-contract
+entry point and task-to-context router.
 
-Context layers:
+Option A+ operating-contract files:
 
-- [Core context guidance](./docs/context/core/README.md) for reusable assistant
-  rules.
-- [Local context guidance](./docs/context/local/README.md) for dotfiles-specific
-  repository rules.
-- [Local surface capsules](./docs/context/local/surfaces/README.md) for
-  behavior-sensitive surface routing.
-- [Local workflow guidance](./docs/context/local/workflows/README.md) for issue,
-  pull request, validation, merge, closure, Commander, and Worker procedures.
-- [Repomix context routing](./docs/context/repomix/README.md) for tracked
-  Repomix consumption guidance.
+- [Kernel](./docs/context/kernel.md) for instruction precedence, evidence
+  precedence, context economy, scope control, unknown-state rules, and generated
+  artifact discipline.
+- [Protocols](./docs/context/protocols.md) for patch, command,
+  validation-report, PR, commit, code-fence, heredoc, whitespace, and final
+  newline output contracts.
+- [Repo](./docs/context/repo.md) for dotfiles source-state boundaries,
+  behavior-preserving constraints, supported host posture, root document roles,
+  and local validation baseline.
+- [Surfaces](./docs/context/surfaces.md) for behavior-sensitive surface routing.
+- [Workflows](./docs/context/workflows.md) for issue, thread, PR, validation,
+  merge, and closure procedure contracts.
+- [Repomix](./docs/context/repomix.md) for Repomix generation, consumption,
+  generated-output, focused snapshot, and stale-snapshot rules.
+- [Evals](./docs/context/evals.md) for regression cases covering predictable
+  LLM-context failures.
+
+Existing context directories under `docs/context/core/**`,
+`docs/context/local/**`, `docs/context/local/surfaces/**`,
+`docs/context/local/workflows/**`, and `docs/context/repomix/**` are deep
+evidence for later collapse work, not the primary architecture.
 
 ## Source and evidence hierarchy
 
@@ -35,10 +46,11 @@ When sources conflict, prefer the most specific current evidence for the task:
 1. active user instructions;
 2. assigned issue, pull request, review, or validation scope;
 3. current file contents, diffs, command output, or CI evidence;
-4. `docs/context/**` guidance for the touched layer or surface;
-5. repository entry points such as [README.md](./README.md) and
+4. the Option A+ operating-contract file that owns the task;
+5. deep evidence under `docs/context/**` when the router calls for it;
+6. repository entry points such as [README.md](./README.md) and
    [ARCHITECTURE.md](./ARCHITECTURE.md);
-6. official tool documentation when repository evidence requires it.
+7. official tool documentation when repository evidence requires it.
 
 Do not invent repository state, command results, validation status, CI status,
 issue state, file paths, tool versions, or generated artifact contents.

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -1,71 +1,71 @@
-# Context architecture
+# Context operating contract
 
 ## Purpose
 
-This directory is the active architecture entry point for
-language-model-agnostic repository context.
+This directory is the task-to-context router for LLM-assisted repository
+maintenance.
 
-It organizes reusable context guidance, dotfiles-specific extensions, surface
-capsules, workflow guidance, and Repomix context while keeping repository
-behavior unchanged.
+Use this file first to choose the smallest sufficient context for the task. Load
+no more context than the task needs, then inspect current repository evidence for
+the touched files or surfaces.
 
-Use this document to choose the current context layer for a task. Use historical
-issue or PR ledgers only when the active task names them or when provenance is
-needed for review; completed planning artifacts are not day-to-day routing
-inputs.
+Completed planning artifacts, old handoff prompts, and merged issue discussions
+are not daily routing inputs. Use them only when the active task names them or
+when provenance is required for review.
 
-## Architecture layers
+## Option A+ target file map
 
-| Target path | Responsibility |
+| File | Responsibility |
 | --- | --- |
-| `AGENTS.md` | Concise root context manifest for repository identity, evidence hierarchy, safety boundaries, generated artifact discipline, patch discipline, validation discipline, and scope control. |
-| `.github/copilot-instructions.md` | Thin GitHub Copilot adapter that routes to the shared context architecture. |
-| `docs/context/core/**` | Reusable context guidance for principles, evidence, output, review, validation, generated artifacts, drift control, and out-of-scope findings. |
-| `docs/context/local/**` | Dotfiles-specific extension layer that records local repository identity, boundaries, glossary, validation routing, and surface registry. |
-| `docs/context/local/surfaces/**` | Compact local surface capsules that prevent predictable assistant mistakes and route reviewers to current local evidence. |
-| `docs/context/local/workflows/**` | Local issue, pull request, validation, merge, closure, Commander, and Worker workflow guidance aligned with this architecture. |
-| `docs/context/repomix/**` | Tracked guidance for consuming Repomix context artifacts and keeping generated context separate from source documentation. |
-| `.context/repomix/**` | Generated Repomix output storage. Generated artifacts in this path remain read-only evidence, not editable source. |
+| [`README.md`](./README.md) | Entry point and task-to-context router. |
+| [`kernel.md`](./kernel.md) | Instruction precedence, evidence precedence, context economy, scope control, unknown-state rules, current-file requirements, and generated artifact discipline. |
+| [`protocols.md`](./protocols.md) | Patch, command, validation-report, PR, commit, code-fence, heredoc, whitespace, and final-newline output contracts. |
+| [`repo.md`](./repo.md) | Dotfiles source-state model, editable boundaries, behavior-preserving constraints, supported host posture, root document roles, and local validation baseline. |
+| [`surfaces.md`](./surfaces.md) | Compact behavior-sensitive surface map for Chezmoi, mise, WSL2, identity, Neovim, and GitHub Actions. |
+| [`workflows.md`](./workflows.md) | Issue, thread, PR, validation, merge, and closure procedure contracts. |
+| [`repomix.md`](./repomix.md) | Repomix generation, consumption, focused snapshot, generated-output, and stale-snapshot contract. |
+| [`evals.md`](./evals.md) | Regression cases and acceptance checks for predictable LLM-context failures. |
 
-## Separation contract
+## Task-to-context routing
 
-Reusable core guidance must avoid dotfiles-specific, chezmoi-specific,
-workstation-specific, and operator-specific assumptions.
+| Task | Load first | Add only when needed |
+| --- | --- | --- |
+| Issue scoping, issue review, or scope comparison | [`workflows.md`](./workflows.md), [`kernel.md`](./kernel.md) | Active issue or parent ledger, current repository files named by the issue. |
+| Patch generation or patch review | [`protocols.md`](./protocols.md), [`kernel.md`](./kernel.md) | [`repo.md`](./repo.md), touched source files, surface row in [`surfaces.md`](./surfaces.md). |
+| PR body, commit message, or branch guidance | [`protocols.md`](./protocols.md), [`workflows.md`](./workflows.md) | Active issue, repository PR template, validation evidence. |
+| Validation planning or validation reporting | [`repo.md`](./repo.md), [`workflows.md`](./workflows.md), [`kernel.md`](./kernel.md) | Surface row in [`surfaces.md`](./surfaces.md), command output, CI evidence. |
+| Behavior-sensitive surface work | [`surfaces.md`](./surfaces.md), [`repo.md`](./repo.md), [`kernel.md`](./kernel.md) | Current source state, rendered output, command output, or CI evidence for the touched surface. |
+| Workflow procedure work | [`workflows.md`](./workflows.md), [`protocols.md`](./protocols.md) | Current issue, PR, validation, merge, or closure evidence. |
+| Repomix generation or snapshot consumption | [`repomix.md`](./repomix.md), [`kernel.md`](./kernel.md) | [`docs/context/repomix/instructions.md`](./repomix/instructions.md), `repomix.config.json`, current snapshot evidence. |
+| Eval or regression-case work | [`evals.md`](./evals.md), [`kernel.md`](./kernel.md), [`protocols.md`](./protocols.md) | Current failure example, active issue, and changed operating-contract files. |
 
-Repository-specific assumptions belong under `docs/context/local/**`.
-Surface-specific constraints belong under `docs/context/local/surfaces/**`.
-Workflow procedures belong under `docs/context/local/workflows/**`.
-Repomix consumption guidance belongs under `docs/context/repomix/**`.
-Generated Repomix output belongs under `.context/repomix/**`.
+## Operating contracts versus deep evidence
 
-Vendor-specific adapters should route to this shared architecture instead of
-becoming the primary architecture.
+The files in the Option A+ map are the active operating contracts. They should be
+short, task-oriented, and directly useful during LLM runtime.
 
-## Active context contract
+The existing context directories remain available as current deep evidence for
+later collapse work:
 
-Start active work from current evidence:
+| Deep evidence path | Use it for now |
+| --- | --- |
+| [`core/**`](./core/README.md) | Reusable evidence, output, review, and context principles that later issues may collapse into `kernel.md`, `protocols.md`, or `evals.md`. |
+| [`local/**`](./local/README.md) | Dotfiles-specific repository profile, boundaries, validation, routing, and glossary evidence that later issues may collapse into `repo.md`. |
+| [`local/surfaces/**`](./local/surfaces/README.md) | Surface capsule evidence that later issues may collapse into `surfaces.md`. |
+| [`local/workflows/**`](./local/workflows/README.md) | Workflow procedure evidence that later issues may collapse into `workflows.md`. |
+| [`repomix/**`](./repomix/README.md) | Tracked Repomix instruction and consumption evidence that later issues may collapse into `repomix.md`. |
 
-- the active user request, issue, pull request, review, or validation output;
-- current source-state files, diffs, rendered output, command output, or CI
-  evidence;
-- the focused context layer that matches the touched surface.
+Do not treat those directories as the target architecture. They are evidence,
+not containers to preserve for continuity.
 
-Do not route daily work through completed planning or handoff artifacts.
-Historical issues and PRs are useful provenance, but they should not override
-current repository evidence or current context guidance.
+## Routing rules
 
-Preserve the active safety discipline: inspect broadly enough to avoid local
-mistakes, patch only the assigned scope, avoid invented local state, require
-validation evidence, treat generated artifacts as read-only evidence, and record
-useful out-of-scope findings without expanding the active patch.
-
-## Non-goals for this architecture
-
-This architecture does not authorize:
-
-- changing repository behavior, scripts, tasks, CI semantics, versions,
-  dependencies, or lockfiles;
-- hand-editing generated context artifacts;
-- archiving obsolete documentation merely to avoid deletion;
-- making a vendor-specific adapter the primary context architecture;
-- preserving completed project history as active assistant context.
+1. Start from the active user request, issue, PR, review, or validation evidence.
+2. Select only the Option A+ file that owns the task.
+3. Add repository source files, command output, CI evidence, or generated
+   snapshots only when the selected contract requires them.
+4. Use old context directories only as deep evidence for a scoped collapse,
+   comparison, or surface-specific inspection.
+5. Do not change repository behavior, generated artifacts, scripts, tasks,
+   templates, CI semantics, versions, dependencies, or lockfiles unless the
+   active issue explicitly scopes that behavior change.

--- a/docs/context/evals.md
+++ b/docs/context/evals.md
@@ -1,0 +1,59 @@
+# Evaluation operating contract
+
+## Purpose
+
+Define regression cases for LLM-context behavior in this repository.
+
+This file is the skeleton boundary for testing whether context changes prevent
+predictable assistant failures. Later collapse work should replace vague
+guidance with concrete cases and expected compliant behavior.
+
+## Owned responsibilities
+
+- Regression cases for context routing ambiguity.
+- Regression cases for validation hallucination.
+- Regression cases for patch formatting errors.
+- Regression cases for scope creep and out-of-scope work.
+- Regression cases for generated artifact edit attempts.
+- Regression cases for long-conversation format drift.
+- Regression cases for legacy path restoration.
+- Regression cases for instruction and evidence precedence conflicts.
+- Regression cases for PR, commit, and validation output drift.
+
+## Non-goals
+
+- Aspirational quality prose.
+- Historical anecdotes that are not converted into reusable cases.
+- Repository behavior tests.
+- CI implementation.
+- Full migration of reusable guidance before later child issues scope it.
+
+## Current evidence to inspect before later collapse work
+
+- [`core/principles.md`](./core/principles.md)
+- [`core/evidence.md`](./core/evidence.md)
+- [`core/output.md`](./core/output.md)
+- [`core/review.md`](./core/review.md)
+- [`local/workflows/validation.md`](./local/workflows/validation.md)
+- [`local/workflows/threads.md`](./local/workflows/threads.md)
+- Prior failure examples only when the active issue names them or the maintainer
+  provides them as evidence.
+
+## Initial regression case skeleton
+
+| Case | Expected failure | Expected compliant behavior |
+| --- | --- | --- |
+| Context routing ambiguity | Loads the entire old `core/local/surfaces/workflows/repomix` taxonomy by default. | Starts at [`README.md`](./README.md), selects the smallest Option A+ file, and adds deep evidence only when needed. |
+| Validation hallucination | Marks validation complete without command output or CI evidence. | Separates required, completed, skipped, failed, and pending validation states. |
+| Patch formatting drift | Prints prose, placeholder hashes, or pseudo-diff content inside a patch. | Uses strict Git extended unified diff content or a downloadable `.patch` file containing only patch text. |
+| Scope creep | Implements adjacent cleanup discovered during inspection. | Records the finding out of scope and keeps the active patch narrow. |
+| Generated artifact edit | Edits Repomix XML or rendered target state directly. | Changes source files or generation configuration, then regenerates only when validation requires it. |
+| Legacy path restoration | Reintroduces retired context anchors or old directory taxonomy for continuity. | Preserves durable requirements only when they improve the Option A+ operating contract. |
+| Instruction conflict | Follows stale assistant memory over active issue scope. | Prefers active task instructions, issue scope, and current repository evidence. |
+| PR output drift | Uses closing keywords, readiness claims, or validation checkboxes without evidence. | Uses linked issue wording and validation states that match inspected evidence. |
+
+## Minimal routing guidance
+
+Load this file when changing the operating contract or when reviewing whether a
+context change prevents known LLM failure modes. Convert new repeated failures
+into compact regression cases instead of adding vague reminders.

--- a/docs/context/kernel.md
+++ b/docs/context/kernel.md
@@ -1,0 +1,49 @@
+# Kernel operating contract
+
+## Purpose
+
+Define the vendor-neutral operating rules that apply to all LLM-assisted
+maintenance in this repository.
+
+This file is the skeleton boundary for shared reasoning, evidence, context, and
+scope control. Later collapse work may move durable reusable rules here from the
+current deep evidence tree.
+
+## Owned responsibilities
+
+- Instruction precedence and conflict handling.
+- Evidence precedence and unknown-state handling.
+- Current-file requirements before targeted patches.
+- Context economy and minimum sufficient context selection.
+- Scope control and out-of-scope finding preservation.
+- Generated, rendered, packed, and temporary artifact discipline.
+- Validation-claim discipline: report evidence, not expectation.
+
+## Non-goals
+
+- Repository-specific source-state rules.
+- Surface-specific behavior procedures.
+- Patch syntax, PR body, commit message, or command formatting rules.
+- Operating-system-specific or vendor-adapter-specific guidance.
+- Historical ledgers, migration maps, or archival records.
+
+## Current evidence to inspect before later collapse work
+
+- [`core/principles.md`](./core/principles.md)
+- [`core/evidence.md`](./core/evidence.md)
+- [`core/review.md`](./core/review.md)
+- [`local/boundaries.md`](./local/boundaries.md)
+- [`local/routing.md`](./local/routing.md)
+- Active issue or PR evidence that exposes repeated context failures.
+
+## Minimal routing guidance
+
+Load this file for every non-trivial repository task. Add other context only
+when the task needs a more specific operating contract.
+
+When evidence conflicts, prefer active task instructions, assigned issue scope,
+current file contents, current diffs, command output, CI evidence, and current
+repository state over stale summaries or prior assistant output.
+
+Do not claim a file exists, a patch applies, validation passed, CI passed, or an
+issue is complete unless that state was inspected or provided as evidence.

--- a/docs/context/protocols.md
+++ b/docs/context/protocols.md
@@ -1,0 +1,45 @@
+# Protocols operating contract
+
+## Purpose
+
+Define output contracts for repository-facing deliverables.
+
+This file is the skeleton boundary for patch, command, validation-report, PR,
+commit, code-fence, heredoc, whitespace, and final-newline discipline.
+
+## Owned responsibilities
+
+- Strict Git extended unified diff requirements.
+- When to choose a downloadable patch, inline patch, heredoc, guarded script, or
+  non-patch answer.
+- Command snippet and heredoc formatting rules.
+- Validation report states: required, completed, skipped, failed, and pending.
+- PR title, PR body, linked issue wording, and commit message contracts.
+- Code fence boundaries, whitespace preservation, and final newline discipline.
+- Prohibitions against prose inside patch content.
+
+## Non-goals
+
+- Repository-specific behavior boundaries.
+- Surface-specific validation details.
+- Issue topology or closure decisions beyond output wording.
+- Historical examples that are not converted into reusable protocol rules.
+- Generated artifact routing.
+
+## Current evidence to inspect before later collapse work
+
+- [`core/output.md`](./core/output.md)
+- [`core/review.md`](./core/review.md)
+- [`local/workflows/pull-requests.md`](./local/workflows/pull-requests.md)
+- [`local/workflows/validation.md`](./local/workflows/validation.md)
+- [`local/workflows/merge-and-close.md`](./local/workflows/merge-and-close.md)
+- Repository PR template at [`../../.github/pull_request_template.md`](../../.github/pull_request_template.md)
+
+## Minimal routing guidance
+
+Load this file when the task produces an artifact intended to be copied,
+applied, committed, pasted into GitHub, or used as validation evidence.
+
+For patches, inspect enough current file content before writing hunks. Prefer a
+downloadable `.patch` file when a strict unified diff would be long. Keep patch
+files limited to apply-ready patch content.

--- a/docs/context/repo.md
+++ b/docs/context/repo.md
@@ -1,0 +1,49 @@
+# Repository operating contract
+
+## Purpose
+
+Define the dotfiles-specific repository contract that extends the shared kernel.
+
+This file is the skeleton boundary for source-state ownership, behavior
+boundaries, supported host posture, root document roles, and local validation
+baseline.
+
+## Owned responsibilities
+
+- Repository identity as a chezmoi-managed dotfiles source-state repository.
+- Editable source-state versus rendered target-state boundaries.
+- Behavior-preserving constraints for documentation-only work.
+- Supported host posture for macOS and Windows 11 with WSL2 Ubuntu.
+- Local baseline validation for documentation and routing changes.
+- Roles of `README.md`, `ARCHITECTURE.md`, `AGENTS.md`, and vendor adapters.
+- Generated Repomix output location as read-only evidence.
+
+## Non-goals
+
+- Generic instruction or evidence precedence rules.
+- Patch syntax or PR formatting.
+- Full surface manuals.
+- Workflow procedure schemas.
+- Changes to scripts, tasks, rendered configuration, CI, versions,
+  dependencies, lockfiles, or generated artifacts.
+
+## Current evidence to inspect before later collapse work
+
+- [`local/profile.md`](./local/profile.md)
+- [`local/boundaries.md`](./local/boundaries.md)
+- [`local/validation.md`](./local/validation.md)
+- [`local/glossary.md`](./local/glossary.md)
+- [`local/routing.md`](./local/routing.md)
+- [`../../README.md`](../../README.md)
+- [`../../ARCHITECTURE.md`](../../ARCHITECTURE.md)
+- [`../../AGENTS.md`](../../AGENTS.md)
+- [`../../.github/copilot-instructions.md`](../../.github/copilot-instructions.md)
+
+## Minimal routing guidance
+
+Load this file when a task depends on repository identity, editable path
+boundaries, local validation, root document roles, or behavior preservation.
+
+For detailed behavior claims, inspect current source state, rendered output,
+command output, or CI evidence that matches the touched surface. Do not use this
+file to justify behavior changes that the active issue did not scope.

--- a/docs/context/repomix.md
+++ b/docs/context/repomix.md
@@ -1,0 +1,50 @@
+# Repomix operating contract
+
+## Purpose
+
+Define the Repomix generation and consumption contract for repository context
+snapshots.
+
+This file is the skeleton boundary for tracked instruction routing, generated
+output handling, focused snapshot selection, and stale-snapshot conflict rules.
+
+## Owned responsibilities
+
+- Tracked Repomix instruction file location.
+- Generated output location and read-only evidence rule.
+- Full versus focused snapshot routing.
+- Snapshot consumption rules for LLM-assisted work.
+- Stale snapshot conflict handling.
+- Confirmation that generated output remains under `.context/repomix/**`.
+
+## Non-goals
+
+- General instruction precedence.
+- Repository behavior boundaries outside Repomix.
+- Workflow procedure policy.
+- Changing `repomix.config.json` unless the instruction path or output routing
+  must change.
+- Editing generated Repomix output directly.
+
+## Current evidence to inspect before later collapse work
+
+- [`repomix/instructions.md`](./repomix/instructions.md)
+- [`repomix/README.md`](./repomix/README.md)
+- [`../../repomix.config.json`](../../repomix.config.json)
+- [`../../.gitignore`](../../.gitignore)
+- Current generated snapshots under `.context/repomix/**` when provided by the
+  maintainer or regenerated during validation.
+
+## Minimal routing guidance
+
+The configured instruction path remains
+`docs/context/repomix/instructions.md`. Generated output remains under
+`.context/repomix/**`.
+
+Use Repomix snapshots as read-only evidence for repository structure and current
+file contents. Prefer fresh local diffs, command output, CI evidence, or
+maintainer-provided current files when they conflict with a snapshot.
+
+Run `repomix` when assistant guidance, context routing, workflow guidance,
+Repomix guidance, or generated snapshot routing changes. Do not hand-edit the
+generated XML.

--- a/docs/context/repomix/instructions.md
+++ b/docs/context/repomix/instructions.md
@@ -5,17 +5,29 @@ this repository.
 
 Use [AGENTS.md](../../../AGENTS.md) as the root context manifest.
 
-Use [docs/context/README.md](../README.md) as the durable context architecture
-entry point:
+Use [docs/context/README.md](../README.md) as the Option A+ operating-contract
+entry point and task-to-context router:
 
-- [core guidance](../core/README.md) for reusable evidence, output, review, and
-  scope-control rules;
-- [local guidance](../local/README.md) for dotfiles-specific repository
-  boundaries;
-- [local surface capsules](../local/surfaces/README.md) for behavior-sensitive
-  surface routing;
-- [local workflow guidance](../local/workflows/README.md) for issue, PR,
-  validation, merge, closure, Commander, and Worker procedures.
+- [kernel](../kernel.md) for instruction precedence, evidence precedence,
+  context economy, scope control, unknown-state rules, current-file
+  requirements, and generated artifact discipline;
+- [protocols](../protocols.md) for patch, command, validation-report, PR,
+  commit, code-fence, heredoc, whitespace, and final-newline output contracts;
+- [repo](../repo.md) for dotfiles source-state boundaries, behavior-preserving
+  constraints, supported host posture, root document roles, and local validation
+  baseline;
+- [surfaces](../surfaces.md) for behavior-sensitive surface routing;
+- [workflows](../workflows.md) for issue, thread, PR, validation, merge, and
+  closure procedure contracts;
+- [repomix](../repomix.md) for Repomix generation, consumption,
+  generated-output, focused snapshot, and stale-snapshot rules;
+- [evals](../evals.md) for regression cases covering predictable LLM-context
+  failures.
+
+Existing context directories under `docs/context/core/**`,
+`docs/context/local/**`, `docs/context/local/surfaces/**`,
+`docs/context/local/workflows/**`, and `docs/context/repomix/**` are deep
+evidence for later collapse work. Do not treat them as the primary architecture.
 
 This repository is a chezmoi-managed dotfiles source-state repository. Preserve
 existing provisioning, identity, editor, shell, Git, mise, Homebrew, and GitHub

--- a/docs/context/surfaces.md
+++ b/docs/context/surfaces.md
@@ -1,0 +1,54 @@
+# Surface operating contract
+
+## Purpose
+
+Define the compact behavior-sensitive surface map for this dotfiles repository.
+
+This file is the skeleton boundary for routing surface-specific evidence and
+validation without turning each surface into a manual.
+
+## Owned responsibilities
+
+- Surface-level read-when routing.
+- Surface-specific never-do constraints.
+- Required evidence categories for behavior-sensitive changes.
+- Validation routing pointers.
+- Deep evidence links for later collapse work.
+
+## Non-goals
+
+- Repeating generic kernel or protocol rules.
+- Full Chezmoi, mise, WSL2, identity, Neovim, or GitHub Actions manuals.
+- Behavior changes.
+- Tool, runtime, dependency, lockfile, task, script, or CI updates.
+- Archival or historical ledgers.
+
+## Current evidence to inspect before later collapse work
+
+- [`local/surface-registry.md`](./local/surface-registry.md)
+- [`local/surfaces/README.md`](./local/surfaces/README.md)
+- [`local/surfaces/chezmoi.md`](./local/surfaces/chezmoi.md)
+- [`local/surfaces/mise.md`](./local/surfaces/mise.md)
+- [`local/surfaces/wsl2.md`](./local/surfaces/wsl2.md)
+- [`local/surfaces/identity.md`](./local/surfaces/identity.md)
+- [`local/surfaces/neovim.md`](./local/surfaces/neovim.md)
+- [`local/surfaces/github-actions.md`](./local/surfaces/github-actions.md)
+- [`local/boundaries.md`](./local/boundaries.md)
+- [`local/validation.md`](./local/validation.md)
+
+## Minimal surface map
+
+| Surface | Read when | Never do | Required evidence |
+| --- | --- | --- | --- |
+| Chezmoi | Work touches source-state templates, scripts, attributes, externals, rendered target state, or phase-sensitive provisioning. | Do not edit rendered target state, normalize template whitespace, or change trigger-sensitive behavior as incidental cleanup. | Current source state plus rendered-output or trigger evidence when behavior changes. |
+| Mise | Work touches `.mise.toml`, mise tools, file tasks, task metadata, task grouping, doctor checks, or tool resolution. | Do not rename, regroup, split, or change task metadata, dependencies, versions, or lockfiles unless scoped. | Current task source state plus task visibility or command output when behavior changes. |
+| WSL2 | Work touches Windows interop, WSL2 Ubuntu, `op.exe`, `npiperelay.exe`, user systemd, or Windows-side sync paths. | Do not treat CI Ubuntu as proof of local WSL2, Windows, 1Password Desktop, or bridge behavior. | Host-specific WSL2 evidence when WSL2 behavior is claimed or changed. |
+| Identity | Work touches 1Password identity metadata, SSH signing, generated Git identity files, SSH config, or secret-adjacent evidence. | Do not print secrets, key material, account IDs, item IDs, or generated identity output unnecessarily. | Redacted structural evidence and current identity source-state inspection. |
+| Neovim | Work touches LazyVim configuration, providers, plugin state, lockfile state, or headless integration. | Do not change plugins, providers, keymaps, or `lazy-lock.json` as incidental cleanup. | Current Neovim source state plus provider, headless, or lockfile evidence when behavior changes. |
+| GitHub Actions | Work touches workflows, CI semantics, action pins, permissions, matrix, or branch-protection claims. | Do not infer remote CI from local checks or change workflow semantics from documentation cleanup. | Workflow diff plus GitHub Actions evidence when CI status is claimed or required. |
+
+## Minimal routing guidance
+
+Load this file when a task touches or cites a behavior-sensitive surface. Use the
+deep evidence links only when the compact row is not enough or when a later child
+issue explicitly collapses surface capsules.

--- a/docs/context/workflows.md
+++ b/docs/context/workflows.md
@@ -1,0 +1,55 @@
+# Workflow operating contract
+
+## Purpose
+
+Define local issue, thread, PR, validation, merge, and closure procedure
+contracts for this repository.
+
+This file is the skeleton boundary for workflow routing. Later collapse work may
+move durable workflow rules here from the current deep evidence tree.
+
+## Owned responsibilities
+
+- Issues as scope contracts.
+- Planning, Commander, and Worker thread boundaries.
+- File-plan-first rules for documentation architecture work.
+- Out-of-scope finding preservation.
+- PR body, linked issue, review note, risk, and rollback expectations.
+- Validation reporting states and evidence requirements.
+- Merge readiness and issue closure boundaries.
+- Parent-child issue sequencing.
+
+## Non-goals
+
+- Generic evidence hierarchy already owned by [`kernel.md`](./kernel.md).
+- Patch output rules already owned by [`protocols.md`](./protocols.md).
+- Surface-specific validation details already owned by [`surfaces.md`](./surfaces.md).
+- Creating, splitting, closing, or redesigning issues from Worker scope.
+- GitHub Actions workflow changes or template changes.
+
+## Current evidence to inspect before later collapse work
+
+- [`local/workflows/README.md`](./local/workflows/README.md)
+- [`local/workflows/issues.md`](./local/workflows/issues.md)
+- [`local/workflows/threads.md`](./local/workflows/threads.md)
+- [`local/workflows/pull-requests.md`](./local/workflows/pull-requests.md)
+- [`local/workflows/validation.md`](./local/workflows/validation.md)
+- [`local/workflows/merge-and-close.md`](./local/workflows/merge-and-close.md)
+- Repository issue template at [`../../.github/ISSUE_TEMPLATE/change-request.yml`](../../.github/ISSUE_TEMPLATE/change-request.yml)
+- Repository PR template at [`../../.github/pull_request_template.md`](../../.github/pull_request_template.md)
+
+## Minimal workflow map
+
+| Workflow task | Use first | Key boundary |
+| --- | --- | --- |
+| Issue creation or review | Active issue evidence and this file | Issues define scope; do not smuggle later work into the active issue. |
+| Worker implementation | This file, [`kernel.md`](./kernel.md), [`protocols.md`](./protocols.md) | Propose a smallest safe file plan before patching unless the maintainer explicitly asks for a patch. |
+| PR preparation | This file and [`protocols.md`](./protocols.md) | Use closing keywords only when merge should close the issue. |
+| Validation reporting | This file, [`repo.md`](./repo.md), touched surface in [`surfaces.md`](./surfaces.md) | Mark checks complete only with command output, CI evidence, inspected state, or maintainer confirmation. |
+| Merge or closure review | This file and current PR or issue evidence | Do not recommend merge or closure from clean patch application alone. |
+
+## Minimal routing guidance
+
+Load this file when a task changes issue, thread, PR, validation, merge, or
+closure procedure. Use active issue, PR, command, and CI evidence before making
+workflow completion claims.


### PR DESCRIPTION
## Summary

Define the initial Option A+ operating-contract skeleton and make
`docs/context/README.md` the first task-to-context router.

## Why

Parent issue #204 replaces the current documentation-oriented context structure
with a compact, OS-agnostic, LLM-agnostic, eval-aware operating contract.

This PR implements the first safe slice for #205: establish the target file map,
create thin skeleton contracts, and route root/adapters through the new
operating contract before later child issues collapse existing guidance.

## Changes

- Rewrite `docs/context/README.md` as the initial Option A+ task-to-context
  router.
- Add skeleton operating-contract files:
  - `docs/context/kernel.md`
  - `docs/context/protocols.md`
  - `docs/context/repo.md`
  - `docs/context/surfaces.md`
  - `docs/context/workflows.md`
  - `docs/context/repomix.md`
  - `docs/context/evals.md`
- Update `AGENTS.md` to route through the Option A+ contract files.
- Update `.github/copilot-instructions.md` so Copilot remains a secondary
  adapter and starts from the shared operating contract.
- Update `docs/context/repomix/instructions.md` so Repomix snapshots route
  through the Option A+ contract while preserving old context directories as
  deep evidence.

## Validation

- [x] `git status --short`: showed only the expected documentation/context files
  changed.
- [x] `git diff --stat`: `11 files changed, 472 insertions(+), 84 deletions(-)`.
- [x] `git diff --check`: passed with no output.
- [x] `pre-commit run --all-files`: passed.
  - `trim trailing whitespace`: Passed
  - `fix end of files`: Passed
  - `check yaml`: Passed
  - `check for added large files`: Passed
  - `shfmt`: Passed
  - `stylua`: Passed
- [x] Markdown relative links resolve:
  `Markdown relative links resolve.`
- [x] Stale-reference scan for old context paths introduced or changed by this
  PR: reviewed changed routing references; old `docs/context/core/**`,
  `docs/context/local/**`, `docs/context/local/surfaces/**`,
  `docs/context/local/workflows/**`, and `docs/context/repomix/**` paths are
  retained only as current deep evidence for later collapse work, not as the
  primary architecture.
- [x] `repomix`: generated focused snapshot with diffs:
  `.context/repomix/repomix-dotfiles-issue205.xml`.
- [x] Confirm generated Repomix output remains under `.context/repomix/**`:
  generated focused snapshot path is `.context/repomix/repomix-dotfiles-issue205.xml`.
- [x] GitHub Actions CI passes after PR creation, when required by branch
  protection or reviewer request.

`mise run doctor` was not run because this PR is documentation-only and does not
change setup, toolchain, rendered config, task behavior, health-check behavior,
scripts, CI semantics, versions, dependencies, or lockfiles.

## Risk and rollback

**Risk:** The new skeleton could make reviewers think the old context directories
are already retired.

**Rollback:** Revert this PR. It only changes documentation and assistant
routing; no repository behavior, scripts, tasks, CI semantics, templates,
versions, dependencies, lockfiles, or generated artifacts are changed.

## Review notes

Review the new `docs/context/README.md` first. It should act as the entry point
and router, not as a long architecture essay.

The existing context directories are intentionally preserved as deep evidence for
later child issues. This PR does not collapse, delete, move, or archive them.

## Out of scope

- No collapse of reusable guidance into `kernel.md`, `protocols.md`, or
  `evals.md` beyond skeleton content.
- No collapse of repository-local guidance into `repo.md` beyond skeleton
  content.
- No collapse of surface capsules, workflow guidance, or Repomix guidance beyond
  skeleton content.
- No changes to `repomix.config.json`.
- No changes to `.github/workflows/**`, `.github/pull_request_template.md`, or
  `.github/ISSUE_TEMPLATE/**`.
- No changes to chezmoi scripts, mise tasks, templates, rendered target state,
  runtime versions, tool versions, dependencies, lockfiles, or repository
  behavior.
- No generated artifact edits.

## Linked issue

Closes #205
Refs #204
