### PR TITLE
[codex] add WSL interop prerequisite errors

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -12,9 +12,39 @@ sourceDir = {{ .chezmoi.sourceDir | quote }}
 {{-   if contains "microsoft" (.chezmoi.kernel.osrelease | lower)}}{{$is_wsl = true}}{{end -}}
 {{- end -}}
 
+{{- $wsl_command_failed := "__DOTFILES_WSL_COMMAND_FAILED__" -}}
+{{- $wslpath_failed := "__DOTFILES_WSLPATH_FAILED__" -}}
+
+{{- if $is_wsl -}}
+{{-   $wsl_interop := output "sh" "-c" "if [ -e /proc/sys/fs/binfmt_misc/WSLInterop ]; then if grep -qxF enabled /proc/sys/fs/binfmt_misc/WSLInterop; then printf ready; else printf disabled; fi; elif (command -v cmd.exe >/dev/null 2>&1 && cmd.exe /c ver >/dev/null 2>&1) || (command -v powershell.exe >/dev/null 2>&1 && powershell.exe -NoProfile -NonInteractive -Command '[Console]::Write(\"ready\")' >/dev/null 2>&1); then printf ready; else printf missing; fi" | trim -}}
+{{-   if eq $wsl_interop "disabled" -}}
+{{-     fail "[FATAL] WSL Windows interop is disabled. Set [interop] enabled=true in /etc/wsl.conf or re-enable /proc/sys/fs/binfmt_misc/WSLInterop, restart WSL, and rerun chezmoi." -}}
+{{-   else if eq $wsl_interop "missing" -}}
+{{-     fail "[FATAL] WSL Windows interop is unavailable. Enable WSL interop so Win32 commands can run from WSL, restart WSL, and rerun chezmoi." -}}
+{{-   end -}}
+
+{{-   $cmd_probe := output "sh" "-c" "command -v cmd.exe >/dev/null 2>&1 && cmd.exe /c ver >/dev/null 2>&1 && printf ready || printf missing" | trim -}}
+{{-   if ne $cmd_probe "ready" -}}
+{{-     fail "[FATAL] WSL prerequisite 'cmd.exe' is unavailable or cannot run. Ensure Windows System32 is on the WSL PATH and WSL interop is enabled, then rerun chezmoi." -}}
+{{-   end -}}
+
+{{-   $powershell_probe := output "sh" "-c" "command -v powershell.exe >/dev/null 2>&1 && powershell.exe -NoProfile -NonInteractive -Command '[Console]::Write(\"ready\")' >/dev/null 2>&1 && printf ready || printf missing" | trim -}}
+{{-   if ne $powershell_probe "ready" -}}
+{{-     fail "[FATAL] WSL prerequisite 'powershell.exe' is unavailable or cannot run. Ensure Windows PowerShell is on the WSL PATH and WSL interop is enabled, then rerun chezmoi." -}}
+{{-   end -}}
+
+{{-   $wslpath_probe := output "sh" "-c" "command -v wslpath >/dev/null 2>&1 && wslpath -u 'C:\\Windows' >/dev/null 2>&1 && printf ready || printf missing" | trim -}}
+{{-   if ne $wslpath_probe "ready" -}}
+{{-     fail "[FATAL] WSL prerequisite 'wslpath' is unavailable or cannot convert Windows paths. Repair the WSL installation and Windows drive mounts, then rerun chezmoi." -}}
+{{-   end -}}
+{{- end -}}
+
 {{- $windows_user := "unknown" -}}
 {{- if $is_wsl -}}
-{{-   $windows_user = env "WINDOWS_USER" | default (output "sh" "-c" "cmd.exe /c 'echo %USERNAME%' 2>/dev/null || echo 'unknown'" | trim) -}}
+{{-   $windows_user = env "WINDOWS_USER" | default (output "sh" "-c" "cmd.exe /c \"echo %USERNAME%\" 2>/dev/null | tr -d '\\r' || true" | trim) -}}
+{{-   if eq $windows_user "" -}}
+{{-     fail "[FATAL] Windows username discovery returned empty. Confirm 'cmd.exe /c echo %USERNAME%' returns a value from WSL or set WINDOWS_USER before running chezmoi." -}}
+{{-   end -}}
 {{- end -}}
 
 {{- $brew_prefix := "/usr/local" -}}
