### PR TITLE
refactor(mise): add identity convergence

### DIFF
--- a/.chezmoiscripts/run_onchange_after_50-converge-identities.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_50-converge-identities.sh.tmpl
@@ -1,64 +1,12 @@
 #!/bin/zsh
 {{ "" -}}
 # =============================================================================
-# Phase 50 converges generated identity files atomically.
-# Public keys are read from chezmoi template data and never from generated files.
-# The pass provisions downstream Git and SSH configuration idempotently.
-# Logic is strictly encapsulated in .chezmoitemplates.
-# [Reference]: https://www.chezmoi.io/reference/special-directories/chezmoitemplates/
+# Phase 50 delegates generated identity convergence to mise-managed tooling.
 # [Trigger]: {{ .ssh_keys_hash }}
+{{/* [Reference]: https://www.chezmoi.io/user-guide/use-scripts-to-perform-actions/ */}}{{ "" -}}
 # =============================================================================
 
 set -euo pipefail
 
-SSH_DIR="{{ .paths.home }}/.ssh"
-GIT_CONFIG_DIR="{{ .paths.xdg_config }}/git/identities"
-ALLOWED_SIGNERS="{{ .paths.xdg_config }}/git/allowed_signers"
-
-# Chezmoi source state owns stable SSH and Git parent topology before
-# run_onchange_after scripts write generated identity files.
-
-# Remove stale generated Git identity includes before writing the new set.
-rm -rf "$GIT_CONFIG_DIR"
-mkdir -p "$GIT_CONFIG_DIR"
-TEMP_SIGNERS=$(mktemp)
-
-echo "🔐 [Identity] Converging Content-Addressable Sovereign Identities..."
-
-{{ $home := .paths.home -}}
-{{ range .identities -}}
-# --- Provisioning Identity: {{ .name }} ({{ .email }}) ---
-# Generated public key paths include identity hash material.
-PUBKEY_FILE="$SSH_DIR/id_{{ .key_type }}_{{ .email }}_{{ .key_hash }}.pub"
-echo {{ .public_key | quote }} > "$PUBKEY_FILE"
-chmod 600 "$PUBKEY_FILE"
-
-CONFIG_FILE="$GIT_CONFIG_DIR/config_{{ .email }}_{{ .key_hash }}"
-# Delegate generated Git config content to the shared identity template.
-cat << 'EOF' > "$CONFIG_FILE"
-{{ includeTemplate "git_identity_config.tmpl" (dict "name" .name "email" .email "public_key" .public_key "key_type" .key_type "key_hash" .key_hash "home" $home) }}
-EOF
-
-# [Reference]: https://man.openbsd.org/ssh-keygen#ALLOWED_SIGNERS
-echo "{{ .email }} namespaces=\"git\" {{ trim .public_key }}" >> "$TEMP_SIGNERS"
-
-echo "  ✅ Synced context routing: {{ .email }} [Hash: {{ .key_hash }}]"
-{{ end -}}
-
-{{ if not .identities -}}
-# CI can verify file generation even when no user identities are mapped.
-echo "ci-bot@example.com namespaces=\"git\" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI_CI_FALLBACK_KEY_STUB" >> "$TEMP_SIGNERS"
-echo "⚠️  [Identity] No sovereign identities mapped. CI fallback stub generated."
-{{ end -}}
-
-# [Idempotency]: Atomic write with unique sorting to prevent duplicate accumulation.
-if [[ -s "$TEMP_SIGNERS" ]]; then
-  sort -u "$TEMP_SIGNERS" > "$ALLOWED_SIGNERS"
-else
-  : > "$ALLOWED_SIGNERS"
-fi
-
-rm -f "$TEMP_SIGNERS"
-chmod 644 "$ALLOWED_SIGNERS"
-
-echo "✅ [Identity] O(1) Convergence complete. All local keyfiles and context scopes provisioned."
+echo "⚡ [Delegate] Invoking mise task: converge:identity"
+exec "{{ .paths.mise }}" run converge:identity

