### PR TITLE
fix(chezmoi): remove scoped-out mise retry

### DIFF
--- a/.chezmoiscripts/run_onchange_after_20-setup-runtimes.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_20-setup-runtimes.sh.tmpl
@@ -18,33 +18,10 @@ if [[ ! -x "$MISE_BIN" ]]; then
   exit 1
 fi
 
-run_with_retries() {
-  local description="$1"
-  shift
-
-  local attempt=1
-  local max_attempts=3
-  local delay_seconds=10
-
-  until "$@"; do
-    local exit_code=$?
-
-    if ((attempt >= max_attempts)); then
-      echo "❌ [Fatal] $description failed after $attempt attempt(s)." >&2
-      return "$exit_code"
-    fi
-
-    echo "⚠️ [Retry] $description failed on attempt $attempt/$max_attempts (exit $exit_code); retrying in ${delay_seconds}s..." >&2
-    sleep "$delay_seconds"
-    attempt=$((attempt + 1))
-    delay_seconds=$((delay_seconds * 2))
-  done
-}
-
 echo "📦 [Phase 20] Executing Runtime Convergence via Mise..."
 
 # Phase 1 installs declared tools idempotently.
-run_with_retries "mise install" "$MISE_BIN" install
+"$MISE_BIN" install
 
 # Phase 2 runs the idempotent setup task graph.
 "$MISE_BIN" run setup


### PR DESCRIPTION
## Summary

Remove the `mise install` retry wrapper that was bundled into PR #292 so the merged task-discovery migration no longer carries an out-of-scope lifecycle behavior change.

## Scope

- Phase 20 Chezmoi runtime convergence script only.
- Corrective cleanup for the scope violation identified after PR #292 merged.

## Changes

- Delete the `run_with_retries` helper from `.chezmoiscripts/run_onchange_after_20-setup-runtimes.sh.tmpl`.
- Restore Phase 20 to calling `"$MISE_BIN" install` directly.
- Leave the repo-owned mise task discovery migration from PR #292 intact.

## Validation

| Check | State | Evidence | Notes |
| --- | --- | --- | --- |
| `git status --short --branch` | Passed | Showed branch `fix/issue291-remove-lifecycle-retry` with only the intended script change before commit. | Working tree was clean after commit. |
| `git diff --stat` | Passed | One file changed: `.chezmoiscripts/run_onchange_after_20-setup-runtimes.sh.tmpl`, 1 insertion and 24 deletions. | Confirms the correction is narrowly scoped. |
| `git diff --check` | Passed | Exited 0. | Whitespace check. |
| `pre-commit run --all-files` | Passed | trailing whitespace, end-of-file fixer, yaml, large-file, shfmt, and stylua all passed. | Commit hook also passed applicable checks. |
| Rendered script syntax | Passed | `chezmoi execute-template < .chezmoiscripts/run_onchange_after_20-setup-runtimes.sh.tmpl | bash -n` exited 0. | Verifies rendered Bash remains syntactically valid. |
| `mise tasks validate` | Passed | `✓ All 22 task(s) validated successfully`. | Ensures PR #292 task discovery state remains valid. |
| `mise tasks ls --extended` | Passed | Listed 22 repo-owned tasks from `~/.config/mise/repo-tasks/**`. | Confirms task discovery isolation remains intact. |

## Risk

This restores the previous behavior where a transient upstream `mise install` download failure aborts Phase 20 immediately. That is intentional here because retry semantics need their own scoped issue or PR if they are desired.

## Rollback

Revert this PR to restore the retry wrapper. If retry behavior is still wanted, open a separate lifecycle-hardening issue or PR with explicit scope.

## Review notes

Commander review found that PR #292 bundled a lifecycle behavior change into child #291, whose acceptance criteria explicitly excluded lifecycle script behavior changes. This PR removes only that bundled retry change and keeps the task-discovery migration intact.

## Out of scope

- Changing mise task discovery, task names, task metadata, task implementations, or `.chezmoiremove.tmpl`.
- Introducing replacement retry behavior.
- Creating or completing the next parent #287 child issue.

## Linked issues

Refs #291
Refs #287
Refs #292