@@ -31,8 +61,19 @@ sourceDir = {{ .chezmoi.sourceDir | quote }}
 {{- /* Resolve op binary path from the current platform without guessing. */}}
 {{- $op_bin := "" -}}
 {{- if $is_wsl -}}
-{{-   $win_op := output "powershell.exe" "-NoProfile" "-NonInteractive" "-Command" "(Get-Command op.exe -ErrorAction SilentlyContinue).Source | Write-Host -NoNewline" -}}
-{{-   if ne $win_op ""}}{{$op_bin = output "wslpath" "-u" $win_op | trim}}{{end -}}
+{{-   $win_op := output "sh" "-c" (printf "powershell.exe -NoProfile -NonInteractive -Command '$cmd = Get-Command \"op.exe\" -ErrorAction SilentlyContinue; if ($cmd) { [Console]::Write($cmd.Source) }' 2>/dev/null || printf '%s'" $wsl_command_failed) | trim -}}
+{{-   if eq $win_op $wsl_command_failed -}}
+{{-     fail "[FATAL] Windows PowerShell failed while discovering required 1Password CLI 'op.exe'. Confirm powershell.exe runs from WSL and 1Password CLI integration is enabled on Windows." -}}
+{{-   else if eq $win_op "" -}}
+{{-     fail "[FATAL] Windows 1Password CLI ('op.exe') not found from WSL. Install 1Password for Windows, enable CLI integration, ensure op.exe is on the Windows PATH visible to WSL, then rerun chezmoi." -}}
+{{-   else -}}
+{{-     $op_bin = output "sh" "-c" (printf "wslpath -u \"$1\" 2>/dev/null || printf '%s'" $wslpath_failed) "dotfiles-wslpath" $win_op | trim -}}
+{{-     if eq $op_bin $wslpath_failed -}}
+{{-       fail "[FATAL] wslpath could not convert the Windows 1Password CLI path. Confirm wslpath works from WSL and Windows drives are mounted, then rerun chezmoi." -}}
+{{-     else if eq $op_bin "" -}}
+{{-       fail "[FATAL] wslpath returned empty while converting the Windows 1Password CLI path. Repair WSL path conversion and rerun chezmoi." -}}
+{{-     end -}}
+{{-   end -}}
 {{- else -}}
 {{-   $op_bin = lookPath "op" -}}
 {{- end -}}
@@ -110,8 +151,19 @@ sourceDir = {{ .chezmoi.sourceDir | quote }}
 {{- if eq $osid "darwin" -}}
 {{-   $op_sign = "/Applications/1Password.app/Contents/MacOS/op-ssh-sign" -}}
 {{- else if $is_wsl -}}
