### PR TITLE
docs(context): route Worker handoff defaults

### DIFF
--- a/docs/context/workflows.md
+++ b/docs/context/workflows.md
@@ -85,11 +85,13 @@ cleanup work, a Worker should:
    them;
 5. report ambiguity, stale material, and useful out-of-scope findings without
    implementing adjacent cleanup;
-6. produce a strict patch only after the file plan is accepted or the maintainer
-   explicitly requests a patch.
+6. produce repository patch or validation-runner artifacts only after the file
+   plan is accepted or the maintainer explicitly requests them, using the output
+   selection defaults in [`protocols.md`](./protocols.md).
 
-Use [`protocols.md`](./protocols.md) for patch, command, heredoc, PR, commit,
-code-fence, whitespace, and final-newline output contracts.
+Use [`protocols.md`](./protocols.md) for downloadable `.patch` and `.sh` handoff
+defaults, patch content boundaries, command, heredoc, PR, commit, code-fence,
+whitespace, and final-newline output contracts.
 
 ## Pull request workflow
 


### PR DESCRIPTION
## Summary

- Route Worker patch and validation-runner handoff through the portable output-selection defaults.
- Keep downloadable artifact behavior centralized in `docs/context/protocols.md`.

## Scope

- Documentation-only change in `docs/context/workflows.md`.
- No repository-local workflow override, behavior, CI, template, generated output, toolchain, version, dependency, or lockfile changes.

## Changes

- Updates Worker file-plan-first guidance to use `docs/context/protocols.md` output-selection defaults after file-plan acceptance or explicit artifact request.
- Routes downloadable `.patch` and `.sh` handoff defaults, patch content boundaries, and other output contracts to the portable protocols contract.

## Validation

| Check | State | Evidence | Notes |
| --- | --- | --- | --- |
| `git status --short` | Passed | Exit 0; reported `M docs/context/workflows.md`. `git -c core.fsmonitor=false status --short` confirmed the same scoped file without fsmonitor warning. | Local fsmonitor warning is unrelated to the docs change. |
| `git diff --stat` | Passed | `docs/context/workflows.md | 10 ++++++----`; `1 file changed, 6 insertions(+), 4 deletions(-)`. | Scoped portable workflow diff only. |
| `git diff --check` | Passed | Exit 0. | No whitespace errors. |
| `pre-commit run --all-files` | Passed | All configured hooks passed. | Includes whitespace, EOF, YAML, large-file, shfmt, and stylua hooks. |
| Markdown relative link validation | Passed | `test -f docs/context/protocols.md` exited 0. | Validates the referenced protocols contract target. |
| `repomix` | Passed | Repomix v1.14.0 packed 105 files to `.context/repomix/repomix-dotfiles.xml`; security check passed. | Generated output treated as validation evidence, not source. |
| Repomix output ignore check | Passed | `.gitignore:18:.context/repomix/**` matched `.context/repomix/repomix-dotfiles.xml`. | Confirms generated output remains ignored. |
| `mise run doctor` | Not required | Documentation-only workflow guidance change. | No setup, toolchain, rendered config, task behavior, health-check behavior, scripts, CI semantics, versions, dependencies, or lockfiles changed. |

## Risk

Low. The change only tightens portable workflow routing to an existing output contract.

## Rollback

Revert this PR.

## Review notes

- `docs/context/protocols.md` already owns the detailed `.patch` and `.sh` output-selection defaults.
- Existing regression cases `REG-003`, `REG-004`, and `REG-021` already cover the relevant drift, so no eval change was needed.

## Out of scope

- Renovate surface or validator parity hardening.
- GitHub Actions workflow changes.
- `renovate.json5` changes.
- `.github` template changes.
- Generated Repomix output edits.
- Chezmoi, mise, Neovim, WSL2, identity, SSH, 1Password, Git signing, package inventory, lockfile, or runtime behavior changes.

## Linked issues

Closes #264
