### PR TITLE
[codex] fix WSL auth environment propagation

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -107,7 +107,7 @@ sourceDir = {{ .chezmoi.sourceDir | quote }}
 {{- if eq $osid "darwin" -}}
 {{-   $ssh_auth_sock = joinPath $home "Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock" -}}
 {{- else if $is_wsl -}}
-{{-   $ssh_auth_sock = joinPath $home ".1password/agent.sock" -}}
+{{-   $ssh_auth_sock = "\\\\.\\pipe\\openssh-ssh-agent" -}}
 {{- end -}}
 
 {{- /* Resolve the SSH signing helper for the current platform. */ -}}

--- a/dot_config/mise/repo-tasks/check/executable_identity.tmpl
+++ b/dot_config/mise/repo-tasks/check/executable_identity.tmpl
@@ -20,6 +20,11 @@ log_guide() { printf "  ${BLUE}👉 %s${NC}\n" "$1"; }
 IS_CI="${CI:-false}"
 OP_BIN="{{ .paths.op }}"
 HAS_ERROR=0
+{{ if .is_wsl -}}
+SSH_ADD_BIN="ssh-add.exe"
+{{ else -}}
+SSH_ADD_BIN="ssh-add"
+{{ end }}
 
 echo "--- 2. Identity & Auth Bridge Analysis ---"
 if "$OP_BIN" account get > /dev/null 2>&1; then
@@ -55,8 +60,29 @@ else
   fi
 fi
 
+{{ if .is_wsl }}
+echo "--- 3. WSL Win32 Auth Environment ---"
+WIN32_OP_BIOMETRIC_UNLOCK_ENABLED=$(powershell.exe -NoProfile -NonInteractive -Command '[Console]::Write($env:OP_BIOMETRIC_UNLOCK_ENABLED)' 2>/dev/null || true)
+if [[ "$WIN32_OP_BIOMETRIC_UNLOCK_ENABLED" == "true" ]]; then
+  log_ok "Win32 1Password biometric unlock flag propagated from WSL."
+else
+  log_err "Win32 1Password biometric unlock flag was not propagated from WSL."
+  HAS_ERROR=1
+fi
+
+WIN32_SSH_AUTH_SOCK=$(powershell.exe -NoProfile -NonInteractive -Command '[Console]::Write($env:SSH_AUTH_SOCK)' 2>/dev/null || true)
+if [[ "$WIN32_SSH_AUTH_SOCK" == '\\.\pipe\openssh-ssh-agent' ]]; then
+  log_ok "Win32 SSH_AUTH_SOCK targets the Windows OpenSSH agent pipe."
+else
+  log_err "Win32 SSH_AUTH_SOCK is not the Windows OpenSSH agent pipe."
+  HAS_ERROR=1
+fi
+
+echo "--- 4. SSH Agent & Cryptographic Trust ---"
+{{ else }}
 echo "--- 3. SSH Agent & Cryptographic Trust ---"
-if ssh-add -l > /dev/null 2>&1; then
+{{ end }}
+if "$SSH_ADD_BIN" -l > /dev/null 2>&1; then
   log_ok "SSH Agent is responsive and active."
 else
   if [[ "$IS_CI" == "true" ]]; then
@@ -64,7 +90,7 @@ else
   else
     log_err "SSH Agent is unresponsive."
     {{ if .is_wsl }}
-    log_guide "Restart the WSL2 1Password bridge explicitly: systemctl --user restart 1password-bridge.service"
+    log_guide "Verify Windows 1Password SSH agent, WSL interop, and ssh-add.exe -l."
     log_guide "Then rerun 'mise run doctor'."
     {{ else }}
     log_guide "Verify the 'SSH Agent' setting in 1Password Desktop App."

--- a/dot_zshenv.tmpl
+++ b/dot_zshenv.tmpl
@@ -22,15 +22,33 @@ export PYTHON_HISTORY="$XDG_STATE_HOME/python/history"
 
 # =============================================================================
 
-# WSL exports the 1Password biometric unlock flag to the Windows host.
-# WSLENV carries the authentication context across the WSL/Windows boundary.
+# WSL exports Win32 authentication context with WSL-to-Win32 WSLENV flags.
 {{ if .is_wsl -}}
-export OP_BIOMETRIC_UNLOCK_ENABLED="true"
-export WSLENV="OP_BIOMETRIC_UNLOCK_ENABLED/u:$WSLENV"
-{{ end -}}
+_dotfiles_wsl_env_prepend() {
+  emulate -L zsh
+  local entry="$1" name="${1%%/*}" existing="${WSLENV:-}" next="" part
 
-# SSH_AUTH_SOCK points Git and SSH clients at the managed agent bridge.
+  # Remove stale managed entries first so old directions such as /u do not survive.
+  for part in ${(s.:.)existing}; do
+    [[ -z "$part" || "${part%%/*}" == "$name" ]] && continue
+    next="${next:+$next:}$part"
+  done
+
+  export WSLENV="${entry}${next:+:$next}"
+}
+
+export OP_BIOMETRIC_UNLOCK_ENABLED="true"
+_dotfiles_wsl_env_prepend "OP_BIOMETRIC_UNLOCK_ENABLED/w"
+
+# Win32 OpenSSH should use the Windows 1Password agent pipe, not a WSL bridge socket.
+export SSH_AUTH_SOCK='{{ .ssh_auth_sock }}'
+_dotfiles_wsl_env_prepend "SSH_AUTH_SOCK/w"
+
+unset -f _dotfiles_wsl_env_prepend
+{{ else -}}
+# SSH_AUTH_SOCK points Git and SSH clients at the managed agent socket.
 export SSH_AUTH_SOCK="{{ .ssh_auth_sock }}"
