### PR TITLE
fix(ci): cache post-apply mise installs

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -158,6 +158,46 @@ jobs:
 
           printf 'Hermetic mise ready: %s (%s)\n' "$hermetic_mise" "$hermetic_version"
 
+      - name: Resolve Post-Apply Mise Install Cache Scope
+        id: post_apply_mise_cache_scope
+        shell: bash
+        run: |
+          mise_data_dir="${MISE_DATA_DIR:-$HOME/.local/share/mise}"
+          mise_installs_dir="$mise_data_dir/installs"
+          mkdir -p "$mise_installs_dir"
+
+          printf 'MISE_DATA_DIR: %s\n' "$mise_data_dir"
+          printf 'Mise installs cache path: %s\n' "$mise_installs_dir"
+          printf 'Runner OS/arch/image: %s/%s/%s\n' "$RUNNER_OS" "$RUNNER_ARCH" "${{ matrix.os }}"
+
+          printf 'installs-dir=%s\n' "$mise_installs_dir" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Post-Apply Mise Installs Cache
+        id: post_apply_mise_installs_cache
+        # Cache only the supported installs surface; downloads, internal cache,
+        # state, and credential paths stay outside the cache.
+        # [Reference]: https://mise.jdx.dev/directories.html
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ${{ steps.post_apply_mise_cache_scope.outputs.installs-dir }}
+          key: mise-post-apply-installs-v1-${{ runner.os }}-${{ runner.arch }}-${{ matrix.os }}-mise-${{ steps.mise_version.outputs.version }}-${{ hashFiles('.mise-version', '.mise.toml', 'dot_config/mise/conf.d/10-tools.toml', 'dot_config/mise/config.toml.tmpl') }}
+          restore-keys: |
+            mise-post-apply-installs-v1-${{ runner.os }}-${{ runner.arch }}-${{ matrix.os }}-mise-${{ steps.mise_version.outputs.version }}-
+
+      - name: Report Post-Apply Mise Cache Restore
+        shell: bash
+        env:
+          CACHE_HIT: ${{ steps.post_apply_mise_installs_cache.outputs.cache-hit }}
+          CACHE_MATCHED_KEY: ${{ steps.post_apply_mise_installs_cache.outputs.cache-matched-key }}
+          CACHE_PATH: ${{ steps.post_apply_mise_cache_scope.outputs.installs-dir }}
+          CACHE_PRIMARY_KEY: ${{ steps.post_apply_mise_installs_cache.outputs.cache-primary-key }}
+        run: |
+          printf 'Post-apply mise installs cache primary key: %s\n' "$CACHE_PRIMARY_KEY"
+          printf 'Post-apply mise installs cache matched key: %s\n' "${CACHE_MATCHED_KEY:-none}"
+          printf 'Post-apply mise installs cache hit: %s\n' "${CACHE_HIT:-false}"
+          tool_count="$(find "$CACHE_PATH" -mindepth 1 -maxdepth 1 -type d 2> /dev/null | wc -l | tr -d '[:space:]')"
+          printf 'Post-apply mise installs cache path top-level entries: %s\n' "${tool_count:-0}"
+
       - name: Phase 1 - Provisioning (Static Apply)
         run: |
           chezmoi init --source="$GITHUB_WORKSPACE" --apply
@@ -211,3 +251,10 @@ jobs:
         if: always()
         run: |
           "$HOME/.local/bin/mise" run doctor
