### PR TITLE
fix(mise): remove lazy-lock self-alias

### DIFF
--- a/dot_config/mise/tasks/update/executable_lazy-lock.tmpl
+++ b/dot_config/mise/tasks/update/executable_lazy-lock.tmpl
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 # [MISE] description="Atomic Neovim plugin update and PR generation"
-# [MISE] alias="update:lazy-lock"
 {{/* [Reference]: https://mise.jdx.dev/tasks/file-tasks.html */}}{{ "" -}}
 
 set -euo pipefail


### PR DESCRIPTION
## Summary

Remove the redundant self-alias from the managed `update:lazy-lock` mise task and record the current unmanaged target-visible mise task drift for Child 1.

## Scope

This PR is limited to mise task hygiene and unmanaged mise task drift inventory for parent issue #271 and child issue #272.

The only source-state file changed is `dot_config/mise/tasks/update/executable_lazy-lock.tmpl`.

## Changes

- Removed `# [MISE] alias="update:lazy-lock"` from `dot_config/mise/tasks/update/executable_lazy-lock.tmpl` because the file task already resolves to the task name `update:lazy-lock`.
- Re-rendered only `/Users/thomma/.config/mise/tasks/update/lazy-lock` locally to validate the active mise task set after the source-state change.
- Inventoried current target-visible mise tasks that have no source-state owner under `dot_config/mise/tasks/**`.

Current unmanaged mise task drift inventory:

| Task name | Visible target path | Source-state ownership status | Resolution |
| --- | --- | --- | --- |
| `setup:nvim-provider` | `/Users/thomma/.config/mise/tasks/setup/nvim-provider` | `chezmoi source-path` reports `not managed`; no matching `dot_config/mise/tasks/setup/executable_nvim-provider.tmpl` exists in the source inventory. | Deferred; inventoried only. |
| `setup:python-provider` | `/Users/thomma/.config/mise/tasks/setup/python-provider` | `chezmoi source-path` reports `not managed`; no matching `dot_config/mise/tasks/setup/executable_python-provider.tmpl` exists in the source inventory. | Deferred; inventoried only. |
| `sync-wezterm` | `/Users/thomma/.config/mise/tasks/sync-wezterm` | `chezmoi source-path` reports `not managed`; source state owns the separate `sync:wezterm` task at `dot_config/mise/tasks/sync/executable_wezterm.tmpl`. | Deferred; inventoried only. |

## Validation

| Check | State | Evidence | Notes |
| --- | --- | --- | --- |
| Pre-fix `mise tasks validate --json --errors-only` | Failed | Exit code 1; `tasks_validated: 20`, `errors: 1`, category `alias-conflict`, task `update:lazy-lock`, message `Alias 'update:lazy-lock' conflicts with task name`. | Defect evidence before the source-state fix. |
| Post-fix `mise tasks validate --json --errors-only` | Passed | Exit code 0; `tasks_validated: 20`, `errors: 0`, `warnings: 0`, `issues: []`. | Run after rendering the changed managed task into the active task set. |
| `mise tasks ls --extended` | Passed | Output inspected after the fix; `update:lazy-lock` is listed from `~/.config/mise/tasks/update/lazy-lock` without the prior alias column, and the unmanaged drift entries remain visible. | Confirms public task visibility and preserves drift for inventory instead of silently resolving it. |
| Source/target task inventory | Passed | `rg --files dot_config/mise/tasks` listed 17 source-state task files; `rg --files /Users/thomma/.config/mise/tasks` listed 20 target-visible task files. `chezmoi source-path` reports the three inventoried drift paths as `not managed`. | Confirms current source-state ownership and target-visible drift. |
| `chezmoi diff /Users/thomma/.config/mise/tasks/update/lazy-lock` | Passed | Before the scoped apply, the diff showed only removal of the redundant alias line from the rendered target; after the scoped apply, the command exited 0 with no output. | Required because a chezmoi source-state task template changed. |
| `git diff --check` | Passed | Exit code 0 with no output. | Whitespace check. |
| `pre-commit run --all-files` | Passed | Exit code 0; `trim trailing whitespace`, `fix end of files`, `check yaml`, `check for added large files`, `shfmt`, and `stylua` passed. | Baseline local validation. |
| `mise run doctor` | Not required | Not run. | This PR does not change setup, doctor, runtime, rendered config behavior, health-check behavior, scripts, CI semantics, versions, dependencies, or lockfiles. |

## Risk

Risk is low because the repository change removes only metadata that duplicated the task's own name. The unmanaged target-visible tasks remain unresolved by design, so later ownership cleanup still needs a scoped follow-up.

## Rollback

Revert this PR. If the rendered workstation target has already been applied, run `chezmoi apply /Users/thomma/.config/mise/tasks/update/lazy-lock` after reverting to restore the previous rendered task state.

## Review notes

Remote GitHub Actions CI is separate from local validation. GitHub Checks and status checks after PR creation are the source of truth for CI; local checks above do not prove remote CI.

The unmanaged drift inventory is intentionally an inventory only. This PR does not delete target-side files, import unmanaged task logic, or introduce `exact_` ownership.

## Out of scope

- Doctor behavior refactors.
- `.chezmoiscripts` logic moves.
- Identity convergence changes.
- Package lists, tool versions, runtime versions, dependencies, or lockfiles.
- GitHub Actions workflow semantics.
- Deleting or importing unmanaged target-side task files.
- Blanket `exact_` ownership for mise task directories.
- Changes to the supported `chezmoi init --apply` bootstrap path or public `mise run doctor` command.

## Linked issues

Closes #272
Refs #271
