### PR TITLE
Move Docker ownership out of mise

### DIFF
--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -56,6 +56,7 @@ packages:
       - notion
       - raycast
       - visual-studio-code
+      - docker-desktop
       - codex-app
       - 1password
       - 1password-cli
@@ -67,6 +68,7 @@ packages:
       - Flow-Launcher.Flow-Launcher
       - Microsoft.PowerToys
       - Microsoft.VisualStudioCode
+      - Docker.DockerDesktop
       - AgileBits.1Password
       - AgileBits.1Password.CLI
 

--- a/.chezmoiremove.tmpl
+++ b/.chezmoiremove.tmpl
@@ -35,3 +35,7 @@ Those dumps increase compaudit overhead.
 
 {{/* Remove the previous 1Password agent config path after scoped path correction. */}}
 Library/Group Containers/2BUA8C4S2C.com.1password/Library/Application Support/1Password/ssh/agent.toml
+
+{{/* Remove stale mise-managed Docker CLI artifacts after Docker ownership moved to platform packages. */}}
+.local/share/mise/installs/docker-cli
+.local/share/mise/shims/docker

--- a/README.md
+++ b/README.md
@@ -106,10 +106,24 @@ Prepare only the supported path that applies to the host you are bootstrapping.
 Grant Full Disk Access to the terminal emulator when the host needs to provision
 or inspect protected directories.
 
+Desktop provisioning installs Docker Desktop through the Homebrew
+`docker-desktop` cask outside CI. Start Docker Desktop and accept Docker's
+subscription terms before expecting the Docker daemon, socket, CLI, or Desktop
+integrations to be usable.
+
 #### Windows 11 with WSL2 Ubuntu 24.04+
 
 Prepare Windows 11 with WSL2 Ubuntu 24.04+ as a WSL-to-Windows bridge path,
 not as generic Linux.
+
+Windows-side GUI provisioning installs Docker Desktop through the WinGet
+`Docker.DockerDesktop` package outside CI. Start Docker Desktop, accept Docker's
+subscription terms, and enable WSL 2 integration for the target Ubuntu
+distribution when Docker commands are required from WSL2.
+
+The WSL2 Ubuntu path does not install Docker Engine or Docker CLI packages
+inside Linux. Docker daemon, socket, Desktop, and WSL integration behavior is
+owned by the Windows-side Docker Desktop installation.
 
 WSL2 convergence requires:
 

--- a/dot_config/mise/conf.d/10-tools.toml
+++ b/dot_config/mise/conf.d/10-tools.toml
@@ -57,7 +57,6 @@ go = "1.26.2"
 "aqua:koalaman/shellcheck" = "0.11.0"
 
 # --- 8. Cloud & Platform Orchestration ---
-docker-cli = "26.0.0"
 "go:github.com/jesseduffield/lazydocker" = "0.25.2"
 kubectl = "1.36.0"
 helm = "4.1.4"

--- a/renovate.json5
+++ b/renovate.json5
@@ -84,7 +84,6 @@
       "description": "Keep mise registry short-name CLI tools out of npm and aqua backend groups.",
       "matchManagers": ["mise"],
       "matchDepNames": [
-        "docker-cli",
         "kubectl",
         "helm",
         "opentofu",


### PR DESCRIPTION
## Summary

Move Docker ownership out of mise and into supported desktop platform package provisioning.

## Scope

This PR completes #262 by removing the mise-managed Docker CLI model and making Docker Desktop the explicit macOS/Windows ownership boundary.

## Changes

- Remove `docker-cli` from `dot_config/mise/conf.d/10-tools.toml`.
- Remove `docker-cli` from the Renovate mise short-name package rule.
- Add Docker Desktop to macOS GUI provisioning through the Homebrew `docker-desktop` cask.
- Add Docker Desktop to Windows GUI provisioning through the WinGet `Docker.DockerDesktop` package.
- Document Docker Desktop subscription, daemon, socket, and WSL integration operator boundaries in `README.md`.
- Remove stale mise-managed Docker CLI install and shim targets through `.chezmoiremove.tmpl`.

## Validation

| Check | State | Evidence | Notes |
| --- | --- | --- | --- |
| `git status --short` | Passed | Reported only `.chezmoidata/packages.yaml`, `.chezmoiremove.tmpl`, `README.md`, `dot_config/mise/conf.d/10-tools.toml`, and `renovate.json5` modified before commit. | Confirms the source diff stayed inside #262 scope. |
| `git diff --stat` | Passed | Reported 5 files changed, 20 insertions, and 2 deletions. | Confirms the patch remained narrow. |
| `git diff --check` | Passed | Completed with exit code 0 and no output. | Whitespace check passed. |
| `pre-commit run --all-files` | Passed | `trim trailing whitespace`, `fix end of files`, `check yaml`, `check for added large files`, `shfmt`, and `stylua` passed. | Baseline local hooks passed. |
| `chezmoi diff` | Passed | Rendered evidence includes `cask "docker-desktop"`, removal of rendered `docker-cli`, and removal of stale mise Docker CLI target paths. | Rendered target inspection matches the ownership change. |
| `mise install` | Passed | Reported `mise all tools are installed`. | Confirms Docker is no longer blocking mise convergence. |
| `mise run doctor` | Passed | Rerun completed with `System Health Evaluation Complete (Zero Drift)`. | Supersedes the earlier transient local Neovim verification failure. |
| `npx --yes --package "renovate@43.150.0" -- renovate-config-validator --version` | Passed | Reported `43.150.0`. | Confirms the validator version used for local reproduction. |
| `npx --yes --package "renovate@43.150.0" -- renovate-config-validator --strict` | Passed | Reported `Config validated successfully`. | Confirms Renovate config validity after removing `docker-cli` from the mise package rule. |
| Focused Repomix evidence | Passed | `repomix-dotfiles-issue262.xml` includes the changed files and worktree diff for #262 review. | Generated evidence was inspected as read-only. |

## Risk

Docker Desktop is a larger platform package boundary than a standalone CLI. It requires operator action for subscription terms, first launch, daemon availability, and WSL integration. Windows and macOS GUI provisioning may install Docker Desktop outside CI, but this PR does not automate license acceptance or daemon startup.

## Rollback

Revert this PR to restore the previous mise-managed Docker CLI declaration and remove Docker Desktop from platform package provisioning. If Docker Desktop was already installed on a workstation by applying this change, uninstalling it remains an operator action outside source-state rollback.

## Review notes

GitHub Checks and status checks are the source of truth for remote CI after PR creation. This PR intentionally does not add Linux Docker Engine or Docker CLI package ownership because that would require owning Docker's Linux repository, keyring, daemon, socket, and service lifecycle boundary.

## Out of scope

- Do not weaken `mise install`, `mise run doctor`, `chezmoi diff`, or compliance CI.
- Do not disable mise/aqua artifact verification.
- Do not add the Homebrew `docker` formula as the ownership boundary.
- Do not install Docker Engine or Docker CLI packages directly inside Linux or WSL2.
- Do not provision Docker's official Linux package repository, keyring, daemon, socket, or service lifecycle.
- Do not automate Docker Desktop subscription acceptance, first launch, sign-in, daemon startup, or WSL integration settings.
- Do not touch generated Repomix output directly.

## Linked issues

Closes #262
Refs #250
