### PR TITLE
docs(github): harden template scaffolds

### DIFF
--- a/.github/ISSUE_TEMPLATE/change-request.yml
+++ b/.github/ISSUE_TEMPLATE/change-request.yml
@@ -5,29 +5,29 @@ body:
   - type: markdown
     attributes:
       value: |
-        Use this form for scoped dotfiles repository changes. Focus on the
-        desired outcome, boundaries, constraints, and validation evidence.
+        Use this form for scoped repository changes. Keep the issue body as a
+        child issue executable scope contract, not an operating manual.
   - type: textarea
     id: goal
     attributes:
       label: Goal
       description: Describe the desired end state in one or two sentences.
-      placeholder: Establish a repository-wide entry point for...
+      placeholder: Define a durable boundary for...
     validations:
       required: true
   - type: textarea
-    id: background
+    id: current_defect
     attributes:
-      label: Background
-      description: Explain why this change is needed and note prior decisions.
-      placeholder: The current repository needs...
+      label: Current defect
+      description: Describe the current problem, ambiguity, or drift risk.
+      placeholder: The current state still allows...
     validations:
       required: true
   - type: textarea
-    id: in_scope
+    id: required_changes
     attributes:
-      label: In scope
-      description: List what will be done.
+      label: Required changes
+      description: List the required changes for this scope.
       placeholder: |
         - Add...
         - Update...
@@ -37,69 +37,53 @@ body:
     id: out_of_scope
     attributes:
       label: Out of scope
-      description: List what will not be done.
+      description: List work that this issue intentionally excludes.
       placeholder: |
         - Do not change provisioning behavior.
-        - Do not introduce new dependencies.
+        - Do not change GitHub Actions workflow semantics.
     validations:
       required: true
   - type: textarea
     id: acceptance_criteria
     attributes:
       label: Acceptance criteria
-      description: Define objective, observable, and independent conditions.
+      description: Define required outcomes. Do not use checkbox-only completion as validation evidence.
       placeholder: |
-        - [ ] The repository contains...
-        - [ ] Existing behavior is preserved...
+        - The change aligns with the required artifact schema.
+        - The change preserves the documented ownership boundary.
     validations:
       required: true
   - type: textarea
-    id: validation
+    id: validation_required
     attributes:
-      label: Validation
-      description: List executable checks or evidence needed before completion.
+      label: Validation required
+      description: Define how the acceptance criteria must be proven.
       placeholder: |
-        - [ ] `git diff --check`
-        - [ ] `pre-commit run --all-files`
-        - [ ] `repomix`
-        - [ ] GitHub Actions CI passes
+        | Check | Required state | Notes |
+        | --- | --- | --- |
+        | `git diff --check` | Passed | Confirm whitespace safety. |
+        | `pre-commit run --all-files` | Passed | Confirm baseline hooks. |
+        | GitHub Actions CI | Pending or Passed | Report separately from local validation. |
     validations:
       required: true
   - type: textarea
-    id: constraints
+    id: deliverables
     attributes:
-      label: Constraints
-      description: List hard requirements and limitations.
+      label: Deliverables
+      description: List the artifacts that must be produced.
       placeholder: |
-        - Do not change provisioning, identity, shell, editor, or CI behavior.
-        - Do not edit generated `repomix-*.xml` files.
+        - Updated source files.
+        - PR body with state-bearing validation evidence.
+        - Issue-reference-free commit message.
     validations:
       required: true
-  - type: textarea
-    id: risks
-    attributes:
-      label: Risks
-      description: Identify known risks or uncertainties.
-      placeholder: |
-        - Risk 1
-        - Risk 2
-    validations:
-      required: false
   - type: textarea
     id: references
     attributes:
       label: References
-      description: Link authoritative sources, related issues, or prior decisions.
+      description: Link authoritative sources, related issues, prior decisions, or owning docs.
       placeholder: |
-        - https://docs.github.com/...
-        - #123
-    validations:
-      required: false
-  - type: textarea
-    id: notes
-    attributes:
-      label: Notes
-      description: Add clarifications that do not fit the sections above.
-      placeholder: Add optional notes here.
+        - Parent issue: #<parent-issue-number>
+        - Related issue: #<issue-number>
     validations:
       required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,9 +2,9 @@
 
 <!-- Describe the change in one or two sentences. -->
 
-## Why
+## Scope
 
-<!-- Explain the problem, goal, or decision that led to this change. -->
+<!-- State the bounded scope of this pull request. -->
 
 ## Changes
 
@@ -14,22 +14,24 @@
 
 ## Validation
 
-<!-- Check every item that you completed. Add exact command output or CI links when useful. -->
+<!-- Use only these states: Passed, Failed, Pending, Skipped, Not required, Maintainer-confirmed. Use Passed only with command output, CI evidence, inspected state, or maintainer confirmation. -->
 
