### PR TITLE
[codex] Drop Docker Desktop from Windows provisioning

### DIFF
--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -67,7 +67,6 @@ packages:
       - Flow-Launcher.Flow-Launcher
       - Microsoft.PowerToys
       - Microsoft.VisualStudioCode
-      - Docker.DockerDesktop
       - AgileBits.1Password
       - AgileBits.1Password.CLI
 

--- a/README.md
+++ b/README.md
@@ -116,14 +116,14 @@ integrations to be usable.
 Prepare Windows 11 with WSL2 Ubuntu 24.04+ as a WSL-to-Windows interop path,
 not as generic Linux.
 
-Windows-side GUI provisioning installs Docker Desktop through the WinGet
-`Docker.DockerDesktop` package outside CI. Start Docker Desktop, accept Docker's
-subscription terms, and enable WSL 2 integration for the target Ubuntu
-distribution when Docker commands are required from WSL2.
+Windows-side GUI provisioning does not install Docker Desktop. Install Docker
+Desktop manually and enable WSL 2 integration for the target Ubuntu distribution
+only when Docker commands are required from WSL2.
 
 The WSL2 Ubuntu path does not install Docker Engine or Docker CLI packages
-inside Linux. Docker daemon, socket, Desktop, and WSL integration behavior is
-owned by the Windows-side Docker Desktop installation.
+inside Linux. When Docker Desktop is installed manually, Docker daemon, socket,
+Desktop, and WSL integration behavior is owned by that Windows-side
+installation.
 
 The WSL2 SSH authentication path follows the official
 [1Password WSL integration](https://developer.1password.com/docs/ssh/integrations/wsl/):


### PR DESCRIPTION
## Summary

Remove Docker Desktop from Windows GUI provisioning so WSL2 `chezmoi apply -v` is not blocked by the current WinGet/Docker installer failure. The macOS Docker Desktop cask remains unchanged.

## Scope

This PR is limited to Windows package provisioning data and the README's Windows Docker wording.

## Changes

- Remove `Docker.DockerDesktop` from `.chezmoidata/packages.yaml` under `packages.gui.windows`.
- Update the Windows 11 + WSL2 README section to say Docker Desktop is not installed by Windows-side GUI provisioning and is only manually installed when WSL2 Docker commands are needed.

## Validation

| Check | State | Evidence | Notes |
| --- | --- | --- | --- |
| `git diff --check` | Passed | Command exited 0 with no output. | Whitespace check passed. |
| `pre-commit run --all-files` | Passed | `trim trailing whitespace`, `fix end of files`, `check yaml`, `check for added large files`, `shfmt`, and `stylua` passed. | Re-run before commit; commit hooks also passed for relevant hooks. |
| Windows package script rendered inspection | Passed | `chezmoi execute-template --override-data '{"is_wsl":true}' --file .chezmoiscripts/run_onchange_before_provision-windows-packages.sh.tmpl` rendered the Windows package install calls without `Docker.DockerDesktop`. | Confirms the WSL-rendered WinGet install list no longer includes Docker Desktop. |
| Markdown relative link validation | Not required | No Markdown links were added, removed, or changed. | README prose only. |
| `repomix` | Not required | No assistant guidance, context routing, workflow contracts, templates, or snapshot routing changed. | Not in the touched-source requirement for this change. |
| `mise run doctor` | Not required | No mise task, toolchain, health-check, script, CI, version, dependency, or lockfile behavior changed. | Package provisioning behavior was validated through rendered Windows script inspection. |
| Windows `chezmoi apply -v` | Maintainer-confirmed | Maintainer reported Windows `chezmoi apply -v` passed after this PR was opened. | Host-local WSL2 convergence evidence was not captured in this PR body. |

## Risk

The main risk is that users who expected Windows provisioning to install Docker Desktop will now need to install it separately. This matches the current decision that Docker Desktop is optional on Windows and not worth a Windows-only provisioning exception.

## Rollback

Re-add `Docker.DockerDesktop` to `packages.gui.windows` and restore the previous README wording.

## Review notes

The prior WinGet/Docker path failed on Windows with Docker Desktop 4.71.0 before installation completed, including attempts to pass Docker's documented per-user installer flags through WinGet. This PR avoids maintaining a Docker-specific Windows installer branch.

## Out of scope

- Adding a dedicated Docker Desktop installer path for Windows.
- Installing Docker Engine or Docker CLI packages inside WSL2 Ubuntu.
- Changing macOS Homebrew Docker Desktop provisioning.

## Linked issues

None.