-{{-   $win_op_sign := output "powershell.exe" "-NoProfile" "-NonInteractive" "-Command" "foreach ($cmd in 'op-ssh-sign-wsl.exe', 'op-ssh-sign.exe') { $p = (Get-Command $cmd -ErrorAction SilentlyContinue).Source; if ($p) { Write-Host -NoNewline $p; break } }" -}}
-{{-   if ne $win_op_sign ""}}{{$op_sign = output "wslpath" "-u" $win_op_sign | trim}}{{end -}}
+{{-   $win_op_sign := output "sh" "-c" (printf "powershell.exe -NoProfile -NonInteractive -Command 'foreach ($cmd in \"op-ssh-sign-wsl.exe\", \"op-ssh-sign.exe\") { $p = (Get-Command $cmd -ErrorAction SilentlyContinue).Source; if ($p) { [Console]::Write($p); break } }' 2>/dev/null || printf '%s'" $wsl_command_failed) | trim -}}
+{{-   if eq $win_op_sign $wsl_command_failed -}}
+{{-     fail "[FATAL] Windows PowerShell failed while discovering the 1Password SSH signing helper. Confirm powershell.exe runs from WSL and 1Password for Windows is installed." -}}
+{{-   else if eq $win_op_sign "" -}}
+{{-     fail "[FATAL] Windows 1Password SSH signing helper ('op-ssh-sign-wsl.exe' or 'op-ssh-sign.exe') not found from WSL. Reinstall or update 1Password for Windows and reconfigure WSL SSH signing, then rerun chezmoi." -}}
+{{-   else -}}
+{{-     $op_sign = output "sh" "-c" (printf "wslpath -u \"$1\" 2>/dev/null || printf '%s'" $wslpath_failed) "dotfiles-wslpath" $win_op_sign | trim -}}
+{{-     if eq $op_sign $wslpath_failed -}}
+{{-       fail "[FATAL] wslpath could not convert the Windows 1Password SSH signing helper path. Confirm wslpath works from WSL and Windows drives are mounted, then rerun chezmoi." -}}
+{{-     else if eq $op_sign "" -}}
+{{-       fail "[FATAL] wslpath returned empty while converting the Windows 1Password SSH signing helper path. Repair WSL path conversion and rerun chezmoi." -}}
+{{-     end -}}
+{{-   end -}}
 {{- else -}}
 {{-   $op_sign = lookPath "op-ssh-sign" | default "" -}}
 {{- end -}}


### PR DESCRIPTION
## Summary

Improves `.chezmoi.toml.tmpl` WSL/Win32 prerequisite failure behavior so common interop and Windows-tool failures stop with repository-authored `[FATAL]` guidance instead of raw low-context `output` errors.

The WSL branch now checks or safely wraps WSL interop, `cmd.exe`, `powershell.exe`, `wslpath`, Windows `op.exe`, the Windows 1Password SSH signing helper, required Windows username discovery, and Windows-path conversion before those failures can surface as opaque template execution errors.

## Scope

Scoped to Child #338 under Parent #332.

Changed only:

- `.chezmoi.toml.tmpl`

This preserves non-WSL behavior and does not change identity routing, WezTerm, shell environment propagation, retired bridge behavior, README operator flow, or macOS SSH/signing behavior.

## Official sources used

- chezmoi `output` template function: https://www.chezmoi.io/reference/templates/functions/output/
- Microsoft WSL filesystem, interop, and `WSLENV` behavior: https://learn.microsoft.com/en-us/windows/wsl/filesystems
- 1Password WSL integration: https://developer.1password.com/docs/ssh/integrations/wsl/

No official-source conflict was found for this scoped implementation. The change follows the official baseline that WSL invokes Windows executables through interop, and that chezmoi `output` command failures abort template execution unless the command is wrapped safely.

## Validation table

