### PR TITLE
docs(repo): define local workflow defaults

### DIFF
--- a/docs/repo/validation.md
+++ b/docs/repo/validation.md
@@ -13,7 +13,8 @@ for validation report formatting.
 
 ## Local validation baseline
 
-For documentation-only context or routing changes, use evidence from:
+For documentation-only context, workflow, schema, template-routing,
+assistant-guidance, validation-default, or routing changes, use evidence from:
 
 - `git status --short`
 - `git diff --stat`
@@ -22,12 +23,15 @@ For documentation-only context or routing changes, use evidence from:
 - Markdown relative link validation, when repository-relative Markdown links are
   added, removed, or changed
 - `repomix`, when context routing, assistant guidance, workflow contracts,
-  Repomix guidance, or generated snapshot routing changes
+  artifact schemas, template routing, Repomix guidance, or generated snapshot
+  routing changes
 - GitHub Actions CI after PR creation, when required by branch protection or
-  reviewer request
+  reviewer request, reported separately from local validation
 
 Do not mark any check complete without command output, CI evidence, inspected
-state, or explicit maintainer confirmation.
+state, or explicit maintainer confirmation. Report unrun applicable checks as
+`Pending` or `Skipped`, and report inapplicable checks as `Not required` with the
+reason.
 
 ## Validation routing by touched source
 
@@ -41,7 +45,7 @@ state, or explicit maintainer confirmation.
 | `.chezmoidata/**` | Review every template, script, package, completion, or tool consumer affected by the data. Add rendered-output and task validation that matches the changed consumer. |
 | `dot_config/mise/tasks/**`, `.mise.toml`, tool declarations, versions, dependencies, or lockfiles | Validate mise task visibility, task behavior, tool resolution, and health checks appropriate to the change. `mise run doctor` is usually relevant when health-check behavior or setup/toolchain behavior changes. |
 | `.github/workflows/**` | Use workflow-focused review plus GitHub Actions CI evidence after PR creation. Local checks do not prove remote CI status. |
-| `.github/ISSUE_TEMPLATE/**` or `.github/pull_request_template.md` | Use template-focused review and baseline documentation validation. Do not change these templates from context cleanup unless explicitly scoped. |
+| `.github/ISSUE_TEMPLATE/**` or `.github/pull_request_template.md` | Use template-focused review and baseline documentation validation. Do not change these templates from context cleanup or workflow-default work unless explicitly scoped. |
 | `.context/repomix/**` generated XML | Do not edit generated output directly. Regenerate with `repomix` when validation requires fresh evidence. |
 
 ## Documentation-only doctor boundary
@@ -60,5 +64,10 @@ Local validation and GitHub Actions CI answer different questions. Do not infer
 GitHub Actions success from local checks, and do not infer local WSL2,
 1Password, SSH agent, Windows interop, user systemd, or workstation convergence
 from GitHub Actions CI.
+
+Report GitHub Actions CI as `Pending` until a workflow run, status check, or
+explicit maintainer confirmation proves the result. Do not mark CI as `Passed`
+from local command output, expected branch protection behavior, or PR creation
+alone.
 
 Use [`surfaces.md`](./surfaces.md) for behavior-sensitive validation routing.

--- a/docs/repo/workflows.md
+++ b/docs/repo/workflows.md
@@ -2,19 +2,52 @@
 
 ## Purpose
 
-Define repository-local workflow exceptions and template routing.
+Define repository-local workflow exceptions, GitHub deliverable defaults, and
+template routing.
 
 Use [`../context/workflows.md`](../context/workflows.md) for reusable issue,
 thread, PR, validation, merge, closure, checkbox, rollback, and parent-child
 procedure. Use this file only when the reusable workflow needs this repository's
