### PR TITLE
[codex] Fix Vale sync path

### DIFF
--- a/dot_config/mise/repo-tasks/check/executable_vale.tmpl
+++ b/dot_config/mise/repo-tasks/check/executable_vale.tmpl
@@ -20,7 +20,7 @@ HAS_ERROR=0
 
 echo "--- 5. Prose Linting Engine (Vale) ---"
 if [[ -f "$VALE_CONFIG" ]]; then
-  if "$MISE_BIN" exec vale -- vale --config="$VALE_CONFIG" ls-config > /dev/null 2>&1; then
+  if "$MISE_BIN" exec -- vale --config="$VALE_CONFIG" ls-config > /dev/null; then
     log_ok "Vale configuration loaded successfully."
 
     STYLE_DIR="{{ .paths.xdg_data }}/vale/styles/Google"
@@ -28,7 +28,7 @@ if [[ -f "$VALE_CONFIG" ]]; then
       log_ok "External style packages (Google) provisioned."
     else
       log_err "External style packages missing at $STYLE_DIR."
-      log_guide "chezmoi apply (or manual: vale --config=\"$VALE_CONFIG\" sync)"
+      log_guide "chezmoi apply (or manual: \"$MISE_BIN\" exec -- vale --config=\"$VALE_CONFIG\" sync)"
       HAS_ERROR=1
     fi
   else

--- a/dot_config/mise/repo-tasks/sync/executable_vale.tmpl
+++ b/dot_config/mise/repo-tasks/sync/executable_vale.tmpl
@@ -15,6 +15,6 @@ if [[ ! -f "$VALE_CONFIG" ]]; then
 fi
 
 echo "📦 [Vale] Synchronizing style packages..."
-"$MISE_BIN" exec vale -- vale --config="$VALE_CONFIG" sync
+"$MISE_BIN" exec -- vale --config="$VALE_CONFIG" sync
 
 echo "✅ [Vale] Styles converged."


### PR DESCRIPTION
## Summary

Fixes the macOS Vale compliance failure by making the Vale sync/check tasks use the repository-configured mise tool environment and the intended Vale `StylesPath`.

## Scope

This PR is limited to the Vale mise task path for issue #368. It does not modify Renovate PRs, broad mise task structure, GitHub Actions workflow semantics, unrelated doctor checks, or Vale style policy.

## Changes

- `check:vale` now runs `vale ls-config` through `mise exec --`, which uses the configured tool set, and only redirects stdout so Vale diagnostics remain visible in CI.
- `sync:vale` now runs `vale sync` through `mise exec --`, so sync uses the pinned configured Vale tool instead of resolving an ad hoc `vale` tool spec.
- The missing-style guidance in `check:vale` now points operators at the same mise-managed sync command used by the task.

## Root cause

The macOS CI log showed `sync:vale` reporting success to `/Users/runner/Library/Application Support/vale/styles`, followed by mise warning that the expected `.local/share/vale/styles/Google` output was missing. Later, `check:vale` hid the underlying `vale ls-config` error and only printed the generic parse failure.

Strict follow-up reproduction showed the decisive mismatch was the old `mise exec vale -- vale ...` command form: mise treated `vale` before `--` as an ad hoc tool request, which resolved a different `vale` tool than the repository-pinned `aqua:errata-ai/vale`. In contrast, `mise exec -- vale --config=... sync` uses the configured tool environment and lets Vale install packages into the active configured `StylesPath`.

## Validation

| Check | State | Evidence | Notes |
| --- | --- | --- | --- |
| `git status --short` | Passed | Worktree clean after amended commit `b4203be904b26f9c84b8abbada9ad437e3c80725`. | Required issue check. |
| `git diff --stat` | Passed | Amended commit: `2 files changed, 3 insertions(+), 3 deletions(-)`. | Required issue check. |
| `git diff --check` | Passed | Command exited 0 with no output. | Required issue check. |
| Rendered template inspection | Passed | `chezmoi execute-template --file` for both touched task templates showed `mise exec --`; `check:vale` keeps stderr visible and its manual guidance now uses the mise-managed sync path. `chezmoi diff --source-path` showed the rendered target diff for `.config/mise/repo-tasks/check/vale` and `.config/mise/repo-tasks/sync/vale`. | Required for touched chezmoi templates. |
| Relevant mise task inspection | Passed | `mise tasks info check:vale` and `mise tasks info sync:vale` resolved the expected task metadata and output contract. `mise exec -- vale --version` returned `vale version 3.14.1`; `mise exec vale -- vale --version` returned `vale version 3.14.2`, confirming the command-form mismatch. | Matches the touched mise task surface. |
| Official-doc consistency review | Passed | mise CLI docs define `mise exec [TOOL@VERSION]… [-- COMMAND]…`, load tools from config, and use `--` to separate runtimes from the command. Vale docs define `StylesPath`, `Packages`, `vale sync`, and `--config` as the intended package/config path. | References: https://mise.jdx.dev/cli/exec.html and https://vale.sh/docs/vale-ini / https://vale.sh/docs/cli / https://vale.sh/docs/keys/packages. |
| Source-rendered Vale task behavior | Passed | `chezmoi execute-template --file dot_config/mise/repo-tasks/sync/executable_vale.tmpl | bash` synced Google to `/Users/thomma/.local/share/vale/styles`; the source-rendered check task then reported the Vale config and Google styles as provisioned. | Focused behavior check for the edited templates. |
| Configured sync without pre-creating `StylesPath` | Passed | Synthetic config with missing target style directory: `mise exec -- vale --config="$tmp/project/vale.ini" sync` installed Google into that configured `StylesPath`. The old ad hoc form attempted the default user styles path instead. | Confirms this is not relying on a `mkdir -p` workaround. |
| Diagnostic exposure | Passed | A synthetic missing-`StylesPath` config run with `mise exec -- vale --config=... ls-config >/dev/null` printed Vale's `E201 Invalid value` path diagnostic and exited nonzero. | Confirms stderr is no longer hidden. |
| `mise run doctor` | Passed | Local doctor completed successfully with zero drift after the amendment. | Local target-state health check; source-rendered commands above validate the edited task templates directly. |
| `pre-commit run --all-files` | Passed | trailing whitespace, EOF fixer, YAML, large-file, shfmt, and stylua hooks passed after the amendment. | Extra baseline check. |

## Risk

Low. The change keeps task names, metadata, outputs, and workflow semantics intact, and removes the ad hoc tool-resolution path instead of adding a compatibility workaround.

## Rollback

Revert the two Vale task template edits to restore the previous `mise exec vale --` command form and sync guidance.

## Review notes

Post-amend CI evidence: the `compliance` workflow run for commit `b4203be904b26f9c84b8abbada9ad437e3c80725` completed successfully after PR update on 2026-05-20 UTC, including `Convergence & Idempotency Proof (macos-14)` and the final doctor phase. Current CI status remains owned by GitHub Checks: https://github.com/tsubasahomma/dotfiles/actions/runs/26177718893

## Out of scope

- Renovate PR merge/rebase work.
- GitHub Actions workflow changes.
- Broad mise task refactors.
- Disabling or skipping Vale validation.
- Unrelated doctor checks.

## Linked issues

Closes #368