+
+      - name: Save Post-Apply Mise Installs Cache
+        if: ${{ success() && steps.post_apply_mise_installs_cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ${{ steps.post_apply_mise_cache_scope.outputs.installs-dir }}
+          key: ${{ steps.post_apply_mise_installs_cache.outputs.cache-primary-key }}


### PR DESCRIPTION
## Summary

Adds an explicit post-apply mise installs cache to the convergence matrix so the rendered global `mise install` path can reuse previously installed tools without bypassing deterministic install validation.

## Scope

This is scoped to #330's CI dependency-fetch resilience path. It does not change tool IDs, tool versions, `.mise-version`, task discovery, bootstrap install semantics, or convergence/doctor strictness.

## Changes

- Resolves and logs the post-apply mise install cache scope from `MISE_DATA_DIR`, defaulting to `$HOME/.local/share/mise`, before `chezmoi init --apply` triggers the rendered post-apply graph.
- Restores only the supported installs surface, `$MISE_DATA_DIR/installs`, with `actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae`.
- Keys the cache by runner OS, runner arch, matrix image, pinned mise version, and hashes of `.mise-version`, `.mise.toml`, `dot_config/mise/conf.d/10-tools.toml`, and `dot_config/mise/config.toml.tmpl`.
- Saves the same installs path with `actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae` only after the strict convergence and doctor path succeeds, and only when the restore was not an exact hit.

## Validation

| Check | State | Evidence | Notes |
| --- | --- | --- | --- |
| `git status --short` | Passed | Clean after commit on `fix/mise-install-cache`; pre-commit also ran during commit. | Working tree was limited to `.github/workflows/compliance.yml` before staging. |
| `git diff --stat` | Passed | `.github/workflows/compliance.yml | 47 ++++++++++++++++++++++++++++++++++++++++`. | One workflow file changed. |
| `git diff --check` | Passed | Command exited 0 with no output. | Whitespace check passed. |
| `pre-commit run --all-files` | Passed | trailing-whitespace, end-of-file-fixer, check-yaml, added-large-files, shfmt, and stylua all passed. | Baseline local validation. |
| `chezmoi execute-template < dot_config/mise/config.toml.tmpl` | Passed | Rendered successfully and confirmed no `MISE_DATA_DIR` override in the rendered mise config. | CI cache step logs the effective default/override path. |
| Workflow-focused review | Passed | Reviewed `.github/workflows/compliance.yml` cache path, key, restore/save order, permissions, and strict failure behavior. | Cache excludes downloads/cache/state/credential paths; `mise install` still runs through Phase 1 post-apply; no `continue-on-error`; permissions remain `contents: read`. |
| `bash -n .bootstrap-mise.sh` | Not required | `.bootstrap-mise.sh` was not changed. | Bootstrap retry was not introduced. |
| Post-apply template syntax/render check | Not required | `.chezmoiscripts/run_onchange_after_20-mise-post-apply-graph.sh.tmpl` was not changed. | Existing `mise install` boundary remains authoritative. |
| Retry fixture test | Not required | No retry helper was introduced. | This PR implements cache-only resilience. |

## Risk

The first run for a new key still performs the full external artifact fetch and can fail on a transient upstream outage. The cache reduces repeated exposure after a successful strict run but does not turn a miss into success.

## Rollback

Revert the workflow cache restore/report/save steps in `.github/workflows/compliance.yml`. The convergence matrix returns to the previous behavior where post-apply `mise install` always fetches missing artifacts without this explicit installs cache.

## Review notes

GitHub Checks remain the source of truth for remote CI. Observed compliance evidence for commit `a61246c3aab043c9b81c1f4fd9debda78e078e3e`:

- Initial run: `compliance` run 25626833025 attempt 1 passed Renovate, Ubuntu convergence, and macOS convergence. Ubuntu and macOS both missed the new post-apply installs cache, completed strict convergence/doctor, and saved OS/arch/image-specific install caches.
- Warm rerun: the same run 25626833025 attempt 2 passed Renovate, Ubuntu convergence, and macOS convergence. Ubuntu restored exact key `mise-post-apply-installs-v1-Linux-X64-ubuntu-24.04-mise-2026.5.4-d8352dfbc5e6abc20b8016032bdde256d68c0080ed145792d69c0c05ad985ae2` with `Post-apply mise installs cache hit: true`; macOS restored exact key `mise-post-apply-installs-v1-macOS-ARM64-macos-14-mise-2026.5.4-d8352dfbc5e6abc20b8016032bdde256d68c0080ed145792d69c0c05ad985ae2` with `Post-apply mise installs cache hit: true`. In both warm jobs, `Save Post-Apply Mise Installs Cache` was skipped because the exact cache already existed.

## Out of scope

- No tool IDs or tool versions changed.
- No `mise` entry was added to `[tools]`.
- No retry helper was added.
- No cache path includes `~/.local/share/mise/downloads`, `~/.cache/mise`, `~/.local/state/mise`, credentials, token files, or `gh` auth state.
- No `id-token: write`, `continue-on-error`, broad job retry, or convergence/doctor skip was added.

## Linked issues

Closes #330
Refs #328