### PR TITLE
[codex] fix WezTerm WSL SSH auth socket policy

### DIFF
--- a/dot_config/wezterm/wezterm.lua.tmpl
+++ b/dot_config/wezterm/wezterm.lua.tmpl
@@ -4,6 +4,8 @@
 - https://wezterm.org/config/lua/wezterm/font_with_fallback.html
 - https://wezterm.org/config/lua/config/window_decorations.html
 - https://wezterm.org/config/lua/window-events/user-var-changed.html
+- https://wezterm.org/config/lua/config/mux_enable_ssh_agent.html
+- https://wezterm.org/config/lua/config/mux_env_remove.html
 */ -}}
 
 local wezterm = require("wezterm")
@@ -73,6 +75,14 @@ if wezterm.target_triple:find("windows") then
 {{- $wsl_distro_name := env "WSL_DISTRO_NAME" | trim -}}
 {{- if eq $wsl_distro_name "" }}{{ fail "[FATAL] WSL_DISTRO_NAME is empty; cannot render WezTerm default_domain for Windows." }}{{ end -}}
   config.default_domain = {{ printf "WSL:%s" $wsl_distro_name | quote }}
+
+  -- Keep WSL-launched Win32 OpenSSH on the Windows 1Password agent path.
+  config.mux_enable_ssh_agent = false
+  config.mux_env_remove = {
+    "SSH_AUTH_SOCK",
+    "SSH_CLIENT",
+    "SSH_CONNECTION",
+  }
 {{- end }}
 else
   config.unix_domains = { { name = "unix" } }


### PR DESCRIPTION
## Summary

Adds an explicit WezTerm mux SSH-agent environment policy to the WSL-rendered Windows WezTerm config.

The WSL/Windows branch now:

- keeps the existing `default_domain = "WSL:<distro>"` behavior;
- sets `mux_enable_ssh_agent = false` so WezTerm does not assign its mux `SSH_AUTH_SOCK` path;
- sets `mux_env_remove` to remove `SSH_AUTH_SOCK`, `SSH_CLIENT`, and `SSH_CONNECTION` from the mux server environment.

This follows the current official baseline that WSL should invoke Windows OpenSSH for the 1Password WSL path, while WezTerm can otherwise inject or preserve SSH-agent environment values unless configured not to.

Official sources used:

- 1Password WSL integration: https://developer.1password.com/docs/ssh/integrations/wsl/
- Microsoft WSL interop and `WSLENV` directionality: https://learn.microsoft.com/en-us/windows/wsl/filesystems
- WezTerm `mux_enable_ssh_agent`: https://wezterm.org/config/lua/config/mux_enable_ssh_agent.html
- WezTerm `mux_env_remove`: https://wezterm.org/config/lua/config/mux_env_remove.html

## Scope

Changed only:

- `dot_config/wezterm/wezterm.lua.tmpl`

The policy is gated to the WSL-rendered Windows WezTerm configuration path. Non-WSL renders keep the existing mux behavior.

## Validation

| Check | Status | Evidence / limitation |
| --- | --- | --- |
| `git status --short` | passed | Clean after commit `c427d4a`. |
| `git diff --check` | passed | No whitespace errors. |
| `pre-commit run --all-files` | passed | All configured hooks passed. |
| Targeted rendered WezTerm inspection | passed | WSL override render with `WSL_DISTRO_NAME=Ubuntu-24.04` and `is_wsl=true` showed the WSL default domain plus `mux_enable_ssh_agent = false`, `mux_env_remove`, and `"SSH_AUTH_SOCK"`. |
| Windows synced WezTerm config inspection | passed | Maintainer-provided PowerShell output showed `%USERPROFILE%\.wezterm.lua` contains `default_domain`, `mux_enable_ssh_agent = false`, `mux_env_remove`, and `"SSH_AUTH_SOCK"`. |
| `wezterm cli list-clients` | passed | Ran locally with JSON output reduced to redacted SSH_AUTH_SOCK classification. Limitation: local worker evidence was Darwin, not the target WSL/Windows path. |
| WSL interop prerequisite | passed | Maintainer-provided WezTerm/WSL output showed `/proc/sys/fs/binfmt_misc/WSLInterop` enabled with interpreter `/init`. |
| WSL `powershell.exe -NoProfile -NonInteractive -Command '[Console]::Write($env:SSH_AUTH_SOCK)'` equivalent | passed | Maintainer-provided WezTerm/WSL output showed `win32_SSH_AUTH_SOCK=<unset>`, not a WezTerm agent path. |
| WSL `ssh-add.exe -l` from WezTerm | passed | Maintainer-provided WezTerm/WSL output showed two redacted keys. No public key material was shared. |
| WSL `ssh.exe -T git@github.com` from WezTerm | passed | Maintainer-provided WezTerm/WSL output showed the redacted GitHub success authentication message. |
| GitHub Actions CI | passed | `compliance` run #615 completed successfully for commit `c427d4a`. GitHub Actions CI cannot prove local WSL/Windows/1Password/WezTerm convergence. |

## Local WSL / WezTerm / 1Password Limitations

Host-specific validation evidence was provided by the maintainer with usernames, paths, and key material redacted. GitHub Actions CI cannot prove local WSL/Windows/1Password/WezTerm convergence; the WSL/Windows/1Password evidence above is separate local host evidence.

## Risk and Rollback

Risk is limited to the WSL-rendered Windows WezTerm config path. If a Windows WezTerm pane in this WSL-managed config intentionally depended on WezTerm's mux SSH agent assignment, it will no longer receive that WezTerm agent path.

Rollback is to revert `c427d4a`, restoring the previous implicit WezTerm mux agent behavior.

## Out of Scope

This PR does not:

- replace the `npiperelay` bridge;
- change `dot_zshenv.tmpl`, `.chezmoi.toml.tmpl`, SSH config, Git identity routing, systemd units, README, or macOS SSH/signing behavior;
- implement sibling issues #334, #335, #336, #337, or #338;
- deliberately override Win32 `SSH_AUTH_SOCK` to `\\.\pipe\openssh-ssh-agent` or change `WSLENV` propagation.

## Linked Work

Refs #332
Closes #333