### PR TITLE
[codex] route WSL Git identities through Windows OpenSSH

### DIFF
--- a/.chezmoitemplates/git_identity_config.tmpl
+++ b/.chezmoitemplates/git_identity_config.tmpl
@@ -1,5 +1,9 @@
 {{- /* Generated Git identity config fragment. */ -}}
 {{- /* [Security]: Decoupled template to prevent script pollution. */ -}}
+{{- $ssh_command := printf "ssh -i %s/.ssh/id_%s_%s_%s.pub -o IdentitiesOnly=yes" .home .key_type .email .key_hash -}}
+{{- if hasKey . "ssh_command" -}}
+{{-   $ssh_command = .ssh_command -}}
+{{- end -}}
 # Auto-generated identity config for {{ .name }}
 
 [user]
@@ -10,4 +14,4 @@
 
 [core]
     # [Security]: Physical file path remains required for sshCommand authentication routing.
-    sshCommand = "ssh -i {{ .home }}/.ssh/id_{{ .key_type }}_{{ .email }}_{{ .key_hash }}.pub -o IdentitiesOnly=yes"
+    sshCommand = {{ $ssh_command | quote }}

--- a/dot_config/mise/repo-tasks/check/executable_identity.tmpl
+++ b/dot_config/mise/repo-tasks/check/executable_identity.tmpl
@@ -41,6 +41,18 @@ if "$OP_BIN" account get > /dev/null 2>&1; then
       log_err "Identity binding mismatch for {{ .name }} (Expected: {{ .email }}, Found: $AUTH_EMAIL)."
       HAS_ERROR=1
     fi
+    {{- if $.is_wsl }}
+    CORE_SSH_COMMAND=$(git config -f "$ID_CONF" core.sshCommand 2>/dev/null || echo "")
+    case "$CORE_SSH_COMMAND" in
+      ssh.exe\ -i\ \'[A-Za-z]:\\*\'\ -o\ IdentitiesOnly=yes|ssh.exe\ -i\ \'\\\\*\'\ -o\ IdentitiesOnly=yes)
+        log_ok "WSL Git SSH command uses Windows OpenSSH with deterministic identity selection."
+        ;;
+      *)
+        log_err "WSL Git SSH command does not use Windows OpenSSH with a Windows-readable identity path."
+        HAS_ERROR=1
+        ;;
+    esac
+    {{- end }}
   else
     log_err "Scoped Git configuration missing at $ID_CONF."
     log_guide "chezmoi apply"

--- a/dot_config/mise/repo-tasks/generate/executable_identity.tmpl
+++ b/dot_config/mise/repo-tasks/generate/executable_identity.tmpl
@@ -31,10 +31,22 @@ echo {{ .public_key | quote }} > "$PUBKEY_FILE"
 chmod 600 "$PUBKEY_FILE"
 
 CONFIG_FILE="$GIT_CONFIG_DIR/config_{{ .email }}_{{ .key_hash }}"
+{{ if $.is_wsl -}}
+PUBKEY_FILE_WIN="$(wslpath -w "$PUBKEY_FILE")"
+PUBKEY_FILE_WIN_SQ="'${PUBKEY_FILE_WIN//\'/\'\\\'\'}'"
+CORE_SSH_COMMAND="ssh.exe -i $PUBKEY_FILE_WIN_SQ -o IdentitiesOnly=yes"
+{{ end -}}
 # Delegate generated Git config content to the shared identity template.
 cat << 'EOF' > "$CONFIG_FILE"
+{{ if $.is_wsl -}}
+{{ includeTemplate "git_identity_config.tmpl" (dict "name" .name "email" .email "public_key" .public_key "key_type" .key_type "key_hash" .key_hash "home" $home "ssh_command" "__DOTFILES_CORE_SSH_COMMAND__") }}
+{{ else -}}
 {{ includeTemplate "git_identity_config.tmpl" (dict "name" .name "email" .email "public_key" .public_key "key_type" .key_type "key_hash" .key_hash "home" $home) }}
+{{ end -}}
 EOF
+{{ if $.is_wsl -}}
+git config --file "$CONFIG_FILE" core.sshCommand "$CORE_SSH_COMMAND"
+{{ end }}
 
 # [Reference]: https://man.openbsd.org/ssh-keygen#ALLOWED_SIGNERS
 echo "{{ .email }} namespaces=\"git\" {{ trim .public_key }}" >> "$TEMP_SIGNERS"


### PR DESCRIPTION
## Summary

Route generated WSL Git identity authentication through Windows OpenSSH while preserving the existing deterministic directory-scoped `includeIf` routing.

This branch was started from the latest `main` after confirming that `main` contains the already-reviewed work for #333 / PR #339, #335 / PR #342, and #334 / PR #343.

## Scope

- Updated `.chezmoitemplates/git_identity_config.tmpl` so generated identity fragments can receive an explicit `core.sshCommand` while keeping the existing non-WSL default command shape.
- Updated `dot_config/mise/repo-tasks/generate/executable_identity.tmpl` so WSL generation converts the generated public-key path with `wslpath -w` and writes `ssh.exe -i '<windows-readable-path>' -o IdentitiesOnly=yes` through `git config --file`.
- Updated `dot_config/mise/repo-tasks/check/executable_identity.tmpl` so WSL identity checks verify the generated command uses Windows OpenSSH and a Windows-readable identity path without printing the path.
- No `.chezmoi.toml.tmpl` change was needed because the generation task can derive the WSL path at generation time.
- `dot_config/git/config.tmpl` was inspected and left unchanged; deterministic `includeIf "gitdir/i:<dir>/**"` routing remains in that template.

