### PR TITLE
refactor(chezmoi): trim identity topology

### DIFF
--- a/.chezmoiscripts/run_onchange_after_50-converge-identities.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_50-converge-identities.sh.tmpl
@@ -12,15 +12,11 @@
 set -euo pipefail
 
 SSH_DIR="{{ .paths.home }}/.ssh"
-SSH_STATE_DIR="{{ .paths.xdg_state }}/ssh"
-SSH_SOCKET_DIR="$SSH_STATE_DIR/sockets"
 GIT_CONFIG_DIR="{{ .paths.xdg_config }}/git/identities"
 ALLOWED_SIGNERS="{{ .paths.xdg_config }}/git/allowed_signers"
 
-# Ensure all SSH and Git state directories exist before writing generated files.
-# Including XDG-compliant state and socket directories to prevent bind errors.
-mkdir -p "$SSH_DIR" "$SSH_STATE_DIR" "$SSH_SOCKET_DIR" "$GIT_CONFIG_DIR" "$(dirname "$ALLOWED_SIGNERS")"
-chmod 700 "$SSH_DIR" "$SSH_STATE_DIR"
+# Chezmoi source state owns stable SSH and Git parent topology before
+# run_onchange_after scripts write generated identity files.
 
 # Remove stale generated Git identity includes before writing the new set.
 rm -rf "$GIT_CONFIG_DIR"


### PR DESCRIPTION
## Summary

Trim redundant static topology creation from the identity convergence script. Stable SSH and Git parent directories now rely on existing chezmoi source-state ownership, while regenerated identity include output remains script-owned.

## Scope

This PR is limited to `.chezmoiscripts/run_onchange_after_50-converge-identities.sh.tmpl`.

No generated identity contents, Git identity routing, SSH signing behavior, 1Password discovery, WSL2 bridge behavior, Windows-side sync behavior, package provisioning, task metadata, lockfiles, tool versions, or GitHub Actions workflow semantics are changed.

## Changes

- Removed unused SSH state topology variables from the identity convergence script.
- Removed redundant creation of stable SSH and Git parent directories from the script.
- Removed script-side `chmod 700` for source-state-owned SSH parent directories.
- Kept regenerated identity include directory handling in the script because that directory is removed and rebuilt on each convergence pass.

Topology ownership audit:

| Target topology | Source-state or rendered evidence | Decision | PR treatment |
| --- | --- | --- | --- |
| `~/.ssh` | `chezmoi source-path` resolves to `private_dot_ssh`; local target mode inspected as `700`. | Already source-state-owned. | Removed script-side `mkdir` and `chmod`. |
| `~/.local/state/ssh` | `chezmoi source-path` resolves to `dot_local/state/private_ssh`; local target mode inspected as `700`. | Already source-state-owned. | Removed script-side `mkdir` and `chmod`. |
| `~/.local/state/ssh/sockets` | `chezmoi source-path` resolves to `dot_local/state/private_ssh/private_sockets`; local target mode inspected as `700`. | Already source-state-owned. | Removed script-side `mkdir`. |
| `~/.config/git` | `chezmoi source-path` resolves to `dot_config/git`; local target mode inspected as `755`. | Already source-state-owned. | Removed script-side parent creation through the allowed-signers parent path. |
| `~/.config/git/identities` | `chezmoi source-path` reports `not managed`; generated include files are removed and rebuilt by the identity convergence script. | Dynamic/generated and identity-adjacent. | Left script-owned. |
| `~/.config/git/allowed_signers` | `chezmoi source-path` reports `not managed`; content is generated from current identity metadata. | Dynamic/generated and identity-adjacent. | Left script-owned. |
| Workspace base directories from identity metadata | Paths are derived from identity metadata and may include wildcard suffixes. | Dynamic and host-specific. | Left workspace setup script unchanged. |
| Windows-side 1Password agent config parent | Path is derived from the WSL Windows user profile. | Host-specific WSL/Windows sync topology. | Left Windows agent sync script unchanged. |
| Windows-side WezTerm config parent | Path is derived from the WSL Windows user profile. | Host-specific WSL/Windows sync topology. | Left WezTerm sync task unchanged. |
| `~/.cache/zsh/completions` and `~/.cache/zsh/init` | `chezmoi source-path` reports `not managed`; directories contain generated cache/init assets produced by `converge:completions`. | Dynamic/generated cache topology. | Left task self-healing unchanged. |
| `~/.cache/zsh`, `~/.config/1Password`, `~/.config/1Password/ssh`, `~/.1password` | `chezmoi source-path` resolves to existing source state; local modes inspected where relevant. | Already source-state-owned. | No script changes needed. |

