### PR TITLE
Align WSL browser interop and WezTerm font fallback

### DIFF
--- a/.chezmoiignore.tmpl
+++ b/.chezmoiignore.tmpl
@@ -69,6 +69,13 @@ renovate.json5
 .mise.toml
 
 # --- 5. OS-Specific Overrides ---
+{{ if not .is_wsl -}}
+{{/*
+The WSL browser opener is only valid where Win32 interoperability is available.
+*/}}
+.local/bin/wsl-open-url
+{{ end -}}
+
 {{ if ne .osid "darwin" -}}
 {{- if not .is_wsl }}
 {{/*

--- a/dot_config/wezterm/wezterm.lua.tmpl
+++ b/dot_config/wezterm/wezterm.lua.tmpl
@@ -14,7 +14,7 @@ local font_fallback = { "JetBrains Mono" }
 
 if wezterm.target_triple:find("darwin") then
   table.insert(font_fallback, "Apple Color Emoji")
-  table.insert(font_fallback, { family = "BIZ UDGothic", weight = "Bold" })
+  table.insert(font_fallback, "BIZ UDGothic")
   table.insert(font_fallback, "Hiragino Sans")
 else
   table.insert(font_fallback, "Segoe UI Emoji")

--- a/dot_local/bin/executable_wsl-open-url
+++ b/dot_local/bin/executable_wsl-open-url
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+  printf '%s: %s\n' "${0##*/}" "$*" >&2
+  exit 1
+}
+
+usage() {
+  printf 'Usage: %s URL\n' "${0##*/}" >&2
+}
+
+if [[ $# -ne 1 || -z "${1:-}" ]]; then
+  usage
+  exit 64
+fi
+
+url="$1"
+case "$url" in
+  http://* | https://*) ;;
+  *)
+    printf '%s: only http:// and https:// URLs are supported: %s\n' "${0##*/}" "$url" >&2
+    exit 64
+    ;;
+esac
+
+if ! grep -qi microsoft /proc/sys/kernel/osrelease 2> /dev/null; then
+  die "this opener is WSL-only"
+fi
+
+if [[ -e /proc/sys/fs/binfmt_misc/WSLInterop ]] &&
+  ! grep -qxF enabled /proc/sys/fs/binfmt_misc/WSLInterop; then
+  die "WSL Win32 interoperability is disabled"
+fi
+
+if ! command -v powershell.exe > /dev/null 2>&1; then
+  die "powershell.exe is unavailable; ensure WSL interop is enabled and Windows System32 is on PATH"
+fi
+
+managed_wsl_env="DOTFILES_WSL_BROWSER_URL/w"
+wsl_env="$managed_wsl_env"
+if [[ -n "${WSLENV:-}" ]]; then
+  IFS=':' read -r -a wsl_env_parts <<< "$WSLENV"
+  for part in "${wsl_env_parts[@]}"; do
+    [[ -z "$part" || "${part%%/*}" == "DOTFILES_WSL_BROWSER_URL" ]] && continue
+    wsl_env+=":$part"
+  done
+fi
+
+# shellcheck disable=SC2016
+ps_command='$target = [Environment]::GetEnvironmentVariable("DOTFILES_WSL_BROWSER_URL"); if ([string]::IsNullOrWhiteSpace($target)) { Write-Error "DOTFILES_WSL_BROWSER_URL is empty."; exit 64 }; Start-Process -FilePath $target'
+
+DOTFILES_WSL_BROWSER_URL="$url" \
+  WSLENV="$wsl_env" \
+  powershell.exe -NoProfile -NonInteractive -Command "$ps_command"

--- a/dot_zshenv.tmpl
+++ b/dot_zshenv.tmpl
@@ -40,6 +40,9 @@ _dotfiles_wsl_env_prepend() {
 export OP_BIOMETRIC_UNLOCK_ENABLED="true"
 _dotfiles_wsl_env_prepend "OP_BIOMETRIC_UNLOCK_ENABLED/w"
 
+# Browser-opening CLI flows should dispatch URLs through the Windows default app.
+export BROWSER="{{ .paths.home }}/.local/bin/wsl-open-url"
+
 # Win32 OpenSSH should use the Windows 1Password agent pipe, not a WSL bridge socket.
 export SSH_AUTH_SOCK='{{ .ssh_auth_sock }}'
 _dotfiles_wsl_env_prepend "SSH_AUTH_SOCK/w"


### PR DESCRIPTION
## Summary

Align WSL2 browser opening with Windows interop and default-app dispatch, and remove the forced bold Japanese fallback from the WezTerm font stack.

## Scope

This PR changes only chezmoi source state for WSL shell browser interop, target routing for the new WSL-only adapter, and the WezTerm Japanese fallback font entry.

## Changes

- Add a WSL-only `wsl-open-url` adapter that accepts `http://` and `https://` URLs and dispatches them to Windows through `powershell.exe Start-Process`.
- Export the adapter through `$BROWSER` only in the WSL-rendered `.zshenv` branch.
- Ignore the adapter target on non-WSL hosts.
- Remove the explicit `weight = "Bold"` override from the macOS `BIZ UDGothic` fallback entry without adding `font_rules`, alternate fonts, or scaling changes.

## Validation

| Check | State | Evidence | Notes |
| --- | --- | --- | --- |
| `git status --short` | Passed | Clean after the two commits. | Confirmed before push. |
| `git diff --check origin/main..HEAD` | Passed | Command exited 0. | Also checked the untracked adapter before commit with `git diff --check --no-index`. |
| Source inspection | Passed | Diff is limited to `.chezmoiignore.tmpl`, `dot_zshenv.tmpl`, `dot_local/bin/executable_wsl-open-url`, and `dot_config/wezterm/wezterm.lua.tmpl`. | Source-state only; no rendered targets edited. |
| Rendered zsh/browser config inspection | Passed | WSL override render includes `export BROWSER="/home/tester/.local/bin/wsl-open-url"`; non-WSL render has no `BROWSER`; both rendered zsh files pass `zsh -n`. | Confirms WSL-only export. |
| Rendered WezTerm config inspection | Passed | Rendered config contains `table.insert(font_fallback, "BIZ UDGothic")` and no template `weight = "Bold"` or `font_rules`. | WSL render still keeps existing `default_domain`, `mux_enable_ssh_agent`, and `mux_env_remove` behavior. |
| WSL adapter syntax/lint | Passed | `bash -n`, `shellcheck`, and direct `shfmt -d` all passed for `dot_local/bin/executable_wsl-open-url`. | The adapter is extensionless, so it was checked directly. |
| `$BROWSER` argument behavior | Passed | Python `webbrowser.open('https://example.com/a?x=1&y=two')` with a fake `$BROWSER` invoked the browser command with one URL argument. | Confirms the standard `$BROWSER` surface used by common Python CLI flows. |
| WSL2 smoke test | Skipped | Current host is Darwin, `chezmoi data` reports `is_wsl=false`, and `powershell.exe` is unavailable. Running the adapter here exits with `this opener is WSL-only`. | Needs maintainer or WSL2-host confirmation for actual Windows browser launch. |
| `xdg-open` smoke test | Not required | `xdg-open` compatibility was not implemented. | See Review notes for the omission rationale. |
| WezTerm local review | Passed | `/Applications/WezTerm.app/Contents/MacOS/wezterm --config-file <rendered config> ls-fonts --text '日本語ABC'` resolves Japanese glyphs to `BIZ UDGothic` with `weight="Regular"`. | Visual confidence is still bounded by local CLI font resolution rather than a manual screenshot review. |
| `mise run check:wsl-openssh` | Not required | This change does not touch WSL SSH/authentication/Windows OpenSSH/1Password/WezTerm mux agent routing. | Existing WSL mux lines were inspected in rendered config and not changed. |
| `pre-commit run --all-files` | Passed | All hooks passed: trailing whitespace, end-of-file fixer, check yaml, added large files, shfmt, stylua. | Re-run after commits. |
| Independent review | Passed with noted residual risks | Two subagent reviews found no implementation blockers after accounting for PR-body `xdg-open` rationale and post-review commits. | Residual WSL2 host smoke risk remains disclosed. |

## Risk

The main residual risk is host-specific: this macOS validation cannot prove that a real WSL2 shell opens the Windows default browser. The adapter avoids shell interpolation of the URL by passing it through `WSLENV` into a PowerShell environment variable, accepts only `http://` and `https://`, and delegates to Windows default-app handling through `Start-Process`.

## Rollback

Revert the two commits in reverse order to restore the previous WezTerm fallback and remove the WSL browser adapter/export.

## Review notes

`xdg-open` compatibility is intentionally omitted. The scoped affected surface is CLI/browser-library behavior that honors `$BROWSER`; Python's documented `webbrowser` behavior and a local fake-browser smoke test confirm that an executable `$BROWSER` receives the URL as one argument. Repository inspection found no managed caller that requires `xdg-open`. Adding an `xdg-open` shim would broaden this change toward Linux desktop compatibility, while WSL2 in this repository is treated as a Windows interop environment.

The implementation follows the official WSL/Windows interop direction: WSL can invoke Windows `.exe` commands, `WSLENV` can pass variables from WSL to Win32 with `/w`, and PowerShell `Start-Process -FilePath` can open a non-executable target through the associated Windows application. WezTerm changes stay within `font_with_fallback` and do not add `font_rules` tuning.

## Out of scope

- `xdg-open` compatibility.
- `wslu`/`wslview` package dependencies.
- Broad Linux desktop defaults.
- WezTerm `font_rules`, alternate Japanese fonts, or font scaling.
- WSL SSH, 1Password, Windows OpenSSH, WezTerm mux SSH agent, or generated identity routing behavior.
- Zsh history behavior.

## Linked issues

Closes #380
