### PR TITLE
ci(renovate): validate repository config in compliance

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -20,6 +20,28 @@ permissions:
   contents: read
 
 jobs:
+  renovate-config:
+    name: Renovate Config Validation
+    runs-on: ubuntu-24.04
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+      # Pin the validator distribution so CI and local checks use the same Renovate schema.
+      # [Reference]: https://docs.renovatebot.com/config-validation/
+      RENOVATE_VERSION: "43.150.0"
+
+    steps:
+      - name: Checkout Repository
+        # Checkout runs on Node.js 24 through FORCE_JAVASCRIPT_ACTIONS_TO_NODE24; Renovate pins the action hash.
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Validate Renovate Repository Config
+        run: |
+          test -f renovate.json5
+          npx --yes --package "renovate@${RENOVATE_VERSION}" -- renovate-config-validator --version
+          npx --yes --package "renovate@${RENOVATE_VERSION}" -- renovate-config-validator --strict
+
   convergence:
     name: Convergence & Idempotency Proof
     strategy:

--- a/docs/repo/validation.md
+++ b/docs/repo/validation.md
@@ -20,6 +20,10 @@ assistant-guidance, validation-default, or routing changes, use evidence from:
 - `git diff --stat`
 - `git diff --check`
 - `pre-commit run --all-files`
+- `test -f renovate.json5`
+- `npx --yes --package "renovate@43.150.0" -- renovate-config-validator --version`
+- `npx --yes --package "renovate@43.150.0" -- renovate-config-validator --strict`,
+  when Renovate governance or Renovate CI validation changes
 - Markdown relative link validation, when repository-relative Markdown links are
   added, removed, or changed
 - `repomix`, when context routing, assistant guidance, workflow contracts,
@@ -34,6 +38,26 @@ state, or explicit maintainer confirmation. Report unrun applicable checks as
 `Pending` or `Skipped`, and report inapplicable checks as `Not required` with the
 reason.
 
+## Renovate config validation
+
+When Renovate governance or Renovate CI validation changes, run the same
+repository-config validation command from the repository root:
+
+```zsh
+test -f renovate.json5
+npx --yes --package "renovate@43.150.0" -- renovate-config-validator --version
+npx --yes --package "renovate@43.150.0" -- renovate-config-validator --strict
+```
+
+The validator checks Renovate's default repository config locations when no file
+argument is provided. `renovate.json5` is one of those default locations, so the
+explicit `test -f renovate.json5` guard makes the target file check visible while
+avoiding positional filename parsing as global self-hosted configuration.
+
+Keep the Renovate package version exact in CI and local reproduction commands so
+both paths validate against the same Renovate schema. Update that version only
+with matching local validation and GitHub Actions evidence.
+
 ## Validation routing by touched source
 
 | Touched source | Validation routing |
@@ -45,6 +69,7 @@ reason.
 | `.chezmoiignore.tmpl`, `.chezmoi.toml.tmpl`, `.chezmoiscripts/**`, `.chezmoitemplates/**`, or rendered configuration templates | Use rendered-output inspection such as `chezmoi diff` or `chezmoi execute-template` in addition to baseline checks. Consider `mise run doctor` only when setup, toolchain, rendered config, task behavior, or health-check behavior changes. |
 | `.chezmoidata/**` | Review every template, script, package, completion, or tool consumer affected by the data. Add rendered-output and task validation that matches the changed consumer. |
 | `dot_config/mise/tasks/**`, `.mise.toml`, tool declarations, versions, dependencies, or lockfiles | Validate mise task visibility, task behavior, tool resolution, and health checks appropriate to the change. `mise run doctor` is usually relevant when health-check behavior or setup/toolchain behavior changes. |
+| `renovate.json5` | Run `test -f renovate.json5`, `npx --yes --package "renovate@43.150.0" -- renovate-config-validator --version`, and `npx --yes --package "renovate@43.150.0" -- renovate-config-validator --strict`. Add package-rule or extraction evidence only when Renovate governance behavior changes, and keep GitHub Actions CI status in Checks or status checks after PR creation. |
 | `.github/workflows/**` | Use workflow-focused review plus GitHub Actions CI evidence after PR creation. Local checks do not prove remote CI status. |
 | `.github/ISSUE_TEMPLATE/**` or `.github/pull_request_template.md` | Use template-focused review and baseline documentation validation. Do not change these templates from context cleanup or workflow-default work unless explicitly scoped. |
 | `.context/repomix/**` generated XML | Do not edit generated output directly. Regenerate with `repomix` when validation requires fresh evidence. |


### PR DESCRIPTION
## Summary

Add CI-backed Renovate repository config validation to the compliance workflow.

This closes the remaining dependency-governance validation gap from the native
mise manifest refactor by making `renovate.json5` validation machine-checkable
instead of prose-only.

## Scope

Included:

