### PR TITLE
fix(doctor): make health checks read-only

### DIFF
--- a/dot_config/mise/tasks/doctor/executable_identity.tmpl
+++ b/dot_config/mise/tasks/doctor/executable_identity.tmpl
@@ -61,20 +61,15 @@ else
   if [[ "$IS_CI" == "true" ]]; then
     log_warn "SSH Agent unresponsive (expected in CI environment)."
   else
-    log_warn "SSH Agent unresponsive. Attempting bridge recovery..."
+    log_err "SSH Agent is unresponsive."
     {{ if .is_wsl }}
-    if command -v systemctl >/dev/null 2>&1; then
-      systemctl --user restart 1password-bridge.service || true
-    fi
+    log_guide "Restart the WSL2 1Password bridge explicitly: systemctl --user restart 1password-bridge.service"
+    log_guide "Then rerun 'mise run doctor:identity'."
+    {{ else }}
+    log_guide "Verify the 'SSH Agent' setting in 1Password Desktop App."
+    log_guide "Then rerun 'mise run doctor:identity'."
     {{ end }}
-    sleep 1
-    if ssh-add -l > /dev/null 2>&1; then
-      log_ok "Authentication bridge recovered successfully."
-    else
-      log_err "Authentication bridge failed to initialize."
-      log_guide "Verify the 'SSH Agent' setting in 1Password Desktop App."
-      HAS_ERROR=1
-    fi
+    HAS_ERROR=1
   fi
 fi
 

--- a/dot_config/mise/tasks/doctor/executable_security.tmpl
+++ b/dot_config/mise/tasks/doctor/executable_security.tmpl
@@ -5,18 +5,51 @@
 set -euo pipefail
 
 GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
 NC='\033[0m'
 
 log_ok() { printf "  ${GREEN}✅ %s${NC}\n" "$1"; }
+log_warn() { printf "  ${YELLOW}⚠️  %s${NC}\n" "$1"; }
+log_err() { printf "  ${RED}❌ %s${NC}\n" "$1"; }
+log_guide() { printf "  ${BLUE}👉 %s${NC}\n" "$1"; }
 
 HOME_DIR="{{ .paths.home }}"
+HAS_ERROR=0
+
+dir_mode() {
+  local dir="$1"
+  local mode=""
+
+  if mode="$(stat -c '%a' "$dir" 2>/dev/null)"; then
+    printf "%s" "$mode"
+  elif mode="$(stat -f '%Lp' "$dir" 2>/dev/null)"; then
+    printf "%s" "$mode"
+  else
+    return 1
+  fi
+}
 
 echo "--- 1. Infrastructure Security & Permissions ---"
 for dir in "$HOME_DIR/.ssh" "{{ .paths.xdg_state }}/ssh"; do
   if [[ -d "$dir" ]]; then
-    chmod 700 "$dir"
-    log_ok "Permissions secured for $dir (0700)."
+    if mode="$(dir_mode "$dir")"; then
+      if [[ "$mode" == "700" ]]; then
+        log_ok "Permissions verified for $dir (0700)."
+      else
+        log_err "Permission drift detected for $dir (mode $mode, expected 700)."
+        log_guide "Run 'chmod 700 \"$dir\"' after confirming ownership."
+        HAS_ERROR=1
+      fi
+    else
+      log_err "Permission mode could not be inspected for $dir."
+      log_guide "Inspect the directory permissions manually, then rerun 'mise run doctor:security'."
+      HAS_ERROR=1
+    fi
+  else
+    log_warn "Directory not present; skipping permission check for $dir."
   fi
 done
 
-exit 0
+exit "$HAS_ERROR"


### PR DESCRIPTION
## Summary

Make `doctor:*` behavior read-only for the scoped mutating and recovery-adjacent checks while preserving `mise run doctor` as the public health-check command.

## Scope

This PR implements child issue #274 under parent issue #271. It is limited to the doctor task source state under `dot_config/mise/tasks/doctor/**`.

Changed files:

- `dot_config/mise/tasks/doctor/executable_security.tmpl`
- `dot_config/mise/tasks/doctor/executable_identity.tmpl`

No repository docs, task names, task grouping, dependencies, lockfiles, package lists, or GitHub Actions workflow semantics are changed.

## Changes

- Changed `doctor:security` from persistent permission repair to read-only permission verification.
- Added portable permission-mode inspection for GNU and BSD/macOS `stat`.
- Made `doctor:security` report permission drift and guide the operator to an explicit `chmod 700` repair instead of applying `chmod` inside the health check.
- Removed automatic SSH agent bridge recovery from `doctor:identity`.
- Replaced WSL2 bridge restart/retry behavior with actionable guidance to explicitly restart `1password-bridge.service` and rerun `doctor:identity`.
- Preserved the `doctor` orchestrator and all public `doctor:*` task names.

Doctor task audit:

| Task | Before classification | After classification | Notes |
| --- | --- | --- | --- |
| `doctor` | Read-only orchestrator | Read-only orchestrator | Runs `doctor:*` tasks and aggregates exit status; unchanged. |
| `doctor:security` | Mutating | Read-only | Replaced persistent `chmod 700` with mode checks and explicit repair guidance. |
| `doctor:identity` | Recovery-adjacent | Read-only | Removed automatic WSL2 bridge restart, sleep, and retry; now reports guidance only. |
| `doctor:nvim` | Read-only | Read-only | Checks lockfile/provider state; unchanged. |
| `doctor:vale` | Read-only | Read-only | Checks Vale config/style package presence; unchanged. |
| `doctor:toolchain` | Read-only | Read-only | Checks mise binary and PATH precedence; unchanged. |
| `doctor:npm-backend` | Read-only | Read-only | Checks configured npm-backed tool artifacts; unchanged. |
| `doctor:hubspot` | Read-only | Read-only | Checks HubSpot CLI install and execution; unchanged. |
| `doctor:completion` | Probe-local temporary write only | Probe-local temporary write only | Uses `mktemp`, writes generated completion output under the temp directory, and removes it with the existing `trap` cleanup; unchanged. |

