### PR TITLE
fix: align Vale XDG paths in post-apply graph

### DIFF
--- a/.chezmoiscripts/run_onchange_after_20-mise-post-apply-graph.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_20-mise-post-apply-graph.sh.tmpl
@@ -23,6 +23,12 @@
 set -euo pipefail
 
 # This script runs before the new Zsh environment is fully initialized.
+# Export the rendered XDG contract before mise or tool subprocesses derive paths.
+export XDG_CONFIG_HOME="{{ .paths.xdg_config }}"
+export XDG_DATA_HOME="{{ .paths.xdg_data }}"
+export XDG_STATE_HOME="{{ .paths.xdg_state }}"
+export XDG_CACHE_HOME="{{ .paths.xdg_cache }}"
+
 # PATH injection is required because this subshell executes before Zsh bootstrap completes.
 export PNPM_HOME="{{ .paths.xdg_data }}/pnpm"
 export PATH="$PNPM_HOME:{{ .paths.home }}/.local/bin:$PATH"


### PR DESCRIPTION
## Summary

Exports the rendered XDG base directory contract inside the platform-neutral post-apply wrapper before mise installs tools or runs the repo-owned lifecycle graph.

This fixes the Vale 3.14.2 macOS mismatch where `vale sync` derived a macOS Application Support package directory while the rendered Vale config and `check:vale` expected the XDG data directory.

## Scope

Issue #377 only. This does not change Vale versions, Renovate PR #365, mise task metadata, Neovim checks, GitHub Actions workflow semantics, package managers, or Renovate policy.

## Changes

- Adds explicit `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, `XDG_STATE_HOME`, and `XDG_CACHE_HOME` exports to `.chezmoiscripts/run_onchange_after_20-mise-post-apply-graph.sh.tmpl`.
- Keeps those exports before `mise install` and `mise run lifecycle:post-apply`, so Vale and other tool subprocesses derive paths from the same rendered contract as shell startup.

## Validation

| Check | State | Evidence | Notes |
| --- | --- | --- | --- |
| Rendered post-apply inspection | Passed | `chezmoi execute-template < .chezmoiscripts/run_onchange_after_20-mise-post-apply-graph.sh.tmpl \| sed -n '20,45p'` showed the four XDG exports before `PNPM_HOME`, `PATH`, `mise install`, and `lifecycle:post-apply`. | Confirms rendered script order, not just template text. |
| Focused macOS Vale reproduction | Passed | Vale 3.14.2 in a temporary HOME: without XDG exports, `sync` installed Google under macOS Application Support and `ls-config` failed with `E201`; with the four XDG exports, `sync` installed Google under the rendered XDG `StylesPath`, `ls-config` passed, and the macOS default package directory was not created. | Matches the Issue #377 failure mode without changing repository source state. |
| `mise run sync:vale` | Passed | Synced one package to `$HOME/.local/share/vale/styles`. | Confirms repo task sync behavior in the rendered environment. |
| `mise run check:vale` | Passed | Vale configuration loaded successfully and Google style package was provisioned. | Confirms the doctor subcheck path agrees with sync output. |
| `mise run doctor` | Passed | Completed with `System Health Evaluation Complete (Zero Drift)`. | Required because this touches post-apply/task behavior. |
| `git diff --check` | Passed | Exited 0 with no output. | Whitespace safety. |
| `pre-commit run --all-files` | Passed | `trim trailing whitespace`, `fix end of files`, `check yaml`, `check for added large files`, `shfmt`, and `stylua` passed. | Baseline local validation. |
| Markdown relative link validation | Not required | No Markdown links changed. | |
| `repomix` | Not required | No assistant/context routing or generated evidence routing changed. | |

## Risk

Residual risk is limited to remote GitHub Actions evidence. Local reproduction and repo tasks prove the XDG contract fix on this macOS host, but the PR should still rely on GitHub Checks/status checks for remote CI status after creation.

## Rollback

Revert the single commit to remove the XDG exports from the post-apply wrapper. That restores prior behavior and would likely leave Renovate PR #365 blocked on macOS until another environment-contract fix lands.

## Review notes

After this lands on `main`, Renovate PR #365 should be rebased or retried so the Vale 3.14.2-only update can run against the fixed post-apply wrapper.

GitHub Actions CI should be reviewed in Checks/status checks for this PR; this body intentionally does not mirror dynamic CI state.

## Out of scope

- Merging, rebasing, or force-updating Renovate PR #365.
- Downgrading or pinning Vale.
- Creating only `$HOME/.local/share/vale/styles` as a symptom workaround.
- Changing unrelated mise tasks, Neovim, workflow semantics, package managers, or Renovate governance.

## Linked issues

Closes #377