- Add a dedicated `renovate-config` compliance job.
- Run Renovate validation against the repository's `renovate.json5`.
- Pin the Renovate validator distribution used by CI and local reproduction.
- Document the exact local reproduction command in repository validation
  guidance.

Not included:

- Renovate package-rule redesign.
- mise tool declaration or runtime behavior changes.
- pnpm setup behavior changes.
- dependency-review or dependency-submission.
- secrets, environments, write permissions, or broad token scopes.
- parent issue closure.

## Changes

- Add a separate `renovate-config` job to `.github/workflows/compliance.yml`.
- Pin the validator distribution with:

  ```yaml
  RENOVATE_VERSION: "43.150.0"
  ```

- Run:

  ```zsh
  test -f renovate.json5
  npx --yes --package "renovate@${RENOVATE_VERSION}" -- renovate-config-validator --version
  npx --yes --package "renovate@${RENOVATE_VERSION}" -- renovate-config-validator --strict
  ```

- Keep the existing Ubuntu and macOS convergence matrix unchanged.
- Keep workflow permissions at `contents: read`.
- Keep existing third-party GitHub Actions pinned to full-length commit SHAs.
- Add `docs/repo/validation.md` guidance for local Renovate config validation.
- Add `renovate.json5` validation routing to the repository validation table.

## Validation

| Check | State | Evidence | Notes |
| --- | --- | --- | --- |
| `test -f renovate.json5` | Passed | Exit code 0. | Confirms the intended repository config file exists before relying on Renovate default config discovery. |
| `npx --yes --package "renovate@43.150.0" -- renovate-config-validator --version` | Passed | Output: `43.150.0`. | Confirms local validation used the same pinned Renovate validator distribution configured for CI. |
| `npx --yes --package "renovate@43.150.0" -- renovate-config-validator --strict` | Passed | `INFO: Validating renovate.json5`; `INFO: Config validated successfully`. | Confirms the repository Renovate config validates under the pinned validator schema. |
| `git diff --check` | Passed | Exit code 0. | Whitespace check passed after the validator pin update. |
| `pre-commit run --all-files` | Passed | `trim trailing whitespace`, `fix end of files`, `check yaml`, `check for added large files`, `shfmt`, and `stylua` passed. | Baseline hooks passed after the validator pin update. |
| `chezmoi diff` | Not required | Not run. | The change touches only GitHub Actions CI and repository validation docs; no rendered source-state behavior changes. |
| `mise install` | Not required | Not run. | The change does not touch tool declarations or mise config. |
| `mise run doctor` | Not required | Not run. | The change does not touch setup, toolchain, rendered config, task behavior, health-check behavior, scripts, versions, dependencies, or lockfiles. |

## Risk

Low to medium.

The main risk is adding a network-backed `npx` validation step to CI. The job
pins the Renovate validator distribution to `renovate@43.150.0` so CI and local
reproduction evaluate the same schema instead of depending on floating package
resolution.

The validation job is separate from the convergence matrix so Renovate config
failures do not obscure Ubuntu or macOS convergence failures.

## Rollback

Revert this PR to remove the dedicated Renovate config validation job and the
local reproduction guidance from `docs/repo/validation.md`.

## Review notes

Renovate config validation belongs in CI because the remaining governance gap is
not whether the current prose describes the intended policy. The gap is that a
future edit to `renovate.json5` could silently break config validity unless CI
checks it.

The validation command intentionally uses Renovate default config discovery after
checking that `renovate.json5` exists:

```zsh
test -f renovate.json5
npx --yes --package "renovate@43.150.0" -- renovate-config-validator --version
npx --yes --package "renovate@43.150.0" -- renovate-config-validator --strict
```

This avoids positional filename parsing as self-hosted global configuration and
keeps CI/local validator schema selection deterministic.

dependency-review and dependency-submission are intentionally not added. No
direct evidence in this scope proves that they observe this repository's
mise-managed dependency graph, so adding them would be decorative governance.

After this PR branch is updated, use GitHub Checks and status checks as the
source of truth for remote CI. Confirm:

- `Renovate Config Validation`
- Ubuntu `Convergence & Idempotency Proof`
- macOS `Convergence & Idempotency Proof`

Do not mirror dynamic GitHub Actions CI results in this PR body validation table.

## Out of scope

- Parent issue closure.
- Renovate package-rule redesign.
- Changes to `config:best-practices`, `:approveMajorUpdates`, Dependency
  Dashboard settings, or failure-domain grouping.
- Changes to `renovate.json5`.
- Changes to `.mise.toml`.
- Changes to `dot_config/mise/conf.d/10-tools.toml`.
- Changes to `dot_config/mise/config.toml.tmpl`.
- Changes to pnpm setup task behavior.
- Homebrew, Linux, Windows, Neovim, identity, SSH, WSL2, 1Password, Git signing,
  WezTerm, package inventory, or generated Repomix behavior changes.
- Generated Repomix output edits.

## Linked issues

Closes #257
Refs #250