-local templates, validation baseline, CI boundary, or assistant routing rules.
+local branch naming, labels, templates, validation baseline, CI boundary,
+Repomix expectations, or assistant routing rules.
+
+## Local GitHub deliverable defaults
+
+These defaults apply to generated issue, PR, commit, validation, and command
+artifacts for this repository. They are local conventions, not portable
+requirements.
+
+| Default | Rule |
+| --- | --- |
+| Documentation branch names | Use `docs/issue<child-issue-number>-<short-scope>` for documentation-only GitHub workflow, context, schema, template-routing, assistant-guidance, and validation-default changes. |
+| Non-documentation branch names | Use the narrowest accurate Conventional Commit-style prefix, such as `fix/`, `chore/`, or `refactor/`, only when the active issue scopes non-documentation behavior. |
+| Short scope | Use lowercase kebab case, keep it specific, and avoid repository names, labels, PR numbers, or parent issue numbers. |
+| Commit scope | Use the touched documentation owner, such as `docs(repo)` or `docs(context)`, and do not imply behavior changes. |
+| Issue references | Keep commit messages issue-reference-free. Put `Closes` and `Refs` only in PR bodies. |
+
+## Local label policy
+
+Generated issue and PR commands may include labels only when label existence is
+proved by current repository evidence or by a preflight check in the emitted
+command.
+
+| Label decision | Rule |
+| --- | --- |
+| Default documentation label | `documentation` is the local default candidate for documentation-only changes when current repository evidence or a command preflight proves the label exists. |
+| Missing label evidence | Do not emit `--label`. State that label evidence is missing or include a label preflight before the command. |
+| Multiple labels | Use more than one label only when each label exists and the meanings are orthogonal. |
+| Portable examples | Keep labels as placeholders such as `<label-name>` outside repository-local docs. |
 
 ## Local template routing
 
+`.github` templates are local UI scaffolds and shape evidence. They are not the
+portable operating-contract source for issue, PR, commit, validation, or command
+schemas.
+
 | Template | Local path | Rule |
 | --- | --- | --- |
-| Issue template | [`../../.github/ISSUE_TEMPLATE/change-request.yml`](../../.github/ISSUE_TEMPLATE/change-request.yml) | Use as shape evidence for scoped repository changes. Do not edit from workflow procedure work. |
-| Pull request template | [`../../.github/pull_request_template.md`](../../.github/pull_request_template.md) | Use as structure evidence for PR bodies. Remove template comments from final PR text. |
+| Issue template | [`../../.github/ISSUE_TEMPLATE/change-request.yml`](../../.github/ISSUE_TEMPLATE/change-request.yml) | Use as local UI scaffold evidence for scoped repository changes. Do not edit from workflow-default or procedure work unless the active issue explicitly scopes template changes. |
+| Pull request template | [`../../.github/pull_request_template.md`](../../.github/pull_request_template.md) | Use as local UI scaffold evidence for PR body structure. Remove template comments from final PR text and use state-bearing validation evidence instead of checkbox-only claims. |
 
 ## Local validation routing
 
@@ -22,10 +55,27 @@ Use [`validation.md`](./validation.md) for repository-specific validation
 baselines, documentation-only `mise run doctor` skip boundaries, and touched-file
 validation routing.
 
+For documentation-only context, workflow, schema, template-routing,
+assistant-guidance, and validation-default changes, expect the local baseline in
+[`validation.md`](./validation.md). Report unrun checks as `Pending`, `Skipped`,
+or `Not required` with a reason instead of implying completion.
+
 Use [`surfaces.md`](./surfaces.md) when workflow decisions depend on
 behavior-sensitive local surfaces. Remote CI cannot substitute for local WSL2,
 1Password, SSH agent bridge, Windows interop, user systemd, or workstation
 convergence evidence.
+
+## Local GitHub Actions CI boundary
+
+GitHub Actions CI is remote evidence and must be reported separately from local
+validation. Mark CI as `Pending` until a workflow run, status check, or explicit
+maintainer confirmation proves the result. Do not mark CI as `Passed` because
+local checks passed, because a PR was created, or because the change is
+documentation-only.
+
+Do not change `.github/workflows/**` semantics from GitHub workflow-default
+work. If a future issue scopes workflow behavior changes, use
+[`surfaces.md`](./surfaces.md) for GitHub Actions validation routing.
 
 ## Local issue-linking expectations
 
@@ -34,8 +84,13 @@ child acceptance criteria are met. Use `Refs #<parent-issue-number>` for the
 parent ledger. Do not use `Closes` for the parent issue unless the parent-level
 acceptance criteria are complete.
 
-## Local generated-artifact boundary
+## Local Repomix expectations
 