--- a/dot_config/mise/tasks/converge/executable_identity.tmpl
+++ b/dot_config/mise/tasks/converge/executable_identity.tmpl
@@ -1,0 +1,58 @@
+#!/bin/zsh
+# [MISE] description="Converge generated Git and SSH identity files"
+{{/* [Reference]: https://mise.jdx.dev/tasks/file-tasks.html */}}{{ "" -}}
+{{/* [Reference]: https://www.chezmoi.io/reference/special-directories/chezmoitemplates/ */}}{{ "" -}}
+
+set -euo pipefail
+
+SSH_DIR="{{ .paths.home }}/.ssh"
+GIT_CONFIG_DIR="{{ .paths.xdg_config }}/git/identities"
+ALLOWED_SIGNERS="{{ .paths.xdg_config }}/git/allowed_signers"
+
+# Chezmoi source state owns stable SSH and Git parent topology before
+# generated identity convergence writes variable identity artifacts.
+
+# Remove stale generated Git identity includes before writing the new set.
+rm -rf "$GIT_CONFIG_DIR"
+mkdir -p "$GIT_CONFIG_DIR"
+TEMP_SIGNERS=$(mktemp)
+
+echo "🔐 [Identity] Converging Content-Addressable Sovereign Identities..."
+
+{{ $home := .paths.home -}}
+{{ range .identities -}}
+# --- Provisioning Identity: {{ .name }} ({{ .email }}) ---
+# Generated public key paths include identity hash material.
+PUBKEY_FILE="$SSH_DIR/id_{{ .key_type }}_{{ .email }}_{{ .key_hash }}.pub"
+echo {{ .public_key | quote }} > "$PUBKEY_FILE"
+chmod 600 "$PUBKEY_FILE"
+
+CONFIG_FILE="$GIT_CONFIG_DIR/config_{{ .email }}_{{ .key_hash }}"
+# Delegate generated Git config content to the shared identity template.
+cat << 'EOF' > "$CONFIG_FILE"
+{{ includeTemplate "git_identity_config.tmpl" (dict "name" .name "email" .email "public_key" .public_key "key_type" .key_type "key_hash" .key_hash "home" $home) }}
+EOF
+
+# [Reference]: https://man.openbsd.org/ssh-keygen#ALLOWED_SIGNERS
+echo "{{ .email }} namespaces=\"git\" {{ trim .public_key }}" >> "$TEMP_SIGNERS"
+
+echo "  ✅ Synced context routing: {{ .email }} [Hash: {{ .key_hash }}]"
+{{ end -}}
+
+{{ if not .identities -}}
+# CI can verify file generation even when no user identities are mapped.
+echo "ci-bot@example.com namespaces=\"git\" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI_CI_FALLBACK_KEY_STUB" >> "$TEMP_SIGNERS"
+echo "⚠️  [Identity] No sovereign identities mapped. CI fallback stub generated."
+{{ end -}}
+
+# [Idempotency]: Atomic write with unique sorting to prevent duplicate accumulation.
+if [[ -s "$TEMP_SIGNERS" ]]; then
+  sort -u "$TEMP_SIGNERS" > "$ALLOWED_SIGNERS"
+else
+  : > "$ALLOWED_SIGNERS"
+fi
+
+rm -f "$TEMP_SIGNERS"
+chmod 644 "$ALLOWED_SIGNERS"
+
+echo "✅ [Identity] O(1) Convergence complete. All local keyfiles and context scopes provisioned."


### PR DESCRIPTION
## Summary

Create a dedicated `converge:identity` mise task for generated identity convergence and keep the phase 50 chezmoi script as the lifecycle trigger adapter.

## Scope

This PR implements child issue #282 under parent issue #271.

Changed source-state files:

- `.chezmoiscripts/run_onchange_after_50-converge-identities.sh.tmpl`
- `dot_config/mise/tasks/converge/executable_identity.tmpl`

No generated identity formats, Git identity routing, SSH signing behavior, 1Password discovery, WSL2 bridge behavior, package provisioning, tool versions, lockfiles, docs, or GitHub Actions workflow semantics are changed.

## Changes

- Added `converge:identity` as a narrowly scoped mise task for generated Git and SSH identity files.
- Moved the existing generated public key file, Git identity include, `allowed_signers`, atomic signer write, file mode, and CI fallback behavior into the new task without intentionally changing output semantics.
- Reduced the phase 50 chezmoi script to a thin lifecycle adapter that preserves the existing identity hash trigger and delegates to `mise run converge:identity`.
- Left generated identity files as generated target state rather than moving variable identity output into static source-state ownership.
- Left `doctor:identity` unchanged and read-only.

Identity convergence boundary audit:

| Artifact or surface | Owner after this PR | Redacted evidence |
| --- | --- | --- |
| Generated public key files | `converge:identity` | Rendered task keeps the existing `~/.ssh/id_<type>_<email>_<hash>.pub` pattern, writes mapped public keys, and sets mode `600`; inspected generated targets remain `chezmoi: not managed`. |
| Generated Git identity includes | `converge:identity` | Rendered task still removes and rebuilds `~/.config/git/identities`, writes `config_<email>_<hash>` files, and the generated config structure remains `user.name`, `user.email`, `user.signingkey`, and `core.sshCommand`; inspected generated targets remain `chezmoi: not managed`. |
| Generated `allowed_signers` | `converge:identity` | Rendered task still writes signer entries through a temporary file, sorts them uniquely, preserves the no-identity CI fallback branch, and sets mode `644`; inspected target remains `chezmoi: not managed`. |
| Git include routing | `dot_config/git/config.tmpl` | Rendered `includeIf` routing still points at the generated Git identity include path pattern and was not changed. |
| `doctor:identity` | `dot_config/mise/tasks/doctor/executable_identity.tmpl` | Source inspection and validation confirm it remains read-only health checking; no repair or convergence behavior was added. |