## Validation

| Check | State | Evidence | Notes |
| --- | --- | --- | --- |
| `mise tasks validate` | Passed | Exit code 0; `All 20 task(s) validated successfully`. | Required for task source-state behavior changes. |
| `mise tasks ls --extended` | Passed | Exit code 0; `doctor` and all public `doctor:*` tasks remain visible from `~/.config/mise/tasks/doctor/**`. | The unmanaged target-visible drift recorded by PR #273 remains visible and unresolved by design. |
| `mise tasks deps doctor` | Passed | Exit code 0; output: `doctor`. | Confirms the public orchestrator dependency view is unchanged. |
| `mise tasks info doctor`, `doctor:security`, and `doctor:identity` | Passed | Exit code 0; task names, descriptions, source paths, and bins remain stable. | Targeted inspection for changed doctor tasks and the public orchestrator. |
| Doctor task audit before and after | Passed | Current source inspection before patching found `doctor:security` mutating, `doctor:identity` recovery-adjacent, `doctor:completion` probe-local, and other doctor tasks read-only. Post-patch anchored command audit finds only `doctor:completion` temp writes under `dot_config/mise/tasks/doctor/**`. | `systemctl --user restart` and `chmod 700` remain only inside operator guidance strings, not as executed doctor commands. |
| Doctor before/after target-state check | Passed | Before `doctor:security`, `/Users/thomma/.ssh` and `/Users/thomma/.local/state/ssh` were mode `700` with unchanged owner/group/mtime; the same mode/owner/group/mtime values were observed after `doctor:security` and after `mise run doctor`. `ssh-add -l` remained exit code 0; `systemctl` is unavailable on this macOS host. | This proves the changed local target execution did not mutate the inspected persistent security directories. WSL2 bridge behavior is source-inspected only; remote CI cannot prove WSL2 bridge behavior. |
| `mise run doctor:security` | Passed | Exit code 0; both inspected SSH directories reported `Permissions verified ... (0700)`. | Required changed task validation. |
| `mise run doctor:identity` | Passed | Exit code 0; 1Password session was reachable, two configured scoped identity bindings were verified, and SSH agent responsiveness passed. | Output intentionally summarized without identity values or agent listing. |
| `mise run doctor` | Passed | Exit code 0; full health evaluation completed successfully across security, identity, Neovim, Vale, toolchain, npm backend, HubSpot, and completion checks. | Required because health-check behavior changed. |
| `chezmoi diff /Users/thomma/.config/mise/tasks/doctor/security /Users/thomma/.config/mise/tasks/doctor/identity` | Passed | Exit code 0 with no output after scoped `chezmoi apply` of the changed managed targets. | Confirms changed doctor targets were rendered/applied for local validation. |
| `chezmoi diff` | Passed | Exit code 0; output inspected. The only reported diff was unrelated target drift for `.chezmoiscripts/21-generate-completions.sh`; changed doctor targets were clean by scoped diff above. | Recorded as out-of-scope local target drift, not fixed in this PR. |
| `git diff --check` | Passed | Exit code 0 with no output. | Whitespace check after the final diff. |
| `pre-commit run --all-files` | Passed | Exit code 0; trim trailing whitespace, fix end of files, check yaml, check for added large files, shfmt, and stylua passed. | Baseline local validation. |

## Risk

Risk is moderate for WSL2 operators because `doctor:identity` now reports bridge failure instead of automatically restarting the user service. That is the intended boundary change for #274, and the task output points to an explicit operator action.

Risk is low for `doctor:security` because permission drift now fails visibly instead of silently applying repair. Existing correctly configured directories continue to pass.

## Rollback

Revert this PR. If the changed task targets were applied locally, run `chezmoi apply /Users/thomma/.config/mise/tasks/doctor/security /Users/thomma/.config/mise/tasks/doctor/identity` after reverting to restore the previous rendered task behavior.

## Review notes

Remote GitHub Actions CI is separate from the local validation table. Remote CI evidence after PR creation: GitHub Actions `compliance` run `25416029847` passed `Renovate Config Validation` in 43s, `Convergence & Idempotency Proof (ubuntu-24.04)` in 3m45s, and `Convergence & Idempotency Proof (macos-14)` in 5m7s. Local checks above do not prove remote CI, and remote CI does not prove local WSL2, Windows interop, 1Password Desktop, user systemd, SSH agent bridge, or workstation convergence behavior.

The WSL2 branch change is source-state inspection on this macOS host. The rendered macOS target has no `systemctl` path, and `systemctl` is unavailable locally.

Useful out-of-scope finding: full `chezmoi diff` currently reports unrelated target drift for `.chezmoiscripts/21-generate-completions.sh`. This PR leaves that drift untouched.

## Out of scope

- Resolving unmanaged mise task drift from #272 / PR #273.
- Moving cache, build, completion generation, host sync, or `.chezmoiscripts` logic.
- Changing identity convergence, identity source data, generated identity file formats, SSH config routing, 1Password item discovery, or SSH signing behavior.
- Changing WSL2 service unit contents, Windows interop assumptions, `op.exe` routing, or `npiperelay.exe` routing beyond removing automatic doctor recovery.
- Changing package lists, tool versions, runtime versions, dependencies, lockfiles, or GitHub Actions workflow semantics.
- Introducing blanket `exact_` ownership for mise task directories.
- Renaming the public `mise run doctor` command.
- Changing `docs/context/**`.

## Linked issues

Closes #274
Refs #271