| Check | State | Evidence | Notes |
| --- | --- | --- | --- |
| Required starting state | Passed | `main` was fast-forward current before edits. GitHub PR metadata confirmed #339, #342, #343, and #345 are merged; local `main` HEAD `16ca279` is PR #345's squash merge commit. | #338 work started only after #345 was present. |
| `git status --short` | Passed | Empty after commit `2936d1f`. | Scoped working tree. |
| `git diff --check HEAD~1..HEAD` | Passed | No whitespace errors. | Also checked before commit. |
| `pre-commit run --all-files` | Passed | `trim trailing whitespace`, `fix end of files`, `check yaml`, `check for added large files`, `shfmt`, and `stylua` passed. | Commit hook also passed for the staged file. |
| Non-WSL `.chezmoi.toml.tmpl` render | Passed | Rendered with `CI=true` and a PATH excluding real `op`; output kept `is_wsl = false`, Darwin data, and did not enter WSL prerequisite probes. | Avoided invoking the real local 1Password CLI session. |
| Normal WSL `.chezmoi.toml.tmpl` rendered-data inspection | Maintainer-confirmed | Maintainer-provided redacted `chezmoi data` inspection showed `is_wsl=true`, nonempty Windows username, `ssh_auth_sock=\\.\pipe\openssh-ssh-agent`, `op_status=ready`, Windows `op.exe` discovered, and Windows signer discovered. | Full paths, identities, account IDs, item IDs, and public keys were omitted. |
| WSL `powershell.exe -NoProfile -NonInteractive -Command '$PSVersionTable.PSVersion.ToString()'` | Maintainer-confirmed | Maintainer-provided WSL output returned a PowerShell version string. | No host-private details required. |
| WSL `cmd.exe /c echo %USERNAME%` | Maintainer-confirmed | Maintainer-provided WSL check confirmed the command returned a nonempty value. | `cmd.exe` also emitted a UNC current-directory warning from the WSL source path; this is non-blocking for the checked value, and the template redirects stderr for this discovery. |
| WSL `wslpath -u <redacted-windows-path>` or safe equivalent | Maintainer-confirmed | Maintainer-provided safe path conversion showed `wslpath -u 'C:\Windows'` returned `/mnt/c/Windows`. | No profile path was exposed. |
| Windows 1Password CLI discovery from WSL | Maintainer-confirmed | Maintainer-provided WSL PowerShell check returned `op_found`. | Does not publish the discovered executable path. |
| Windows 1Password SSH signer discovery from WSL | Maintainer-confirmed | Maintainer-provided WSL PowerShell check returned `signer_found`. | Does not publish the discovered executable path. |
| Safe simulated missing-command / interop inspection | Passed | PATH and command-wrapper simulations covered missing interop, missing `cmd.exe`, missing `powershell.exe`, missing `wslpath`, missing Windows `op.exe`, missing Windows signer, empty Windows username, and `wslpath` conversion failure. Each stopped with a scoped `[FATAL]` message. | Destructive interop disablement was not attempted. |
| Error-message review | Passed | Reviewed all `[FATAL]` messages with `rg`; new messages name the failed prerequisite and remediation route without printing discovered Windows paths or identity values. | Messages do not include full Windows profile paths, local usernames, account IDs, item IDs, SSH public keys, generated identity files, or private repo names. |

## Redaction statement

No full Windows profile paths, local usernames, 1Password account IDs, item IDs, SSH public keys, generated identity files, private repository names, or real identity output are included in this PR body. WSL render evidence used deliberately fake or redacted values, and maintainer-provided WSL evidence is summarized structurally.

## Remote CI limitation

GitHub Checks/status checks after PR creation are the source of truth for remote CI. This static PR body does not manually mirror dynamic GitHub Actions status.

GitHub Actions CI cannot prove local WSL/Windows/1Password convergence. The WSL `powershell.exe`, `wslpath`, Windows OpenSSH, Windows 1Password Desktop, and 1Password SSH agent paths require local WSL host evidence; the maintainer-provided checks above cover the scoped #338 prerequisite path.

## Risk and rollback

Risk is limited to WSL evaluation of `.chezmoi.toml.tmpl`. Hosts with partially configured WSL interop or Windows PATH propagation may now fail earlier with explicit prerequisite messages instead of falling through to later raw command errors.

Rollback is to revert commit `2936d1f`, restoring the prior direct Windows-command `output` calls and previous failure behavior.

## Out of scope

This PR does not:

- implement sibling #337 WSL preflight/operator documentation consolidation;
- change `dot_config/wezterm/wezterm.lua.tmpl` from #333;
- change `dot_zshenv.tmpl` from #335;
- change `.chezmoitemplates/git_identity_config.tmpl` or `dot_config/mise/repo-tasks/generate/executable_identity.tmpl` from #336;
- restore or edit retired bridge files from #334;
- change `dot_config/mise/repo-tasks/check/executable_identity.tmpl`;
- change Git identity routing, Windows OpenSSH routing, macOS SSH/signing behavior, package provisioning, or README operator flow;
- claim local WSL/Windows/1Password convergence from GitHub Actions CI.

Refs #332
Closes #338