## Validation

| Check | State | Evidence | Notes |
| --- | --- | --- | --- |
| Required issue and PR evidence | Passed | Inspected parent #271, child #282, prior issues #272/#274/#278/#280, and merged PRs #273/#277/#279/#281. | Used as scope and sequencing evidence before patching. |
| Identity convergence boundary audit | Passed | Current source inspection and redacted rendered-output inspection classified generated public key files, Git identity includes, `allowed_signers`, Git include routing, and `doctor:identity` as recorded above. | Secret-adjacent values were redacted from durable evidence. |
| Redacted rendered-output inspection | Passed | `chezmoi execute-template` inspected the phase 50 adapter, new `converge:identity` task, rendered Git identity config fragments, Git include routing, and SSH routing structurally. | Public key material, identity values, account IDs, item IDs, local home paths, and agent output were not copied into the PR body. |
| `chezmoi diff --source-path .chezmoiscripts/run_onchange_after_50-converge-identities.sh.tmpl` | Passed | Pre-apply diff showed the expected adapter split; after scoped apply, exit code 0 with no output. | Adapter execution delegated to `converge:identity` after the task target was rendered. |
| `chezmoi diff --source-path dot_config/mise/tasks/converge/executable_identity.tmpl` | Passed | Pre-apply diff showed the new rendered task target; after scoped apply, exit code 0 with no output. | Required for the new identity convergence task. |
| Targeted `chezmoi verify` | Passed | Exit code 0 for the changed source-path targets and selected rendered Git, SSH, and mise task targets. | Generated identity artifacts themselves remain unmanaged generated targets. |
| `mise tasks validate` | Passed | Exit code 0; `All 25 task(s) validated successfully`. | Confirms the new task metadata validates with the active task set. |
| `mise tasks ls --extended` | Passed | Exit code 0; inspected output lists `converge:identity` from `~/.config/mise/tasks/converge/identity` and preserves the known unmanaged task drift. | Visibility changed only by adding the new scoped task. |
| `mise tasks info converge:identity` | Passed | Exit code 0; inspected name, description, source path, and bin. | Targeted metadata inspection for the added task. |
| `mise run converge:identity` | Passed | Exit code 0; redacted output showed mapped identity convergence completed and regenerated downstream files. | No public key material or identity values are included here. |
| `mise run doctor:identity` | Passed | Exit code 0; redacted output verified 1Password reachability, scoped identity bindings, and SSH agent responsiveness. | Local workstation evidence only. |
| `mise run doctor` | Passed | Exit code 0; full health evaluation completed successfully. | Local workstation evidence only; remote CI and WSL2/Windows behavior are separate. |
| `git diff --check` and `git diff --cached --check` | Passed | Exit code 0 with no output. | Whitespace validation before commit. |
| `pre-commit run --all-files` | Passed | Exit code 0; trim trailing whitespace, fix end of files, check yaml, check for added large files, shfmt, and stylua passed. | Baseline local validation. |

## Risk

Risk is moderate because the generated identity implementation now lives in a persistent rendered mise task target rather than directly inside the phase 50 script target. The generated artifacts, naming patterns, file modes, Git include routing, `allowed_signers` semantics, and CI fallback branch were preserved to keep behavior stable.

The first-run bootstrap path still relies on normal chezmoi application order: mise task targets are rendered before the phase 50 after-script adapter delegates to `converge:identity`.

## Rollback

Revert this PR. The phase 50 chezmoi script will again own generated identity convergence directly on the next apply, and the `converge:identity` task target can be removed by applying the reverted source state.

## Review notes

Remote GitHub Actions `compliance` is separate from local validation. After PR creation, workflow run `25422338976` passed `Renovate Config Validation` in 49s, `Convergence & Idempotency Proof (ubuntu-24.04)` in 3m44s, and `Convergence & Idempotency Proof (macos-14)` in 4m57s. Local checks above do not prove remote CI, and remote CI does not prove WSL2, Windows interop, 1Password Desktop, user systemd, SSH agent bridge, or local workstation convergence.

The known target-visible unmanaged mise task drift recorded by PR #273 remains visible and unresolved by design.

## Out of scope

- 1Password item discovery, tags, schema, account IDs, item IDs, or key hash semantics.
- Generated identity file formats or generated identity contents beyond moving their convergence owner.
- Git identity routing, SSH signing behavior, SSH config routing, `allowedSignersFile`, or SSH agent bridge behavior.
- WSL2 bridge behavior, Windows interop, Windows-side sync paths, `op.exe`, `op-ssh-sign`, `npiperelay.exe`, or user systemd behavior.
- Package provisioning, package lists, tool versions, runtime versions, dependencies, lockfiles, or GitHub Actions workflow semantics.
- Doctor task behavior or the public `mise run doctor` command.
- Unmanaged mise task drift resolution or blanket `exact_` ownership for mise task directories.
- Changes to `docs/context/**`.

## Linked issues

Closes #282
Refs #271