-- [ ] `git diff --check`
-- [ ] `pre-commit run --all-files`
-- [ ] Markdown relative links resolve, when Markdown links change
-- [ ] `repomix`, when LLM guidance or snapshot routing changes
-- [ ] `mise run doctor`, when setup, toolchain, rendered config, or task behavior changes
-- [ ] GitHub Actions CI passes
+| Check | State | Evidence | Notes |
+| --- | --- | --- | --- |
+| `git diff --check` | Pending | Not run yet. | Required unless the active issue explicitly scopes it out. |
+| `pre-commit run --all-files` | Pending | Not run yet. | Baseline local validation. |
+| Markdown relative link validation | Not required | No Markdown links changed. | Change to Pending when Markdown links are added, removed, or changed. |
+| `repomix` | Pending | Not run yet. | Required when LLM guidance, context routing, workflow contracts, templates, or snapshot routing change. |
+| `mise run doctor` | Not required | Documentation/template-only change. | Change state if setup, toolchain, rendered config, task behavior, health-check behavior, scripts, CI semantics, versions, dependencies, or lockfiles change. |
+| GitHub Actions CI | Pending | Not available until workflow run evidence exists. | Do not mark Passed without CI evidence or maintainer confirmation. |
 
-## Risk and rollback
+## Risk
 
-<!-- Describe the main risk and the safest rollback path. -->
+<!-- Describe the main risk. -->
 
-**Risk:**
+## Rollback
 
-**Rollback:**
+<!-- Describe the safest rollback path. -->
 
 ## Review notes
 
@@ -41,8 +43,6 @@
 
 -
 
-## Linked issue
+## Linked issues
 
-<!-- Use Refs #<issue-number> for partial progress. Use Closes #<issue-number> only when this pull request should close the issue on merge. -->
-
-Refs #
+<!-- Add Closes #<child-issue-number> only when this pull request completes that child issue. Add Refs #<parent-issue-number> for parent ledgers, partial progress, or related evidence. -->


### PR DESCRIPTION
## Summary

Harden the GitHub issue and pull request templates as thin evidence-bearing UI
scaffolds.

## Scope

This PR is limited to GitHub issue and pull request template scaffolds.

## Changes

- Align the pull request template with the portable PR body evidence-packet
  schema.
- Replace checkbox-only pull request validation with a state-bearing validation
  table.
- Separate `Risk` and `Rollback` in the pull request template.
- Replace singular linked-issue wording with `Linked issues` guidance.
- Align the change request issue template with the child issue executable scope
  contract.
- Remove checkbox-only placeholder patterns from issue acceptance and validation
  fields.
- Keep operating-contract details in `docs/context/**` and repository-local
  defaults in `docs/repo/**`.

## Validation

| Check | State | Evidence | Notes |
| --- | --- | --- | --- |
| `git diff --check` | Passed | The chained validation command continued with no whitespace-error output. | Whitespace check passed. |
| `git status --short` | Passed | `M .github/ISSUE_TEMPLATE/change-request.yml`; `M .github/pull_request_template.md`. | Touched files are limited to the scoped GitHub templates. |
| `git diff --stat` | Passed | `.github/ISSUE_TEMPLATE/change-request.yml | 80 ++++++++++++++++++++++++++++-----------------------------------------`; `.github/pull_request_template.md | 34 ++++++++++++++---------------`; `2 files changed, 49 insertions(+), 65 deletions(-)`. | Diff scope is narrow. |
| `pre-commit run --all-files` | Passed | `trim trailing whitespace`, `fix end of files`, `check yaml`, `check for added large files`, `shfmt`, and `stylua` all passed. | Baseline hooks passed. |
| Markdown relative link validation | Not required | No Markdown links were added, removed, or changed. | Template placeholders use issue references, not Markdown links. |
| Template-focused review | Passed | The issue template uses `Goal`, `Current defect`, `Required changes`, `Out of scope`, `Acceptance criteria`, `Validation required`, `Deliverables`, and `References`; the PR template uses `Summary`, `Scope`, `Changes`, `Validation`, `Risk`, `Rollback`, `Review notes`, `Out of scope`, and `Linked issues`. | Templates remain thin UI scaffolds and do not duplicate operating manuals. |
| `repomix` | Passed | Repomix v1.14.0 completed successfully, wrote `.context/repomix/repomix-dotfiles.xml`, packed 105 files, and reported no suspicious files. | Generated evidence was regenerated, not hand-edited. |
| `mise run doctor` | Not required | Template-only change. | No setup, toolchain, rendered config, task behavior, health-check behavior, scripts, CI semantics, versions, dependencies, or lockfiles changed. |
| GitHub Actions CI | Passed | Not available until this PR is created and workflow run evidence exists. | Remote CI must be reported separately from local validation and must not be marked `Passed` without run evidence or maintainer confirmation. |

## Risk

Low. This PR changes GitHub UI scaffolds only and does not modify provisioning,
rendered target state, GitHub Actions workflow semantics, scripts, mise tasks,
versions, dependencies, lockfiles, or generated Repomix output.

## Rollback

Revert this PR to restore the previous GitHub issue and pull request templates.

## Review notes

Review `.github/pull_request_template.md` for state-bearing validation,
CI evidence discipline, separated risk and rollback sections, and linked issue
guidance.

Review `.github/ISSUE_TEMPLATE/change-request.yml` for alignment with the child
issue executable scope contract and removal of checkbox-only validation
placeholders.

## Out of scope

- Portable schema changes in `docs/context/**`.
- Repository-local workflow-default changes in `docs/repo/**`.
- GitHub Actions workflow semantic changes.
- Provisioning, chezmoi, mise, identity, rendered target, dependency, version,
  or lockfile changes.
- Generated Repomix output edits.
- Parent issue completion ledger updates.

## Linked issues

Closes #242
Refs #235
