### PR TITLE
docs(context): remove issue-number residue examples

### DIFF
--- a/docs/context/protocols.md
+++ b/docs/context/protocols.md
@@ -98,7 +98,7 @@ when the changes are part of one reviewable unit. Use a predictable lowercase
 filename tied to the active issue and scope, such as:
 
 ```text
-issue223-output-protocols.patch
+<issue-number>-output-protocols.patch
 <issue-number>-<short-scope>.patch
 ```
 
@@ -124,7 +124,7 @@ Use file-backed bodies for GitHub CLI issue and PR creation instead of embedding
 Markdown in shell arguments:
 
 ```zsh
-issue_number="223"
+issue_number="<issue-number>"
 issue_dir="/tmp/issue${issue_number}"
 pr_body_file="$issue_dir/pr_body.md"
 mkdir -p "$issue_dir"
@@ -136,8 +136,8 @@ cat > "$pr_body_file" <<'EOF'
 
 ## Linked issue
 
-Closes #223
-Refs #217
+Closes #<child-issue-number>
+Refs #<parent-issue-number>
 EOF
 
 gh pr create \
@@ -148,7 +148,7 @@ gh pr create \
 Use the same file-backed pattern for issue creation when the body is multiline:
 
 ```zsh
-issue_number="223"
+issue_number="<issue-number>"
 issue_dir="/tmp/issue${issue_number}"
 issue_body_file="$issue_dir/issue_body.md"
 mkdir -p "$issue_dir"
@@ -216,7 +216,7 @@ run a few direct commands and do not include functions, loops, heredocs, embedde
 interpreters, high-output command sets, or complex quoting:
 
 ```zsh
-issue_dir="/tmp/issue223"
+issue_dir="/tmp/issue<issue-number>"
 validation_log="$issue_dir/validation_results.txt"
 validation_failed=0
 mkdir -p "$issue_dir"
@@ -308,7 +308,7 @@ docs(context): harden output protocols
 Define file-backed patch, command, PR, commit, and validation output
 boundaries for repository deliverables.
 
-Refs: #223
+Refs: #<issue-number>
 EOF
 ```
 

--- a/docs/repo/repomix.md
+++ b/docs/repo/repomix.md
@@ -39,7 +39,7 @@ Use this focused working-tree recipe when a task is bounded to a known issue,
 PR, diff, or small file set:
 
 ```zsh
-scope="issue230"
+scope="issue-or-review-scope"
 changed_files="$(git diff --name-only | paste -sd, -)"
 router_files="AGENTS.md,docs/context/README.md,docs/context/kernel.md,docs/repo/README.md"
 include_paths="$(printf '%s,%s' "$changed_files" "$router_files" | tr ',' '\n' | sed '/^$/d' | sort -u | paste -sd, -)"


### PR DESCRIPTION
## Summary

Remove concrete issue-number residue from active context documentation examples.

## Why

The post-#227 review found active reusable documentation examples that still used
concrete issue numbers. Active operating-contract docs should use durable
placeholders so planning or implementation residue does not survive in reusable
guidance.

## Changes

- Replace concrete issue-number examples in `docs/context/protocols.md` with
  generic issue-reference placeholders.
- Replace the concrete `scope="issue230"` example in `docs/repo/repomix.md` with
  a generic review-scope placeholder.

## Validation

- [x] `git status --short`
- [x] `git diff --stat`
- [x] `git diff --check`
- [x] Concrete issue residue scan for `docs/context/**/*.md` and `docs/repo/**/*.md`
- [x] Placeholder confirmations for `Refs #<parent-issue-number>`, `Closes #<child-issue-number>`, and `scope="issue-or-review-scope"`
- [x] Markdown relative links unchanged by this patch
- [x] `pre-commit run --all-files`
- [x] `repomix`
- [x] Generated Repomix output remains ignored under `.context/repomix/**`
- [x] GitHub Actions CI passes

## Risk and rollback

**Risk:** Low. This PR changes documentation examples only.

**Rollback:** Revert this PR to restore the previous example strings.

## Review notes

This PR intentionally does not create a new issue because the scope is limited to
post-#227 documentation residue cleanup.

## Out of scope

- Do not change repository behavior.
- Do not change docs structure.
- Do not change Repomix configuration.
- Do not edit generated Repomix output.
- Do not add new context guidance.

## Linked issue

Refs #227