-Do not hand-edit generated Repomix output. When assistant guidance or context
-routing changes, run the local Repomix checks in [`repomix.md`](./repomix.md) and
+Do not hand-edit generated Repomix output. When context, workflow contract,
+schema, template-routing, assistant-guidance, or repository-local workflow
+defaults change, run the local Repomix checks in [`repomix.md`](./repomix.md) and
 report generated evidence as validation, not source documentation.
+
+Use [`../context/repomix.md`](../context/repomix.md) for generic Repomix
+procedure. Use [`repomix.md`](./repomix.md) only for local paths, recipes, and
+confirmation checks.


### PR DESCRIPTION
## Summary

Define repository-local GitHub workflow defaults under `docs/repo/**`.

## Scope

This PR is limited to documentation-only repository-local workflow defaults for
branch naming, label emission, validation routing, CI evidence boundaries,
Repomix expectations, and local template scaffold routing.

## Changes

- Add local documentation branch naming defaults for GitHub workflow
  deliverables.
- Define local label emission policy, including repository label evidence or
  preflight requirements.
- Document `.github` templates as local UI scaffold evidence, not portable
  operating-contract sources.
- Tighten local validation routing for context, workflow, schema,
  template-routing, assistant-guidance, and validation-default changes.
- Document the local GitHub Actions CI boundary so CI remains separate from
  local validation and cannot be marked `Passed` without run evidence.
- Route local Repomix expectations for workflow contract, schema,
  template-routing, assistant-guidance, and repository-local workflow-default
  changes.
- Preserve portable artifact schemas and command contracts in `docs/context/**`.

## Validation

| Check | State | Evidence | Notes |
| --- | --- | --- | --- |
| `git diff --check` | Passed | `git diff --check` produced no output and the chained command continued. | Whitespace check passed. |
| `git status --short` | Passed | `M docs/repo/validation.md`; `M docs/repo/workflows.md`. | Touched files are limited to the scoped repository-local documentation files. |
| `git diff --stat` | Passed | `docs/repo/validation.md | 19 ++++++++++++++-----`; `docs/repo/workflows.md | 69 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-------`; `2 files changed, 76 insertions(+), 12 deletions(-)`. | Diff scope is narrow. |
| `pre-commit run --all-files` | Passed | `trim trailing whitespace`, `fix end of files`, `check yaml`, `check for added large files`, `shfmt`, and `stylua` all passed. | Baseline hooks passed. |
| Markdown relative link validation | Passed | `Markdown relative links resolve.` | Repository-relative Markdown links were validated across `docs`, `AGENTS.md`, `README.md`, `.github/copilot-instructions.md`, and `.github/pull_request_template.md`. |
| `repomix` | Passed | Repomix v1.14.0 completed successfully, wrote `.context/repomix/repomix-dotfiles.xml`, and reported no suspicious files. | Generated evidence was regenerated, not hand-edited. |
| `mise run doctor` | Not required | Documentation-only workflow-default change. | No setup, toolchain, rendered config, task behavior, health-check behavior, scripts, CI semantics, versions, dependencies, or lockfiles changed. |
| GitHub Actions CI | Passed | Not available until this PR is created and workflow run evidence exists. | Remote CI must be reported separately from local validation. |

## Risk

Low. This PR changes repository-local documentation only and does not modify
provisioning, rendered target state, GitHub Actions workflow semantics, templates,
scripts, mise tasks, versions, dependencies, lockfiles, or generated Repomix
output.

## Rollback

Revert this PR to restore the previous repository-local workflow and validation
routing documentation.

## Review notes

Review `docs/repo/workflows.md` for local branch naming, label policy, CI
boundary, template scaffold routing, and Repomix expectations.

Review `docs/repo/validation.md` for local validation baseline wording and CI
claim discipline.

The `.github/**` files are intentionally unchanged and treated only as local UI
scaffold evidence.

## Out of scope

- Portable artifact schema changes in `docs/context/**`.
- GitHub issue template changes.
- GitHub pull request template changes.
- GitHub Actions workflow semantic changes.
- Provisioning, chezmoi, mise, identity, rendered target, dependency, version,
  or lockfile changes.
- Generated Repomix output edits.
- Parent issue completion ledger updates.

## Linked issues

Closes #240
Refs #235