+{{ end -}}
 
 # PNPM_HOME follows the XDG data directory used by the managed Node.js toolchain.
 export PNPM_HOME="{{ .paths.xdg_data }}/pnpm"


### PR DESCRIPTION
## Summary

Corrects WSL-to-Win32 authentication environment propagation for the #335-owned shell/env surface.

- Changes WSL `ssh_auth_sock` data from the retired WSL bridge socket to the Windows OpenSSH agent pipe.
- Renders WSL `dot_zshenv` with documented WSL-to-Win32 `WSLENV` directionality: `/w` for `OP_BIOMETRIC_UNLOCK_ENABLED` and deliberate `SSH_AUTH_SOCK` propagation.
- Rebuilds managed `WSLENV` entries idempotently so stale `/u` or duplicate managed entries do not survive shell startup.
- Updates the identity health check so WSL validates the Win32 auth environment and uses `ssh-add.exe` for the official Windows OpenSSH path.

## Scope

Changed only:

- `.chezmoi.toml.tmpl`
- `dot_zshenv.tmpl`
- `dot_config/mise/repo-tasks/check/executable_identity.tmpl`

This PR does not change WezTerm mux policy and does not reimplement #333 / PR #339. It also does not implement sibling issues #334, #336, #337, or #338.

The maintainer is expected to squash merge after review; this PR does not request or create a merge commit.

## Validation

| Check | Status | Evidence / limitation |
| --- | --- | --- |
| `git status --short` | passed | Clean before edits and clean after commit `c76ad53`. |
| `git diff --check` | passed | No whitespace errors. |
| `pre-commit run --all-files` | passed | `trim trailing whitespace`, `fix end of files`, `check yaml`, `check for added large files`, `shfmt`, and `stylua` passed. |
| Targeted rendered `dot_zshenv` inspection | passed | WSL override with redacted paths rendered `OP_BIOMETRIC_UNLOCK_ENABLED/w`, `SSH_AUTH_SOCK/w`, and `SSH_AUTH_SOCK='\\.\pipe\openssh-ssh-agent'`; no `OP_BIOMETRIC_UNLOCK_ENABLED/u` or WSL bridge socket path was rendered. Rendered output passed `zsh -n`. |
| Managed `WSLENV` idempotence inspection | passed | Sourcing the WSL-rendered file with stale managed entries rewrote `WSLENV` to managed `/w` entries plus the unrelated existing entry, without duplicates. |
| Targeted rendered identity-check inspection | passed | WSL override rendered `ssh-add.exe`, Win32 PowerShell environment checks, and no bridge restart guidance. Rendered output passed `bash -n`. |
| WSL `powershell.exe -NoProfile -NonInteractive -Command '[Console]::Write($env:OP_BIOMETRIC_UNLOCK_ENABLED)'` | maintainer_confirmed | Maintainer-provided WezTerm/WSL evidence showed the Win32 process receives `true`; no host-private data is needed for this claim. |
| WSL `powershell.exe -NoProfile -NonInteractive -Command '[Console]::Write($env:SSH_AUTH_SOCK)'` | maintainer_confirmed | Maintainer-provided WezTerm/WSL evidence showed the Win32 process receives `\\.\pipe\openssh-ssh-agent`, not a WezTerm agent path. |
| WSL rendered shell environment inspection | maintainer_confirmed | Maintainer-provided WezTerm/WSL evidence showed WSL `OP_BIOMETRIC_UNLOCK_ENABLED=true`, WSL `SSH_AUTH_SOCK=\\.\pipe\openssh-ssh-agent`, and managed `WSLENV` entries `OP_BIOMETRIC_UNLOCK_ENABLED/w` and `SSH_AUTH_SOCK/w`. |
| WSL `ssh-add.exe -l` | maintainer_confirmed | Maintainer-provided WezTerm/WSL evidence showed two ED25519 keys. Key material and identity details are intentionally omitted from this PR body. |
| WSL `ssh.exe -T git@github.com` | maintainer_confirmed | Maintainer-provided WezTerm/WSL evidence showed successful GitHub authentication through Windows OpenSSH and 1Password. Identity details are intentionally omitted from this PR body. |
| GitHub Actions CI | passed | `compliance` run #619 passed for commit `c76ad53`: macOS convergence, Ubuntu convergence, and Renovate validation. GitHub Actions CI cannot prove local WSL/Windows/1Password/WezTerm convergence. |

## Local WSL / Windows / 1Password Validation Limitations

Host-specific WSL runtime evidence was provided by the maintainer from WezTerm/WSL. Host-private details are intentionally omitted: this PR body does not expose full local usernames, Windows profile paths, socket paths with user details, SSH public keys, 1Password account IDs, item IDs, or generated identity files.

GitHub Actions CI cannot prove local WSL/Windows/1Password/WezTerm convergence. The required WSL `powershell.exe`, `ssh-add.exe`, and `ssh.exe` checks are supported by separate maintainer-provided local host evidence.

## Risk and Rollback

Risk is limited to WSL authentication environment behavior and the WSL branch of the identity health check. WSL shells now deliberately pass `SSH_AUTH_SOCK=\\.\pipe\openssh-ssh-agent` to Win32 processes, so native Linux OpenSSH clients should not treat this as a Unix agent socket; the intended #332 path is Windows OpenSSH from WSL.

Rollback is to revert `c76ad53`, which restores the previous WSL bridge socket environment and previous identity-check behavior.

## Out of Scope

This PR does not:

- remove the `npiperelay` bridge or edit bridge service files;
- change WezTerm mux policy or reimplement #333 / PR #339;
- implement Git identity routing;
- update README operator flow;
- implement sibling issues #334, #336, #337, or #338;
- claim local WSL/Windows/1Password/WezTerm convergence from GitHub Actions CI.

## Linked Work

Refs #332
Closes #335