### PR TITLE
Reduce Git state ambiguity for LLM collaboration

### DIFF
--- a/dot_config/git/config.tmpl
+++ b/dot_config/git/config.tmpl
@@ -55,11 +55,12 @@ Editing rules:
     */ -}}
     pager = delta
 
-    {{/* [Performance]
-    Built-in fsmonitor + untracked cache + split index + commit-graph is the modern fast path
-    for repeated status/add/checkout operations in medium-to-large working trees.
+    {{/* [Evidence + Performance]
+    Keep fsmonitor disabled globally so status and diff evidence does not depend on a
+    long-lived filesystem monitor in sandboxed, nonstandard, or LLM-assisted sessions.
+    Untracked cache + split index + commit-graph keep the conservative fast path.
     */ -}}
-    fsmonitor = true
+    fsmonitor = false
     untrackedCache = true
     splitIndex = true
     commitGraph = true
@@ -129,11 +130,12 @@ Editing rules:
     directoryRenames = conflict
 
 [rerere]
-    {{/* [Automation]
-    Reuse recorded conflict resolutions. Extremely high leverage for rebase-heavy workflows.
+    {{/* [Automation + Evidence]
+    Reuse recorded conflict resolutions, but do not copy them into the index automatically.
+    The index should remain explicit evidence of reviewed staging intent.
     */ -}}
     enabled = true
-    autoupdate = true
+    autoupdate = false
 
 [diff]
     colorMoved = default
@@ -173,7 +175,11 @@ Editing rules:
     useForceIfIncludes = true
 
 [rebase]
-    autoStash = true
+    {{/* [Evidence]
+    Do not auto-stash dirty state during rebase; hidden save/restore steps make
+    working-tree evidence harder to track in mixed human/LLM workflows.
+    */ -}}
+    autoStash = false
     updateRefs = true
     autoSquash = true
     {{/* [Safety]
@@ -203,7 +209,7 @@ Editing rules:
 
 [status]
     {{/* [UX]
-    Surface stash count in status output; surprisingly useful when autoStash is common.
+    Surface stash count in status output; useful when context switches leave local work parked.
     */ -}}
     showStash = true
 


### PR DESCRIPTION
## Summary

Reduce global Git state ambiguity for Codex and LLM-assisted repository work by making the three scoped defaults more conservative in the chezmoi Git config source template.

## Scope

This PR changes only `dot_config/git/config.tmpl`.

## Changes

- Set `core.fsmonitor = false` so status and diff evidence do not depend on a long-lived filesystem monitor in sandboxed, nonstandard, or LLM-assisted sessions.
- Preserve `rerere.enabled = true` while setting `rerere.autoupdate = false` so recorded resolutions are reused without automatically mutating the index.
- Set `rebase.autoStash = false` so rebase does not hide and restore dirty working-tree state by default.
- Update only adjacent comments that explain the evidence boundary for mixed human/LLM workflows.

## Validation

| Check | State | Evidence | Notes |
| --- | --- | --- | --- |
| `git status --short` | Passed | Reported only `M dot_config/git/config.tmpl` before staging. | No out-of-scope files were present. |
| `git diff --stat` | Passed | `dot_config/git/config.tmpl | 24 +++++++++++++++---------`; `1 file changed, 15 insertions(+), 9 deletions(-)`. | Confirms narrow patch. |
| `git diff --check` | Passed | Command exited 0 with no output. | Whitespace-safe. |
| `pre-commit run --all-files` | Passed | trailing whitespace, end-of-file, YAML, large-file, shfmt, and stylua hooks passed. | Local hook baseline passed before commit. |
| `chezmoi execute-template < dot_config/git/config.tmpl > /private/tmp/issue269-rendered-gitconfig` | Passed | Command exited 0. | Rendered source template without editing rendered target files. |
| `git config --file /private/tmp/issue269-rendered-gitconfig --get core.fsmonitor` | Passed | `false` | Asserted from rendered output. |
| `git config --file /private/tmp/issue269-rendered-gitconfig --get rerere.enabled` | Passed | `true` | Preserves conflict-resolution memory. |
| `git config --file /private/tmp/issue269-rendered-gitconfig --get rerere.autoupdate` | Passed | `false` | Prevents automatic index mutation from recorded resolutions. |
| `git config --file /private/tmp/issue269-rendered-gitconfig --get rebase.autoStash` | Passed | `false` | Prevents hidden dirty-state movement during rebase. |

GitHub Actions CI should be read from GitHub Checks for this PR after creation.

## Risk

Low. The change intentionally trades some global automation and performance convenience for clearer working-tree and index evidence in mixed human/LLM workflows.

## Rollback

Revert this commit to restore the previous global Git defaults.

## Review notes

No identity routing, signing, aliases, push/pull behavior, diff settings, merge settings, maintenance settings, mise tooling, workflows, lockfiles, generated artifacts, or rendered target files were changed.

## Out of scope

- Identity routing and 1Password signing behavior.
- Git aliases, diff behavior, merge behavior, push/pull behavior, and maintenance behavior.
- mise tooling, workflows, lockfiles, generated Repomix output, and rendered target files.

## Linked issues

Closes #269
