### PR TITLE
chore(renovate): harden native mise governance

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,11 +1,13 @@
-// Renovate keeps GitHub Actions digests pinned for dependency governance.
-// Immutable action digests reduce supply-chain drift in workflow updates.
-// [Reference]: https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigests
+// Renovate governance is intentionally official-manager-first.
+// config:best-practices provides config:recommended, GitHub Actions digest pinning,
+// npm release-age protection, config migration, and other maintainer-recommended defaults.
+// Package rules below document review domains without grouping unrelated failures.
+// [Reference]: https://docs.renovatebot.com/presets-config/#configbest-practices
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
-    "helpers:pinGitHubActionDigests",
+    "config:best-practices",
+    ":approveMajorUpdates",
     ":dependencyDashboard"
   ],
   "labels": ["dependencies", "renovate"],
@@ -14,5 +16,85 @@
   "commitMessageExtra": "to v{{newVersion}}",
   "mise": {
     "managerFilePatterns": ["/^dot_config/mise/conf\\.d/.*\\.toml$/"]
-  }
+  },
+  "packageRules": [
+    {
+      "description": "Keep GitHub Actions updates separate from mise-managed tool updates.",
+      "matchManagers": ["github-actions"],
+      "dependencyDashboardCategory": "GitHub Actions",
+      "groupName": null
+    },
+    {
+      "description": "Keep core runtimes independent from CLI tool backends.",
+      "matchManagers": ["mise"],
+      "matchDepNames": ["node", "python", "go", "rust", "core:deno", "deno"],
+      "dependencyDashboardCategory": "mise core runtimes",
+      "groupName": null
+    },
+    {
+      "description": "Keep pnpm as a standalone CLI update, not an npm backend umbrella.",
+      "matchManagers": ["mise"],
+      "matchDepNames": ["pnpm"],
+      "dependencyDashboardCategory": "mise pnpm CLI",
+      "groupName": null
+    },
+    {
+      "description": "Keep npm-backed CLI tools separate from pnpm and core runtimes.",
+      "matchManagers": ["mise"],
+      "matchDepNames": ["/^npm:/"],
+      "dependencyDashboardCategory": "mise npm CLI tools",
+      "groupName": null
+    },
+    {
+      "description": "Keep aqua-backed CLI tools separate from npm, pnpm, and core runtimes.",
+      "matchManagers": ["mise"],
+      "matchDepNames": ["/^aqua:/"],
+      "dependencyDashboardCategory": "mise aqua-backed tools",
+      "groupName": null
+    },
+    {
+      "description": "Keep cargo-backed tools separate from npm and aqua backends.",
+      "matchManagers": ["mise"],
+      "matchDepNames": ["/^cargo:/"],
+      "dependencyDashboardCategory": "mise cargo-backed tools",
+      "groupName": null
+    },
+    {
+      "description": "Keep go-backed tools separate from npm and aqua backends.",
+      "matchManagers": ["mise"],
+      "matchDepNames": ["/^go:/"],
+      "dependencyDashboardCategory": "mise go-backed tools",
+      "groupName": null
+    },
+    {
+      "description": "Keep pipx-backed tools separate from npm and aqua backends.",
+      "matchManagers": ["mise"],
+      "matchDepNames": ["/^pipx:/"],
+      "dependencyDashboardCategory": "mise pipx-backed tools",
+      "groupName": null
+    },
+    {
+      "description": "Keep GitHub-backed mise tools separate from aqua-backed tools.",
+      "matchManagers": ["mise"],
+      "matchDepNames": ["/^github:/"],
+      "dependencyDashboardCategory": "mise GitHub-backed tools",
+      "groupName": null
+    },
+    {
+      "description": "Keep mise registry short-name CLI tools out of npm and aqua backend groups.",
+      "matchManagers": ["mise"],
+      "matchDepNames": [
+        "docker-cli",
+        "kubectl",
+        "helm",
+        "opentofu",
+        "terraform",
+        "tflint",
+        "terragrunt",
+        "gcloud"
+      ],
+      "dependencyDashboardCategory": "mise registry short-name tools",
+      "groupName": null
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Harden Renovate governance after the native mise manifest migration.

This moves Renovate from the previous recommended-plus-explicit-pinning posture
to the best-practices preset, requires Dependency Dashboard approval for major
updates, preserves the native mise source-state manifest pattern, and adds
failure-domain package rules for native mise-managed dependencies.

## Scope

This PR is limited to `renovate.json5`.

Included:

- `config:best-practices`
- `:approveMajorUpdates`
- preserved `:dependencyDashboard`
- preserved native `mise.managerFilePatterns`
- failure-domain package rules for Renovate-managed updates

Not included:

- GitHub Actions workflow changes
- Renovate CI validation workflow changes
- mise tool declaration changes
- mise runtime behavior changes
- package inventory changes
- generated Repomix output edits
- parent issue closure

## Changes

- Replace `config:recommended` with `config:best-practices`.
- Remove explicit `helpers:pinGitHubActionDigests` because `config:best-practices`
  already includes GitHub Actions digest pinning.
- Add `:approveMajorUpdates` so major updates require Dependency Dashboard
  approval.
- Preserve explicit `:dependencyDashboard`.
- Preserve native `mise.managerFilePatterns` for
  `dot_config/mise/conf.d/*.toml`.
- Add package rules that separate:
  - GitHub Actions
  - mise core runtimes
  - pnpm CLI
  - npm-backed mise CLI tools
  - aqua-backed mise tools
  - cargo-backed mise tools
  - go-backed mise tools
  - pipx-backed mise tools
  - GitHub-backed mise tools
  - mise registry short-name tools
- Use Dependency Dashboard categories and `groupName: null` to document review
  domains without forcing unrelated updates into one shared PR.

## Validation

| Check | State | Evidence | Notes |
| --- | --- | --- | --- |
| `git status --short` | Passed | `M renovate.json5` | Touched file is limited to scoped Renovate governance config. |
| `git diff --stat` | Passed | `renovate.json5 | 94 ++++++++++++++++++++++++++++++++++++++++++++++++++++++----`; `1 file changed, 88 insertions(+), 6 deletions(-)`. | Diff is limited to `renovate.json5`. |
| `git diff --check` | Passed | Exit code 0. | Whitespace check passed. |
| `pre-commit run --all-files` | Passed | `trim trailing whitespace`, `fix end of files`, `check yaml`, `check for added large files`, `shfmt`, and `stylua` passed. | Baseline hooks passed. |
| `renovate-config-validator --strict` | Passed | `Config validated successfully`. | Renovate accepted the updated JSON5 config. |
| Native mise extraction evidence | Passed | Local Renovate dry-run matched `2 file(s) for manager mise`: `.mise.toml` and `dot_config/mise/conf.d/10-tools.toml`. Extraction stats reported `mise` `fileCount: 2`, `depCount: 59`. | Confirms the native mise manager sees the source-state TOML manifest. |
| Package-rule review | Passed | Review script reported `PASS: package rules keep the required failure domains separate without broad grouping.` | Confirms package rules separate GitHub Actions, core runtimes, pnpm, npm, aqua, cargo, go, pipx, GitHub-backed, and short-name mise tools. |
| Renovate dry-run lookup | Passed | Local dry-run returned separate branches for `pnpm` and `npm:@anthropic-ai/claude-code`: `renovate/pnpm-10.x` and `renovate/npm-anthropic-ai-claude-code-2.x`. | Confirms pnpm is not grouped with unrelated npm CLI tools in this lookup. GitHub-hosted release lookups emitted a token warning, so this is extraction and grouping evidence, not exhaustive GitHub datasource freshness evidence. |
| Open Renovate PR review | Passed | Open Renovate PRs inspected: #253 `aqua:astral-sh/uv`; #254 `aqua:aws/aws-cli`. | Reviewed only as old-state/current Renovate evidence. No PRs were closed, rebased, edited, or otherwise mutated. |
| `mise install` | Passed | `mise all tools are installed`. | Not required by scope because tool declarations and mise config were unchanged, but run successfully. |
| `mise run doctor` | Passed | `System Health Evaluation Complete (Zero Drift)`. | Not required by scope because setup, toolchain, rendered config, task behavior, health-check behavior, scripts, versions, dependencies, and lockfiles were unchanged, but run successfully. |
| Final `git status --short` | Passed | `M renovate.json5` | Confirms validation artifacts were written outside the repository working tree. |
| GitHub Actions CI | Pending | Not available until PR creation. | Use GitHub Checks and status checks after PR creation; do not mirror dynamic CI status in this table. |

## Risk

Medium. This PR changes Renovate governance, so the main risk is accidentally
hiding updates, recreating broad dependency grouping, or relying on redundant
preset behavior without evidence.

The risk is mitigated by strict Renovate config validation, local Renovate
dry-run extraction evidence, package-rule review, explicit failure-domain
categories, and removal of redundant GitHub Actions digest pinning only after
moving to `config:best-practices`.

## Rollback

Revert this PR to restore the previous `config:recommended` posture and remove
the explicit failure-domain package rules.

## Review notes

Review `renovate.json5` only.

Key points for review:

- `config:best-practices` replaces `config:recommended`.
- Explicit `helpers:pinGitHubActionDigests` is removed as redundant because
  GitHub Actions digest pinning is inherited from `config:best-practices`.
- `:dependencyDashboard` remains explicit.
- `:approveMajorUpdates` is added.
- Native `mise.managerFilePatterns` remains scoped to
  `dot_config/mise/conf.d/*.toml`.
- Package rules use Dependency Dashboard categories and `groupName: null` to
  avoid forcing unrelated dependencies into shared PRs.

GitHub Actions CI is intentionally not mirrored in this PR body validation
table. After PR creation, use GitHub Checks and status checks as the source of
truth for remote CI.

## Out of scope

- Parent issue closure.
- Renovate validation in GitHub Actions CI.
- GitHub Actions workflow edits.
- GitHub Actions action pin or permission changes.
- mise tool declaration changes.
- mise runtime behavior changes.
- pnpm setup task changes.
- Homebrew, Linux, Windows, Neovim, identity, SSH, WSL2, 1Password, Git signing,
  WezTerm, package inventory, or generated Repomix behavior changes.
- Generated Repomix output edits.

## Linked issues

Closes #255
Refs #250