## Official sources used

- 1Password WSL integration: https://developer.1password.com/docs/ssh/integrations/wsl/
- 1Password SSH client compatibility: https://developer.1password.com/docs/ssh/agent/compatibility/
- Microsoft WSL filesystem and Windows tool behavior: https://learn.microsoft.com/en-us/windows/wsl/filesystems

The implementation follows the official WSL model where Git authentication in WSL uses `core.sshCommand=ssh.exe`, Windows OpenSSH talks to the Windows-host 1Password SSH agent, and Windows tools launched from WSL receive path arguments unmodified, so the generated public-key path is converted before it is passed to `ssh.exe`.

## Validation table

| Check | Status | Evidence / limitation |
| --- | --- | --- |
| `git status --short` | Passed | Empty after commit. |
| `git diff --check origin/main..HEAD` | Passed | No whitespace errors. |
| `pre-commit run --all-files` | Passed | `trim trailing whitespace`, `fix end of files`, `check yaml`, `check for added large files`, `shfmt`, and `stylua` passed. |
| Targeted generated WSL identity inspection | Passed | Rendered the WSL generation task with dummy identity data and a stubbed `wslpath`; confirmed generated `core.sshCommand` replaces the placeholder and uses `ssh.exe -i '<windows-readable-public-key-path>' -o IdentitiesOnly=yes`. |
| Git shell quoting inspection | Passed | Used a fake local `ssh.exe` with `git -c core.sshCommand=... ls-remote` and confirmed the UNC leading backslashes are preserved in the `ssh.exe` argv. |
| `mise run generate:identity` or targeted generation-task inspection | Maintainer-confirmed | Maintainer reran `mise run --force generate:identity` on WSL head `7d2ec1d`; identity generation completed and synced both mapped identities. Sensitive identity details are redacted from this PR body. |
| `mise run check:identity` | Maintainer-confirmed | Maintainer reran `mise run check:identity` on WSL head `7d2ec1d`; identity bindings, WSL Git SSH command shape, Win32 auth environment, and SSH agent responsiveness all passed. |
| Scoped `git config --get-regexp '^includeIf\.'` equivalent | Passed | Rendered `dot_config/git/config.tmpl` with dummy identity data and inspected includeIf entries with `git config --file ... --get-regexp`; routing remained deterministic and directory-scoped. Maintainer also confirmed the identity-scoped repo resolved the expected `core.sshCommand` shape. |
| Rendered WSL identity check syntax | Passed | Rendered `check:identity` with dummy WSL data and ran `bash -n`. |
| WSL `ssh.exe -i <windows-readable-public-key-path> -o IdentitiesOnly=yes -T git@github.com` | Maintainer-confirmed | Maintainer-provided redacted WSL evidence on head `7d2ec1d` authenticated successfully with GitHub using the extracted generated Windows-readable key path. |
| WSL `git -c core.sshCommand=<rendered-command> ls-remote git@github.com:<redacted/repo>.git` | Maintainer-confirmed | Maintainer-provided redacted WSL evidence on head `7d2ec1d` returned the remote HEAD SHA. This confirms Git uses the rendered command path after the single-quote fix. |
| WSL `git commit -S` and `git log --show-signature -1` | Maintainer-confirmed | Maintainer configured a safe local test repository from an identity-scoped source repo, created a signed commit with `git commit -S`, and confirmed `git log --show-signature -1` reported a good signature. |
| GitHub Actions CI after PR creation | Passed | GitHub Checks for updated head `7d2ec1d` passed at observation time: Convergence & Idempotency Proof on macOS 14 and Ubuntu 24.04, plus Renovate Config Validation. GitHub Checks remain the current source of truth. |

## Redaction statement

No SSH public keys, full local usernames, Windows profile paths, 1Password account IDs, item IDs, real generated identity file contents, or private repository names are included in this PR body. Local identity evidence was inspected with dummy data or summarized structurally. Maintainer-provided WSL evidence was summarized without publishing sensitive paths, public keys, private repo names, or full generated identity output.

## Remote CI limitation

GitHub Actions CI cannot prove local WSL/Windows/1Password/Git identity convergence. It can validate repository checks for this revision, but the WSL `ssh.exe`, Windows OpenSSH pipe, 1Password Desktop agent, generated local identity files, Git authentication, and Git SSH signing path require local WSL host evidence.

## Risk and rollback

Risk is concentrated in generated WSL identity fragments: a quoting or path-conversion bug would affect WSL Git SSH authentication for generated identity-scoped repositories. Existing Git SSH signing remains on the 1Password WSL signing helper and was not conflated with authentication routing.

Rollback is to revert this commit and regenerate identities. Non-WSL identity command output is intended to remain unchanged.

## Out of scope

- WezTerm SSH agent behavior from #333.
- WSL auth environment propagation from #335.
- Retired `npiperelay` / systemd bridge behavior from #334.
- WSL preflight/operator documentation for #337.
- `.chezmoi.toml.tmpl` interop failure UX for #338.
- macOS identity behavior changes.
- Broad 1Password identity discovery redesign.

Refs #332
Closes #336