## Validation

| Check | State | Evidence | Notes |
| --- | --- | --- | --- |
| Topology ownership audit | Passed | `rg` inspected topology commands across scoped scripts and tasks; `chezmoi source-path`, `chezmoi managed --include dirs,files,symlinks`, and local mode inspection classified the audited targets above. | Audit is recorded in `Changes`. |
| Targeted rendered-output inspection | Passed | `chezmoi execute-template` inspected the rendered phase 50 script around the changed block; the rendered script no longer contains `SSH_STATE_DIR`, `SSH_SOCKET_DIR`, broad parent `mkdir`, or SSH parent `chmod`. | Generated identity material was not copied into this PR body. |
| `chezmoi diff --source-path .chezmoiscripts/run_onchange_after_50-converge-identities.sh.tmpl` | Passed | Exit code 0; rendered script diff showed only the expected phase 50 topology narrowing. | The diff was inspected without applying the identity convergence script. |
| Managed parent directory `chezmoi diff` | Passed | Exit code 0 with no output for the stable source-owned parent targets inspected individually. | Confirms the parent topology removed from the script already matches source state locally. |
| Targeted `chezmoi verify` | Passed | Exit code 0 with no output for `~/.ssh`, `~/.local/state/ssh`, `~/.local/state/ssh/sockets`, `~/.config/git`, `~/.cache/zsh`, `~/.config/1Password`, `~/.config/1Password/ssh`, `~/.config/1Password/ssh/agent.toml`, and `~/.1password`. | Verification was targeted to the stable source-owned topology in this PR. |
| `mise tasks validate` | Passed | Exit code 0; `All 24 task(s) validated successfully`. | Run even though no mise task source changed. |
| `mise tasks ls --extended` | Passed | Exit code 0; managed `converge:*`, `sync:*`, and doctor tasks remained visible, and the known target-visible unmanaged task drift remains visible. | No task visibility, wrapper, or source path changed. |
| `mise run doctor` | Passed | Exit code 0; security checks verified the SSH parent directories and the full health evaluation completed successfully. | Local workstation evidence only; remote CI and WSL/Windows behavior are separate. |
| `git diff --check` | Passed | Exit code 0 with no output. | Whitespace validation. |
| `pre-commit run --all-files` | Passed | Exit code 0; trim trailing whitespace, fix end of files, check yaml, check for added large files, shfmt, and stylua passed. | Baseline local validation. |

## Risk

Risk is low for normal `chezmoi init --apply` convergence because the removed topology is already managed by source state before after-scripts run.

The main residual risk is direct, out-of-band execution of the identity convergence script after manually deleting source-owned parent directories. That path now relies on the normal chezmoi source-state application order instead of silently recreating those parents inside the generated identity script.

## Rollback

Revert this PR. The previous identity convergence script behavior will restore redundant parent directory creation and permission repair on the next convergence pass.

## Review notes

Remote GitHub Actions CI is intentionally not mirrored in the validation table. Use GitHub Checks or status checks after PR creation for the `compliance` workflow.

A normal local `chezmoi diff` attempt was stopped because the local bootstrap hook waited in this workstation session. The recorded rendered-output checks used targeted chezmoi commands with the hook bypassed and avoided applying the identity convergence script.

Sensitive identity output was inspected structurally and summarized instead of copied into the PR body.

## Out of scope

- Generated identity file formats or contents.
- Variable generated identity files as source-state-owned files.
- Git identity routing, SSH signing behavior, public key handling, or 1Password item discovery.
- WSL2 bridge behavior, Windows interop assumptions, Windows-side copy targets, `op.exe` routing, or `npiperelay.exe` routing.
- Cache/build/sync task boundaries from the prior child slice.
- Doctor task behavior, package provisioning, package lists, tool versions, runtime versions, dependencies, lockfiles, or GitHub Actions workflow semantics.
- Unmanaged mise task drift resolution or blanket `exact_` ownership for mise task directories.
- Changes to `docs/context/**`.

## Linked issues

Closes #280
Refs #271
